### PR TITLE
SharpDX: Fixed touch to mouse promotion.

### DIFF
--- a/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10048/MyLineGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10048/MyLineGeometryModel3D.cs
@@ -27,8 +27,9 @@ namespace Workitem10048
             }
 
             var result = base.HitTest(rayWS, ref hits);
+            var pressedMouseButtons = Viewport3DX.GetPressedMouseButtons();
 
-            if (Mouse.LeftButton == MouseButtonState.Pressed)
+            if (pressedMouseButtons == 0 || pressedMouseButtons.HasFlag(MouseButton.Left))
             {
                 this.Color = result ? Color.Red : this.initialColor.Value;
             }


### PR DESCRIPTION
Due to the CameraController using Manipulation, there is no automatic touch to mouse promotion (see http://nui.joshland.org/2010/04/why-wont-wpf-controls-work-with-touch.html). Thus Viewport3DX doesn't do hit testing and isn't firing Mouse3D events, which makes touch selection impossible. 

Here is a fix. You can see the results in ExampleBrowser's Workitem10048 (you will need a touch device or some way to simulate touch events like the Surface 2.0 SDK).

@przem321 Do we still need the Viewport3DX.Emulate* methods?