### PR TITLE
Fixing SetSmoothingGroup trying to parse a long as an int

### DIFF
--- a/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
@@ -421,8 +421,8 @@ namespace HelixToolkit.Wpf
             }
             else
             {
-                int smoothingGroup;
-                if (int.TryParse(values, out smoothingGroup))
+                long smoothingGroup;
+                if (long.TryParse(values, out smoothingGroup))
                 {
                     this.currentSmoothingGroup = smoothingGroup;
                 }


### PR DESCRIPTION
This was already fixed in SharpDX, just updating ObjReader in WPF to not parse a long value as an int. Having this code in two places adds risk and may be worth trying to share between projects.