### PR TITLE
WPF: enable/disable snapping current position to element

### DIFF
--- a/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
+++ b/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
@@ -280,6 +280,13 @@ namespace HelixToolkit.Wpf
                 new UIPropertyMetadata(false, HeadlightChanged));
 
         /// <summary>
+        /// Identifies the <see cref="SnapMouseToElement"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty SnapMouseToElementProperty =
+            DependencyProperty.Register(
+                "SnapMouseToElement", typeof(bool), typeof(HelixViewport3D), new UIPropertyMetadata(true));
+
+        /// <summary>
         /// Identifies the <see cref="IsInertiaEnabled"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty IsInertiaEnabledProperty =
@@ -1585,6 +1592,23 @@ namespace HelixToolkit.Wpf
             set
             {
                 this.SetValue(InfoForegroundProperty, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Mouse Cursor (current Position) snaps to an element if it is over the element.
+        /// </summary>
+        /// <value><c>true</c> if snaping is activated; otherwise, <c>false</c>.</value>
+        public bool SnapMouseToElement
+        {
+            get
+            {
+                return (bool)this.GetValue(SnapMouseToElementProperty);
+            }
+
+            set
+            {
+                this.SetValue(SnapMouseToElementProperty, value);
             }
         }
 
@@ -3315,7 +3339,7 @@ namespace HelixToolkit.Wpf
             {
                 var pt = e.GetPosition(this);
                 var pos = this.FindNearestPoint(pt);
-                if (pos != null)
+                if (pos != null && this.SnapMouseToElement == true)
                 {
                     this.CurrentPosition = pos.Value;
                 }


### PR DESCRIPTION
We use the HelixToolkit in a WPF application to simplify a given 3D drawing. We mainly create single Points on intersections. This was difficult, because the property "CurrentPosition" of the HelixViewport snaps to the element position if it is in click range around the mouse cursor.
But we don't need this behaviour. We need the real click position. Therefore I have extend the HelixViewPort3D class. I have implemented the new dependency property *SnapMouseToElement*. If this property is set to false the snapping is disabled and we get the coordinates we expect. 

Kind regards,
Christof Konstantinopoulos