### PR TITLE
ColorAxis - Issues #69 & #70 - Canvas is null fix, and Allow flipping of color axis for canvas controls

### DIFF
--- a/Source/HelixToolkit.Wpf/Controls/ColorAxis/ColorAxis.cs
+++ b/Source/HelixToolkit.Wpf/Controls/ColorAxis/ColorAxis.cs
@@ -36,6 +36,12 @@ namespace HelixToolkit.Wpf
             "ColorScheme", typeof(Brush), typeof(ColorAxis), new UIPropertyMetadata(null, PropertyChanged));
 
         /// <summary>
+        /// Identifies the <see cref="FlipColorScheme"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty FlipColorSchemeProperty = DependencyProperty.Register(
+            "FlipColorScheme", typeof(bool), typeof(ColorAxis), new UIPropertyMetadata(false, PropertyChanged));
+
+        /// <summary>
         /// Identifies the <see cref="Position"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty PositionProperty = DependencyProperty.Register(
@@ -102,6 +108,23 @@ namespace HelixToolkit.Wpf
             set
             {
                 this.SetValue(ColorSchemeProperty, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the color scheme direction, if true inverts the color normal color brush direction.
+        /// </summary>
+        /// <value>A boolean indicating inverted color direction when true.</value>
+        public bool FlipColorScheme
+        {
+            get
+            {
+                return (bool)this.GetValue(FlipColorSchemeProperty);
+            }
+
+            set
+            {
+                this.SetValue(FlipColorSchemeProperty, value);
             }
         }
 
@@ -216,13 +239,20 @@ namespace HelixToolkit.Wpf
             }
 
             var r = new Rectangle
-                        {
-                            Fill = this.ColorScheme,
-                            Width = this.ColorArea.Width,
-                            Height = this.ColorArea.Height
-                        };
+                              {
+                                  Fill = this.ColorScheme,
+                                  Width = this.ColorArea.Width,
+                                  Height = this.ColorArea.Height
+                              };
+
+            if (this.FlipColorScheme)
+            {
+                r.LayoutTransform = new RotateTransform(180);
+            }
+
             Canvas.SetLeft(r, this.ColorArea.Left);
             Canvas.SetTop(r, this.ColorArea.Top);
+
             this.Canvas.Children.Add(r);
 
             this.Canvas.Children.Add(


### PR DESCRIPTION
Added a null check for canvas in the UpdateVisuals() method.  

Added a property FlipColorScheme to the ColorAxis class.  Apply's a layout rotation transform of 180\* to the rectangle that contains the colors to be shown in the control.  Allows the colors in the color axis to be aligned with the applied material texture coordinates without having to create a separate color brush.
