### PR TITLE
HelixToolkit.Wpf.SharpDX: Check bHasInstances effect variable existence.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -183,7 +183,10 @@ namespace HelixToolkit.Wpf.SharpDX
 
             /// --- check instancing
             this.hasInstances = (this.Instances != null) && (this.Instances.Any());
-            this.bHasInstances.Set(this.hasInstances);
+            if (this.bHasInstances != null)
+            {
+                this.bHasInstances.Set(this.hasInstances);
+            }
 
             /// --- set context
             this.Device.ImmediateContext.InputAssembler.InputLayout = this.vertexLayout;


### PR DESCRIPTION
bHasInstances field is initialized in the Attach method. However, it can be not found. The variable will be null.

```
public override void Attach(IRenderHost host)
{
    // ...

    /// --- init instances buffer            
    this.hasInstances = (this.Instances != null) && (this.Instances.Any());
    this.bHasInstances = this.effect.GetVariableByName("bHasInstances").AsScalar(); // <-
    if (this.hasInstances)
    {
        this.instanceBuffer = Buffer.Create(this.Device, this.instanceArray, new BufferDescription(Matrix.SizeInBytes * this.instanceArray.Length, ResourceUsage.Dynamic, BindFlags.VertexBuffer, CpuAccessFlags.Write, ResourceOptionFlags.None, 0));
    }

    // ...
```

Need to check it in the Render method.
