### PR TITLE
Make fields on PointGeometryModel3D and LineGeometryModel3D protected.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -28,19 +28,19 @@ namespace HelixToolkit.Wpf.SharpDX
 
     public class LineGeometryModel3D : GeometryModel3D
     {
-        private InputLayout vertexLayout;        
-        private Buffer vertexBuffer;
-        private Buffer indexBuffer;
-        private Buffer instanceBuffer;
-        private EffectTechnique effectTechnique;
-        private EffectTransformVariables effectTransforms;
-        private EffectVectorVariable vViewport, vLineParams; // vFrustum, 
+        protected InputLayout vertexLayout;
+        protected Buffer vertexBuffer;
+        protected Buffer indexBuffer;
+        protected Buffer instanceBuffer;
+        protected EffectTechnique effectTechnique;
+        protected EffectTransformVariables effectTransforms;
+        protected EffectVectorVariable vViewport, vLineParams; // vFrustum, 
         //private DepthStencilState depthStencilState;
         //private LineGeometry3D geometry;
-        private EffectScalarVariable bHasInstances;
-        private Matrix[] instanceArray;
-        private bool hasInstances = false;
-        private bool isChanged = true;
+        protected EffectScalarVariable bHasInstances;
+        protected Matrix[] instanceArray;
+        protected bool hasInstances = false;
+        protected bool isChanged = true;
 
         [TypeConverter(typeof(ColorConverter))]
         public Color Color
@@ -204,8 +204,6 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-
-
         /// <summary>
         /// 
         /// </summary>
@@ -213,10 +211,10 @@ namespace HelixToolkit.Wpf.SharpDX
         public override void Attach(IRenderHost host)
         {
             /// --- attach            
-            this.renderTechnique = Techniques.RenderLines;
+            renderTechnique = Techniques.RenderLines;
             base.Attach(host);
 
-            if (this.Geometry == null)            
+            if (Geometry == null)            
                 return;
 
 #if DEFERRED  
@@ -225,10 +223,10 @@ namespace HelixToolkit.Wpf.SharpDX
 #endif
 
             // --- get device
-            this.vertexLayout = EffectsManager.Instance.GetLayout(this.renderTechnique);
-            this.effectTechnique = effect.GetTechniqueByName(this.renderTechnique.Name);
+            vertexLayout = EffectsManager.Instance.GetLayout(this.renderTechnique);
+            effectTechnique = effect.GetTechniqueByName(this.renderTechnique.Name);
 
-            this.effectTransforms = new EffectTransformVariables(this.effect);
+            effectTransforms = new EffectTransformVariables(this.effect);
             
             // --- get geometry
             var geometry = this.Geometry as LineGeometry3D;
@@ -237,28 +235,28 @@ namespace HelixToolkit.Wpf.SharpDX
             if (geometry != null)
             {
                 /// --- set up buffers            
-                this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, LinesVertex.SizeInBytes, this.CreateLinesVertexArray());
+                vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, LinesVertex.SizeInBytes, CreateLinesVertexArray());
 
                 /// --- set up indexbuffer
-                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.Indices.Array);
+                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.Indices.Array);
             }
 
             /// --- init instances buffer            
-            this.hasInstances = (this.Instances != null)&&(this.Instances.Any());
-            this.bHasInstances = this.effect.GetVariableByName("bHasInstances").AsScalar();
-            if (this.hasInstances)
+            hasInstances = (Instances != null)&&(Instances.Any());
+            bHasInstances = effect.GetVariableByName("bHasInstances").AsScalar();
+            if (hasInstances)
             {
-                this.instanceBuffer = Buffer.Create(this.Device, this.instanceArray, new BufferDescription(Matrix.SizeInBytes * this.instanceArray.Length, ResourceUsage.Dynamic, BindFlags.VertexBuffer, CpuAccessFlags.Write, ResourceOptionFlags.None, 0));
+                instanceBuffer = Buffer.Create(Device, instanceArray, new BufferDescription(Matrix.SizeInBytes * instanceArray.Length, ResourceUsage.Dynamic, BindFlags.VertexBuffer, CpuAccessFlags.Write, ResourceOptionFlags.None, 0));
             }
 
             /// --- set up const variables
-            this.vViewport = effect.GetVariableByName("vViewport").AsVector();
+            vViewport = effect.GetVariableByName("vViewport").AsVector();
             //this.vFrustum = effect.GetVariableByName("vFrustum").AsVector();
-            this.vLineParams = effect.GetVariableByName("vLineParams").AsVector();
+            vLineParams = effect.GetVariableByName("vLineParams").AsVector();
 
             /// --- set effect per object const vars
-            var lineParams = new Vector4((float)this.Thickness, (float)this.Smoothness, 0, 0);
-            this.vLineParams.Set(lineParams);
+            var lineParams = new Vector4((float)Thickness, (float)Smoothness, 0, 0);
+            vLineParams.Set(lineParams);
 
             /// === debug hack
             //{
@@ -268,7 +266,7 @@ namespace HelixToolkit.Wpf.SharpDX
             //}
 
             /// --- create raster state
-            this.OnRasterStateChanged(this.DepthBias);
+            OnRasterStateChanged(DepthBias);
             
 
             
@@ -285,7 +283,7 @@ namespace HelixToolkit.Wpf.SharpDX
            
 
             /// --- flush
-            this.Device.ImmediateContext.Flush();
+            Device.ImmediateContext.Flush();
         }        
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -223,13 +223,13 @@ namespace HelixToolkit.Wpf.SharpDX
 #endif
 
             // --- get device
-            vertexLayout = EffectsManager.Instance.GetLayout(this.renderTechnique);
-            effectTechnique = effect.GetTechniqueByName(this.renderTechnique.Name);
+            vertexLayout = EffectsManager.Instance.GetLayout(renderTechnique);
+            effectTechnique = effect.GetTechniqueByName(renderTechnique.Name);
 
-            effectTransforms = new EffectTransformVariables(this.effect);
+            effectTransforms = new EffectTransformVariables(effect);
             
             // --- get geometry
-            var geometry = this.Geometry as LineGeometry3D;
+            var geometry = Geometry as LineGeometry3D;
 
             // -- set geometry if given
             if (geometry != null)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -14,12 +14,12 @@
 
     public class PointGeometryModel3D : GeometryModel3D
     {
-        private InputLayout vertexLayout;
-        private Buffer vertexBuffer;
-        private EffectTechnique effectTechnique;
-        private EffectTransformVariables effectTransforms;
-        private EffectVectorVariable vViewport;
-        private EffectVectorVariable vPointParams;
+        protected InputLayout vertexLayout;
+        protected Buffer vertexBuffer;
+        protected EffectTechnique effectTechnique;
+        protected EffectTransformVariables effectTransforms;
+        protected EffectVectorVariable vViewport;
+        protected EffectVectorVariable vPointParams;
 
         [TypeConverter(typeof(ColorConverter))]
         public Color Color
@@ -190,7 +190,7 @@
         /// <param name="host"></param>
         public override void Attach(IRenderHost host)
         {
-            this.renderTechnique = Techniques.RenderPoints;
+            renderTechnique = Techniques.RenderPoints;
             base.Attach(host);
 
             if (this.Geometry == null)
@@ -202,10 +202,10 @@
 #endif
 
             // --- get device
-            this.vertexLayout = EffectsManager.Instance.GetLayout(this.renderTechnique);
-            this.effectTechnique = effect.GetTechniqueByName(this.renderTechnique.Name);
+            vertexLayout = EffectsManager.Instance.GetLayout(this.renderTechnique);
+            effectTechnique = effect.GetTechniqueByName(this.renderTechnique.Name);
 
-            this.effectTransforms = new EffectTransformVariables(this.effect);
+            effectTransforms = new EffectTransformVariables(this.effect);
 
             // --- get geometry
             var geometry = this.Geometry as PointGeometry3D;
@@ -214,23 +214,23 @@
             if (geometry != null)
             {
                 /// --- set up buffers            
-                this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, Geometry3D.PointsVertex.SizeInBytes, this.CreatePointVertexArray());
+                vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, Geometry3D.PointsVertex.SizeInBytes, this.CreatePointVertexArray());
             }
 
             /// --- set up const variables
-            this.vViewport = effect.GetVariableByName("vViewport").AsVector();
+            vViewport = effect.GetVariableByName("vViewport").AsVector();
             //this.vFrustum = effect.GetVariableByName("vFrustum").AsVector();
-            this.vPointParams = effect.GetVariableByName("vPointParams").AsVector();
+            vPointParams = effect.GetVariableByName("vPointParams").AsVector();
 
             /// --- set effect per object const vars
             var pointParams = new Vector4((float)this.Size.Width, (float)this.Size.Height, (float)this.Figure, (float)this.FigureRatio);
-            this.vPointParams.Set(pointParams);
+            vPointParams.Set(pointParams);
 
             /// --- create raster state
-            this.OnRasterStateChanged(this.DepthBias);
+            OnRasterStateChanged(this.DepthBias);
 
             /// --- flush
-            this.Device.ImmediateContext.Flush();
+            Device.ImmediateContext.Flush();
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -193,7 +193,7 @@
             renderTechnique = Techniques.RenderPoints;
             base.Attach(host);
 
-            if (this.Geometry == null)
+            if (Geometry == null)
                 return;
 
 #if DEFERRED
@@ -202,19 +202,19 @@
 #endif
 
             // --- get device
-            vertexLayout = EffectsManager.Instance.GetLayout(this.renderTechnique);
-            effectTechnique = effect.GetTechniqueByName(this.renderTechnique.Name);
+            vertexLayout = EffectsManager.Instance.GetLayout(renderTechnique);
+            effectTechnique = effect.GetTechniqueByName(renderTechnique.Name);
 
-            effectTransforms = new EffectTransformVariables(this.effect);
+            effectTransforms = new EffectTransformVariables(effect);
 
             // --- get geometry
-            var geometry = this.Geometry as PointGeometry3D;
+            var geometry = Geometry as PointGeometry3D;
 
             // -- set geometry if given
             if (geometry != null)
             {
                 /// --- set up buffers            
-                vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, Geometry3D.PointsVertex.SizeInBytes, this.CreatePointVertexArray());
+                vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, Geometry3D.PointsVertex.SizeInBytes, CreatePointVertexArray());
             }
 
             /// --- set up const variables
@@ -223,11 +223,11 @@
             vPointParams = effect.GetVariableByName("vPointParams").AsVector();
 
             /// --- set effect per object const vars
-            var pointParams = new Vector4((float)this.Size.Width, (float)this.Size.Height, (float)this.Figure, (float)this.FigureRatio);
+            var pointParams = new Vector4((float)Size.Width, (float)Size.Height, (float)Figure, (float)FigureRatio);
             vPointParams.Set(pointParams);
 
             /// --- create raster state
-            OnRasterStateChanged(this.DepthBias);
+            OnRasterStateChanged(DepthBias);
 
             /// --- flush
             Device.ImmediateContext.Flush();


### PR DESCRIPTION
Currently, if one wants to override `PointGeometryModel3D.Attach` or `LineGeometryModel3D.Attach`, you have no access to fields which must be set in this method, because those fields are marked as private. This PR marks these fields as `protected` so that the `Attach` method can be overridden.

As an example, I want to make a type which derives from `PointGeometryModel3D`. I want to give it a custom vertex layout and vertex type. To do this, I would override `Attach` where the vertex buffers are created, passing in an array of my custom vertex type, and setting the vertex layout to a layout which corresponds to that vertex type. 
