### PR TITLE
Solved drag&drop problem: a lot of DragEnter/DragLeave events when dragging over HelixViewport3D and its children.

### DIFF
--- a/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
+++ b/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
@@ -3224,6 +3224,7 @@ namespace HelixToolkit.Wpf
                 if (this.adornerLayer != null)
                 {
                     this.adornerLayer.Child = this.viewport;
+                    adornerLayer.IsHitTestVisible = false;
                 }
             }
 


### PR DESCRIPTION
Solved drag&drop problem mentioned http://forum.helix-toolkit.org/topic/509250-drag-drop-behaviour-changing-between-helixtoolkit-and-helixtoolkitwpf/

A lot of DragEnter/DragLeave events when dragging over HelixViewport3D and its children.
