### PR TITLE
Skip choco confirmations in AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ environment:
     secure: kM3Kse+ivuuE5RVoe6dPdw+aguWx56K2YeXujGa9tMPQTms3lv7QxNpTLFMALYNa
       
 install:
-  - cinst stylecop
-  - cinst LynxToolkit
-  - cinst gitlink -Pre
+  - cinst stylecop -y
+  - cinst LynxToolkit -y
+  - cinst gitlink -Pre -y
 
 platform: Any CPU
 


### PR DESCRIPTION
To solve the following message in the build log

``` 
ATTENTION
The next version of Chocolatey (v0.9.9) will require -y to perform
  behaviors that change state without prompting for confirmation. Start
  using it now in your automated scripts.
 
  For details on the all new Chocolatey, visit http://bit.ly/new_choco 
```