### PR TITLE
Reducing SharpDX idle load (issue #113) (minimally invasive version)

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -543,6 +543,18 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
+        /// Tries to invalidate the current render.
+        /// </summary>
+        public void InvalidateRender()
+        {
+            var rh = this.RenderHost;
+            if (rh != null)
+            {
+                rh.InvalidateRender();
+            }
+        }
+
+        /// <summary>
         /// Change the camera to look at the specified point.
         /// </summary>
         /// <param name="p">
@@ -984,6 +996,8 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 this.UpdateCameraInfo();
             }
+
+            this.InvalidateRender();
         }
 
         /// <summary>


### PR DESCRIPTION
- Does ALL Update() calls before ALL Render() calls (problem?)
- Only calls Render() after invalidation
- Render invalidation by Element3D.Attach(), Element3D.OnPropertyChanged(), Viewport3DX.OnCameraChanged()
- Update() is still called on every WPF render cycle (keeps game loop like engine)

Note that the demos still have some idle load because of the status bar (updating dependency properties is expensive). Without the statusbar, static demos have < 1% CPU usage.