### PR TITLE
Update ExtrudedVisual3D.cs

### DIFF
--- a/Source/HelixToolkit.Wpf/Visual3Ds/MeshVisuals/ExtrudedVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/MeshVisuals/ExtrudedVisual3D.cs
@@ -224,7 +224,7 @@ namespace HelixToolkit.Wpf
         /// </returns>
         protected override MeshGeometry3D Tessellate()
         {
-            if (this.Path == null || this.Path.Count == 0)
+            if (this.Path == null || this.Path.Count >= 2)
             {
                 return null;
             }


### PR DESCRIPTION
Method "Tessellate"  : Path property must contains at least 2 values, because line 243 : var forward = this.Path[1] - this.Path[0];
Without this, the following code causes an exception :
TubeVisual3D tb = new TubeVisual3D ();
tb.Path = new Point3DCollection();
tb.Path.Add();