### PR TITLE
use Point3DCollection instead of List<Point3D>

### DIFF
--- a/Source/HelixToolkit.Wpf/Visual3Ds/ScreenSpaceVisuals/BoundingBoxWireFrameVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/ScreenSpaceVisuals/BoundingBoxWireFrameVisual3D.cs
@@ -53,7 +53,7 @@ namespace HelixToolkit.Wpf
                 return;
             }
 
-            var points = new List<Point3D>();
+            var points = new Point3DCollection();
 
             var bb = this.BoundingBox;
 

--- a/Source/HelixToolkit.Wpf/Visual3Ds/ScreenSpaceVisuals/ScreenSpaceVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/ScreenSpaceVisuals/ScreenSpaceVisual3D.cs
@@ -52,7 +52,7 @@ namespace HelixToolkit.Wpf
             this.Mesh = new MeshGeometry3D();
             this.Model = new GeometryModel3D { Geometry = this.Mesh };
             this.Content = this.Model;
-            this.Points = new List<Point3D>();
+            this.Points = new Point3DCollection();
             this.ColorChanged();
         }
 
@@ -129,11 +129,11 @@ namespace HelixToolkit.Wpf
         /// <value>
         /// The points collection.
         /// </value>
-        public IList<Point3D> Points
+        public Point3DCollection Points
         {
             get
             {
-                return (IList<Point3D>)this.GetValue(PointsProperty);
+                return (Point3DCollection)this.GetValue(PointsProperty);
             }
 
             set


### PR DESCRIPTION
Reasons:

1. Use `Point3DCollection` which implement `IFormattable` enable usage like this in xaml:
`<Helix:LinesVisual3D Points="-100,0,0 100,0,0" />`
2. `Point3DCollection` is the standard data type in WPF. `MeshGeometry3D.Positions` is `Point3DCollection`.
3.  `Point3DCollection` also implement  `IList`, so it just add new functionalities without lost.