### PR TITLE
"Zoom extents" doesn't work correctly for BillboardText #234

### DIFF
--- a/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
@@ -120,6 +120,11 @@ namespace HelixToolkit.Wpf
 
             foreach (var child in GetChildren(visual))
             {
+                if (child is IBoundsIgnoredVisual3D)
+                {
+                    continue;
+                }
+
                 var b = FindBounds(child, childTransform);
                 bounds.Union(b);
             }


### PR DESCRIPTION
Added IBoundsIgnore support to all FindBounds overloads