### PR TITLE
SharpDX: Reduce input lag (issue #115)

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -570,7 +570,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.surfaceD3D.InvalidateD3DImage();
             }
 
-            this.lastRenderDuration = renderTimer.Elapsed - t0;
+            this.lastRenderDuration = this.renderTimer.Elapsed - t0;
         }
 
         /// <summary>


### PR DESCRIPTION
The solution that @mortalV pointed out (using BeginInvoke()) made LightingDemo stutter when running at 60 fps, so I took a different approach. You can simulate a big scene by putting Thread.Sleep(30) in the Render() method.