### PR TITLE
add default value for MaterialsFile, fix #205

### DIFF
--- a/Source/HelixToolkit.Wpf/Exporters/ObjExporter.cs
+++ b/Source/HelixToolkit.Wpf/Exporters/ObjExporter.cs
@@ -253,6 +253,11 @@ namespace HelixToolkit.Wpf
                 writer.WriteLine("# {0}", this.Comment);
             }
 
+            if (this.MaterialsFile == null)
+            {
+                this.MaterialsFile = Path.ChangeExtension((stream as FileStream).Name, ".mtl");
+            }
+
             writer.WriteLine("mtllib ./" + this.MaterialsFile);
 
             var materialStream = this.FileCreator(this.MaterialsFile);

--- a/Source/HelixToolkit.Wpf/Exporters/ObjExporter.cs
+++ b/Source/HelixToolkit.Wpf/Exporters/ObjExporter.cs
@@ -253,7 +253,7 @@ namespace HelixToolkit.Wpf
                 writer.WriteLine("# {0}", this.Comment);
             }
 
-            if (this.MaterialsFile == null)
+            if (this.MaterialsFile == null && stream is FileStream)
             {
                 this.MaterialsFile = Path.ChangeExtension((stream as FileStream).Name, ".mtl");
             }


### PR DESCRIPTION
#### Note:
In this patch I assume the `stream` to be a `FileStream`.
#### Reason:
Although the `IExporter.Export` take a `Stream` as the second parameter, but we can see from many places (like `Exporter<T>.FileCreator `) that current implementation has assumed it to be a `FileStream`. So I also take this assumption and leave it to be refactored in the future. 