### PR TITLE
Allow model to be loaded on different thread

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Materials/Material.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Materials/Material.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 
 namespace HelixToolkit.Wpf.SharpDX
 {
@@ -21,7 +20,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _name = value;
-                OnPropertyChanged();
+                OnPropertyChanged("Name");
             }
         }
 
@@ -31,7 +30,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
-        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null) {
+        protected virtual void OnPropertyChanged(string propertyName) {
             var handler = PropertyChanged;
             if (handler != null) handler(this, new PropertyChangedEventArgs(propertyName));
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Materials/Material.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Materials/Material.cs
@@ -4,27 +4,37 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
 namespace HelixToolkit.Wpf.SharpDX
 {
-    using System;
-    using System.Windows;
 
     [Serializable]
-    public abstract class Material : DependencyObject
+    public abstract class Material : INotifyPropertyChanged
     {
-        public static readonly DependencyProperty NameProperty =
-            DependencyProperty.Register("Name", typeof(string), typeof(Material), new UIPropertyMetadata(null));
-
+        private string _name;
         public string Name
         {
-            get { return (string)this.GetValue(NameProperty); }
-            set { this.SetValue(NameProperty, value); }
+            get { return _name; }
+            set
+            {
+                _name = value;
+                OnPropertyChanged();
+            }
         }
 
         public override string ToString()
         {
             return Name;
-        }       
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null) {
+            var handler = PropertyChanged;
+            if (handler != null) handler(this, new PropertyChangedEventArgs(propertyName));
+        }
     }
 
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Materials/PhongMaterial.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Materials/PhongMaterial.cs
@@ -11,7 +11,6 @@
 namespace HelixToolkit.Wpf.SharpDX
 {
     using global::SharpDX;
-    using System.Windows;    
     using System.Windows.Media.Imaging;
     using System;    
 
@@ -34,12 +33,6 @@ namespace HelixToolkit.Wpf.SharpDX
         public BitmapSource _displacementMap;
 
         /// <summary>
-        /// Constructs a Shading Material which correspnds with 
-        /// the Phong and BlinnPhong lighting models.
-        /// </summary>
-        public PhongMaterial() { }
-
-        /// <summary>
         /// Gets or sets a color that represents how the material reflects System.Windows.Media.Media3D.AmbientLight.
         /// For details see: http://msdn.microsoft.com/en-us/library/windows/desktop/bb147175(v=vs.85).aspx
         /// </summary>
@@ -49,7 +42,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _ambientColor = value;
-                OnPropertyChanged();
+                OnPropertyChanged("AmbientColor");
             }
         }
 
@@ -63,7 +56,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _diffuseColor = value;
-                OnPropertyChanged();
+                OnPropertyChanged("DiffuseColor");
             }
         }
 
@@ -77,7 +70,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _emissiveColor = value;
-                OnPropertyChanged();
+                OnPropertyChanged("EmissiveColor");
             }
         }
 
@@ -90,7 +83,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _reflectiveColor = value;
-                OnPropertyChanged();
+                OnPropertyChanged("ReflectiveColor");
             }
         }
 
@@ -104,7 +97,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _specularColor = value;
-                OnPropertyChanged();
+                OnPropertyChanged("SpecularColor");
             }
         }
 
@@ -118,7 +111,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _specularShininess = value;
-                OnPropertyChanged();
+                OnPropertyChanged("SpecularShininess");
             }
         }
 
@@ -132,7 +125,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _diffuseMap = value;
-                OnPropertyChanged();
+                OnPropertyChanged("DiffuseMap");
             }
         }
 
@@ -145,7 +138,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _normalMap = value;
-                OnPropertyChanged();
+                OnPropertyChanged("NormalMap");
             }
         }
 
@@ -158,7 +151,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 _displacementMap = value;
-                OnPropertyChanged();
+                OnPropertyChanged("DisplacementMap");
             }
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Materials/PhongMaterial.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Materials/PhongMaterial.cs
@@ -23,62 +23,15 @@ namespace HelixToolkit.Wpf.SharpDX
     [Serializable]
     public partial class PhongMaterial : Material
     {
-        /// <summary>
-        /// Identifies the System.Windows.Media.Media3D.DiffuseMaterial.AmbientColor�dependency
-        /// property.
-        /// </summary>
-        public static readonly DependencyProperty AmbientColorProperty =
-            DependencyProperty.Register("AmbientColor", typeof(Color4), typeof(PhongMaterial), new UIPropertyMetadata((Color4)Color.Gray));
-
-        /// <summary>
-        /// Identifies the System.Windows.Media.Media3D.DiffuseMaterial.Color�dependency
-        /// property.
-        /// </summary>
-        public static readonly DependencyProperty DiffuseColorProperty =
-            DependencyProperty.Register("DiffuseColor", typeof(Color4), typeof(PhongMaterial), new UIPropertyMetadata((Color4)Color.Gray));
-
-        /// <summary>
-        ///         
-        /// </summary>
-        public static readonly DependencyProperty EmissiveColorProperty =
-            DependencyProperty.Register("EmissiveColor", typeof(Color4), typeof(PhongMaterial), new UIPropertyMetadata((Color4)Color.Black));
-
-        /// <summary>
-        ///         
-        /// </summary>
-        public static readonly DependencyProperty SpecularColorProperty =
-            DependencyProperty.Register("SpecularColor", typeof(Color4), typeof(PhongMaterial), new UIPropertyMetadata((Color4)Color.Black));
-
-        /// <summary>
-        ///         
-        /// </summary>
-        public static readonly DependencyProperty SpecularShininessProperty =
-            DependencyProperty.Register("SpecularShininess", typeof(float), typeof(PhongMaterial), new UIPropertyMetadata(30f));
-
-        /// <summary>
-        ///         
-        /// </summary>
-        public static readonly DependencyProperty ReflectiveColorProperty =
-            DependencyProperty.Register("ReflectiveColor", typeof(Color4), typeof(PhongMaterial), new UIPropertyMetadata(new Color4(0.1f, 0.1f, 0.1f, 1.0f)));
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public static readonly DependencyProperty DiffuseMapProperty =
-            DependencyProperty.Register("DiffuseMap", typeof(BitmapSource), typeof(PhongMaterial), new UIPropertyMetadata(null));
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public static readonly DependencyProperty NormalMapProperty =
-            DependencyProperty.Register("NormalMap", typeof(BitmapSource), typeof(PhongMaterial), new UIPropertyMetadata(null));
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public static readonly DependencyProperty DisplacementMapProperty =
-            DependencyProperty.Register("DisplacementMap", typeof(BitmapSource), typeof(PhongMaterial), new UIPropertyMetadata(null));
-
+        private Color4 _ambientColor = Color.Gray;
+        public Color4 _diffuseColor = Color.Gray;
+        public Color4 _emissiveColor = Color.Black;
+        public Color4 _reflectiveColor = new Color4(0.1f, 0.1f, 0.1f, 1f);
+        public Color4 _specularColor = Color.Black;
+        public float _specularShininess = 30f;
+        public BitmapSource _diffuseMap;
+        public BitmapSource _normalMap;
+        public BitmapSource _displacementMap;
 
         /// <summary>
         /// Constructs a Shading Material which correspnds with 
@@ -92,8 +45,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public Color4 AmbientColor
         {
-            get { return (Color4)this.GetValue(AmbientColorProperty); }
-            set { this.SetValue(AmbientColorProperty, value); }
+            get { return _ambientColor; }
+            set
+            {
+                _ambientColor = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -102,8 +59,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public Color4 DiffuseColor
         {
-            get { return (Color4)this.GetValue(DiffuseColorProperty); }
-            set { this.SetValue(DiffuseColorProperty, value); }
+            get { return _diffuseColor; }
+            set
+            {
+                _diffuseColor = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -112,8 +73,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public Color4 EmissiveColor
         {
-            get { return (Color4)this.GetValue(EmissiveColorProperty); }
-            set { this.SetValue(EmissiveColorProperty, value); }
+            get { return _emissiveColor; }
+            set
+            {
+                _emissiveColor = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -121,8 +86,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public Color4 ReflectiveColor
         {
-            get { return (Color4)this.GetValue(ReflectiveColorProperty); }
-            set { this.SetValue(ReflectiveColorProperty, value); }
+            get { return _reflectiveColor; }
+            set
+            {
+                _reflectiveColor = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -131,8 +100,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public Color4 SpecularColor
         {
-            get { return (Color4)this.GetValue(SpecularColorProperty); }
-            set { this.SetValue(SpecularColorProperty, value); }
+            get { return _specularColor; }
+            set
+            {
+                _specularColor = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -141,8 +114,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public float SpecularShininess
         {
-            get { return (float)this.GetValue(SpecularShininessProperty); }
-            set { this.SetValue(SpecularShininessProperty, value); }
+            get { return _specularShininess; }
+            set
+            {
+                _specularShininess = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -151,8 +128,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public BitmapSource DiffuseMap
         {
-            get { return (BitmapSource)this.GetValue(DiffuseMapProperty); }
-            set { this.SetValue(DiffuseMapProperty, value); }
+            get { return _diffuseMap; }
+            set
+            {
+                _diffuseMap = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -160,8 +141,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public BitmapSource NormalMap
         {
-            get { return (BitmapSource)this.GetValue(NormalMapProperty); }
-            set { this.SetValue(NormalMapProperty, value); }
+            get { return _normalMap; }
+            set
+            {
+                _normalMap = value;
+                OnPropertyChanged();
+            }
         }
 
         /// <summary>
@@ -169,8 +154,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public BitmapSource DisplacementMap
         {
-            get { return (BitmapSource)this.GetValue(DisplacementMapProperty); }
-            set { this.SetValue(DisplacementMapProperty, value); }
+            get { return _displacementMap; }
+            set
+            {
+                _displacementMap = value;
+                OnPropertyChanged();
+            }
         }
 
         public PhongMaterial Clone()
@@ -189,5 +178,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 DiffuseMap = this.DiffuseMap,
             };
         }
+
+
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
@@ -1178,9 +1178,9 @@ namespace HelixToolkit.Wpf.SharpDX
             private static BitmapImage LoadImage(string path)
             {
                 var bmp = new BitmapImage(new Uri(@"./Media/" + path, UriKind.RelativeOrAbsolute));
+                bmp.Freeze();
                 return bmp;
             }
-
         }
     }
 }


### PR DESCRIPTION
It was important for me to be able to load models on non-UI threads. The main blocker on that was Material / PhongMaterial being DependencyObjects and having thread affinity. I believe I was able to accomplish the same thing by implementing INotifyPropertyChanged in those classes instead. I couldn't find anything that specifically relied on Material being a DependencyObject.

With this change I am now able to run ObjReader.Read on another thread and dispatch the results back to the UI thread. Excuse the ugly code:

```
ThreadPool.QueueUserWorkItem(modelPath => {
    var objReader = new ObjReader();
    var loadedObjects = objReader.Read((string)modelPath);

    Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action<object> (object3Ds => {
        foreach (var obj3D in (IEnumerable<Object3D>) object3Ds) {
            var mesh = new MeshGeometryModel3D {
                Name = obj3D.Name,
                Geometry = obj3D.Geometry,
                Material = obj3D.Material,
                Transform = ConvertMatrixTransform(obj3D.Transform)
            };
            Models.Add(mesh);
        }
    }), loadedObjects);

}, @"C:\test.obj");
```