### PR TITLE
Initialize billboard text only once.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -52,7 +52,7 @@ namespace HelixToolkit.Wpf.SharpDX
             // this.AttachMaterial();
             billboardTextureVariable = effect.GetVariableByName("billboardTexture").AsShaderResource();
 
-            var textureBytes = geometry.Texture.ToByteArray();
+            var textureBytes = BillboardText3D.Texture.ToByteArray();
             billboardTextureView = ShaderResourceView.FromMemory(Device, textureBytes);
             billboardTextureVariable.SetResource(billboardTextureView);
 


### PR DESCRIPTION
This PR fixes the fact that every time a `BillboardText3D` object is created, the texture atlas is read from disk. This is not necessary. When creating many text objects quickly, this has a severe impact on performance. 

This pull request adds an `Initialize` method which stores the texture information in a static property. The next time a `BillboardText3D` object is created, it checks whether initialization has already occurred. If so, it uses the stored texture info.