### PR TITLE
"Zoom extents" doesn't work correctly for BillboardText. #229

### DIFF
--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf_NET40.csproj
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf_NET40.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Helpers\ColorHelper.cs" />
     <Compile Include="Helpers\ContourHelper.cs" />
     <Compile Include="Helpers\DependencyPropertyEx.cs" />
+    <Compile Include="Helpers\IBoundsIgnoredVisual3D.cs" />
     <Compile Include="Helpers\Model3DHelper.cs" />
     <Compile Include="Helpers\ScreenSpace\Billboard.cs" />
     <Compile Include="Helpers\ScreenSpace\BillboardGeometryBuilder.cs" />
@@ -338,5 +339,3 @@
   </Target>
   -->
 </Project>
-
-

--- a/Source/HelixToolkit.Wpf/Helpers/IBoundsIgnoredVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/IBoundsIgnoredVisual3D.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IBoundsIgnoredVisual3D.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// <summary>
+//   Defines the visual3D type that its bounds will be ignored.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace HelixToolkit.Wpf
+{
+    /// <summary>
+    /// Defines the visual3D type that its bounds will be ignored.
+    /// </summary>
+    public interface IBoundsIgnoredVisual3D
+    {
+    }
+}

--- a/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
@@ -79,6 +79,11 @@ namespace HelixToolkit.Wpf
             var bounds = Rect3D.Empty;
             foreach (var visual in children)
             {
+                if (visual is IBoundsIgnoredVisual3D)
+                {
+                    continue;    
+                }
+
                 var b = FindBounds(visual, Transform3D.Identity);
                 bounds.Union(b);
             }

--- a/Source/HelixToolkit.Wpf/Visual3Ds/Text/BillboardTextGroupVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Text/BillboardTextGroupVisual3D.cs
@@ -22,7 +22,7 @@ namespace HelixToolkit.Wpf
     /// A visual element that contains a collection of text billboards.
     /// </summary>
     [ContentProperty("Items")]
-    public class BillboardTextGroupVisual3D : RenderingModelVisual3D
+    public class BillboardTextGroupVisual3D : RenderingModelVisual3D, IBoundsIgnoredVisual3D
     {
         /// <summary>
         /// Identifies the <see cref="Background"/> dependency property.

--- a/Source/HelixToolkit.Wpf/Visual3Ds/Text/BillboardTextVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Text/BillboardTextVisual3D.cs
@@ -35,7 +35,7 @@ namespace HelixToolkit.Wpf
     /// <summary>
     /// A visual element that contains a text billboard.
     /// </summary>
-    public class BillboardTextVisual3D : BillboardVisual3D
+    public class BillboardTextVisual3D : BillboardVisual3D, IBoundsIgnoredVisual3D
     {
         /// <summary>
         /// Identifies the <see cref="Background"/> dependency property.


### PR DESCRIPTION
Add an interface that the bounds of the visual will be ignored.