### PR TITLE
Reference SharpDX 2.6.3 in nuspec.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.nuspec
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.nuspec
@@ -15,15 +15,15 @@
       <dependency id="Cyotek.Drawing.BitmapFont" version="1.0.2.0" />
       <dependency id="HelixToolkit" version="$version" />
       <dependency id="HelixToolkit.Wpf" version="$version" />
-      <dependency id="SharpDX" version="2.5.0" />
-      <dependency id="SharpDX.D3DCompiler" version="2.5.0" />
-      <dependency id="SharpDX.Direct2D1" version="2.5.0" />
-      <dependency id="SharpDX.Direct3D11" version="2.5.0" />
-      <dependency id="SharpDX.Direct3D11.Effects" version="2.5.0" />
-      <dependency id="SharpDX.Direct3D9" version="2.5.0" />
-      <dependency id="SharpDX.DXGI" version="2.5.0" />
-      <dependency id="SharpDX.Toolkit" version="2.5.0" />
-      <dependency id="SharpDX.Toolkit.Graphics" version="2.5.0" />
+      <dependency id="SharpDX" version="2.6.3" />
+      <dependency id="SharpDX.D3DCompiler" version="2.6.3" />
+      <dependency id="SharpDX.Direct2D1" version="2.6.3" />
+      <dependency id="SharpDX.Direct3D11" version="2.6.3" />
+      <dependency id="SharpDX.Direct3D11.Effects" version="2.6.3" />
+      <dependency id="SharpDX.Direct3D9" version="2.6.3" />
+      <dependency id="SharpDX.DXGI" version="2.6.3" />
+      <dependency id="SharpDX.Toolkit" version="2.6.3" />
+      <dependency id="SharpDX.Toolkit.Graphics" version="2.6.3" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
This PR updates the `.nuspec` to require a version of SharpDX >= 2.6.3. We have already updated all relevant projects to reference SharpDX 2.6.3, but now when you attempt to use the Helix3D NuGet package in your Visual Studio project, it still installs SharpDX 2.5.0 by default. 

You can get around this currently by updating the SharpDX packages after they are installed, but it's not entirely clear that this is required.

@objorke Please take a look.