### PR TITLE
add and enable SwitchYZ

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
@@ -57,6 +57,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public ObjReader()
         {
             this.IgnoreErrors = false;
+            this.SwitchYZ = false;
 
             this.IsSmoothingDefault = true;
             this.SkipTransparencyValues = true;
@@ -90,6 +91,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The default value is on (true).
         /// </remarks>
         public bool IgnoreErrors { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to switch Y and Z coordinates.
+        /// </summary>
+        public bool SwitchYZ { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to skip transparency values ("Tr") in the material files.
@@ -730,7 +736,14 @@ namespace HelixToolkit.Wpf.SharpDX
         private void AddNormal(string values)
         {
             var fields = Split(values);
-            this.Normals.Add(new Vector3D((float)fields[0], (float)fields[1], (float)fields[2]));
+            if (SwitchYZ)
+            {
+                this.Normals.Add(new Vector3D((float)fields[0], (float)-fields[2], (float)fields[1]));
+            }
+            else
+            {
+                this.Normals.Add(new Vector3D((float)fields[0], (float)fields[1], (float)fields[2]));
+            }
         }
 
         /// <summary>
@@ -754,7 +767,14 @@ namespace HelixToolkit.Wpf.SharpDX
         private void AddVertex(string values)
         {
             var fields = Split(values);
-            this.Points.Add(new Point3D((float)fields[0], (float)fields[1], (float)fields[2]));
+            if (SwitchYZ)
+            {
+                this.Points.Add(new Point3D((float)fields[0], (float)-fields[2], (float)fields[1]));
+            }
+            else
+            {
+                this.Points.Add(new Point3D((float)fields[0], (float)fields[1], (float)fields[2]));
+            }
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
@@ -52,6 +52,7 @@ namespace HelixToolkit.Wpf
             : base(dispatcher)
         {
             this.IgnoreErrors = false;
+            this.SwitchYZ = true;
 
             this.IsSmoothingDefault = true;
             this.SkipTransparencyValues = true;
@@ -80,6 +81,11 @@ namespace HelixToolkit.Wpf
         /// The default value is on (true).
         /// </remarks>
         public bool IgnoreErrors { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to switch Y and Z coordinates.
+        /// </summary>
+        public bool SwitchYZ { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to skip transparency values in the material files.
@@ -629,7 +635,14 @@ namespace HelixToolkit.Wpf
         private void AddNormal(string values)
         {
             var fields = Split(values);
-            this.Normals.Add(new Vector3D(fields[0], fields[1], fields[2]));
+            if (SwitchYZ)
+            {
+                this.Normals.Add(new Vector3D(fields[0], -fields[2], fields[1]));
+            }
+            else
+            {
+                this.Normals.Add(new Vector3D(fields[0], fields[1], fields[2]));
+            }
         }
 
         /// <summary>
@@ -653,7 +666,14 @@ namespace HelixToolkit.Wpf
         private void AddVertex(string values)
         {
             var fields = Split(values);
-            this.Points.Add(new Point3D(fields[0], fields[1], fields[2]));
+            if (SwitchYZ)
+            {
+                this.Points.Add(new Point3D(fields[0], -fields[2], fields[1]));
+            }
+            else
+            {
+                this.Points.Add(new Point3D(fields[0], fields[1], fields[2]));
+            }
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
@@ -52,7 +52,7 @@ namespace HelixToolkit.Wpf
             : base(dispatcher)
         {
             this.IgnoreErrors = false;
-            this.SwitchYZ = true;
+            this.SwitchYZ = false;
 
             this.IsSmoothingDefault = true;
             this.SkipTransparencyValues = true;


### PR DESCRIPTION
Option `SwitchYZ` is missing in `ObjReader`. It should exist and should be enabled by default to fit the conventions of Wavefront obj format.

What's more, option `SwitchYZ` exists in `ObjExporter` and is enabled by default, which leads to an awkward behavior that model exported by `ObjExporter` is incompatible with `ObjReader`.