### PR TITLE
Fix Windows 10 issue #224

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Effects.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Effects.cs
@@ -85,7 +85,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 foreach (var item in f.Adapters)
                 {
-                    // nVidia Optimus Windows 10 fix
+                    // Windows 10 fix
                     if (item.Outputs == null || item.Outputs.Length == 0)
                     {
                         continue;

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Effects.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Effects.cs
@@ -66,7 +66,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
             }
 #else
-            this.device = new Direct3D11.Device(Direct3D.DriverType.Hardware, DeviceCreationFlags.BgraSupport, Direct3D.FeatureLevel.Level_10_1);                        
+            this.device = new global::SharpDX.Direct3D11.Device(DriverType.Hardware, DeviceCreationFlags.BgraSupport, FeatureLevel.Level_10_1);
 #endif
             InitEffects();
         }
@@ -85,6 +85,12 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 foreach (var item in f.Adapters)
                 {
+                    // nVidia Optimus Windows 10 fix
+                    if (item.Outputs == null || item.Outputs.Length == 0)
+                    {
+                        continue;
+                    }
+
                     var level = global::SharpDX.Direct3D11.Device.GetSupportedFeatureLevel(item);
 
                     if (level < DefaultEffectsManager.MinimumFeatureLevel)


### PR DESCRIPTION
On Windows 7 with nVidia Optimus, only one adapter is reported (the nVidia one) and that works regardless of settings. On Windows 10, both adapters (nVidia and Indel) are reported. The one that is active is reported first and the one that is inactive has no outputs and causes the "new Texture()" exception. This PR should fix it.