### PR TITLE
Fix Obj texture loading with SharpDX

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
@@ -1180,13 +1180,13 @@ namespace HelixToolkit.Wpf.SharpDX
                     //AmbientMap = this.AmbientMap,
 
                     DiffuseColor = this.Diffuse,
-                    DiffuseMap = (this.DiffuseMap == null) ? null : LoadImage(this.DiffuseMap),
+                    DiffuseMap = (this.DiffuseMap == null) ? null : LoadImage(Path.Combine(texturePath, this.DiffuseMap)),
 
                     SpecularColor = this.Specular,
                     SpecularShininess = (float)this.SpecularCoefficient,
                     //SpecularMap = this.SpecularMap,
 
-                    NormalMap = (this.BumpMap == null) ? null : LoadImage(this.BumpMap),
+                    NormalMap = (this.BumpMap == null) ? null : LoadImage(Path.Combine(texturePath, this.BumpMap)),
                     //Dissolved = this.Dissolved,
                     //Illumination = this.Illumination,
 
@@ -1199,7 +1199,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
             private static BitmapImage LoadImage(string path)
             {
-                var bmp = new BitmapImage(new Uri(@"./Media/" + path, UriKind.RelativeOrAbsolute));
+                var bmp = new BitmapImage(new Uri(path,UriKind.RelativeOrAbsolute));
                 return bmp;
             }
 


### PR DESCRIPTION
I edited some lines of code to enhance texture loading when they are linked to an MTL file with the Helix SharpDX ObjLoader. 

User won't have to copy textures in a "media" folder but their path will be relative to the OBJ/MTL file folder.

One possible issue is the loading of textures specified with absolute paths (some softwares export obj/mtl in such format) but I think this change would be useful to many users.