### PR TITLE
Make DX11ImageSource use the same adapter as the EffectsManager.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -277,7 +277,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 return; // StardD3D() is called from DP changed handler
             }
 
-            surfaceD3D = new DX11ImageSource();
+            surfaceD3D = new DX11ImageSource(EffectsManager.AdapterIndex);
             surfaceD3D.IsFrontBufferAvailableChanged += OnIsFrontBufferAvailableChanged;
             device = EffectsManager.Device;
             deferredRenderer = new DeferredRenderer();

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DX11ImageSource.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DX11ImageSource.cs
@@ -43,10 +43,13 @@ namespace HelixToolkit.Wpf.SharpDX
         private static int activeClients;
         private static Direct3DEx context;
         private static DeviceEx device;
+
+        private readonly int adapterIndex;
         private Texture renderTarget;
 
-        public DX11ImageSource()
+        public DX11ImageSource(int adapterIndex = 0)
         {
+            this.adapterIndex = adapterIndex;
             this.StartD3D();
             activeClients++;
         }
@@ -129,7 +132,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 PresentationInterval = PresentInterval.Default,    
             };
                         
-            device = new DeviceEx(context, 0, DeviceType.Hardware, IntPtr.Zero, CreateFlags.HardwareVertexProcessing | CreateFlags.Multithreaded | CreateFlags.FpuPreserve, presentparams);
+            device = new DeviceEx(context, this.adapterIndex, DeviceType.Hardware, IntPtr.Zero, CreateFlags.HardwareVertexProcessing | CreateFlags.Multithreaded | CreateFlags.FpuPreserve, presentparams);
         }
 
         private void EndD3D()

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Effects.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Effects.cs
@@ -25,6 +25,7 @@ namespace HelixToolkit.Wpf.SharpDX
         InputLayout GetLayout(RenderTechnique technique);
         Effect GetEffect(RenderTechnique technique);
         global::SharpDX.Direct3D11.Device Device { get; }
+        int AdapterIndex { get; }
     }
 
     /// <summary>
@@ -47,7 +48,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             this.renderTechniquesManager = renderTechniquesManager;
 #if DX11
-            var adapter = GetBestAdapter();
+            var adapter = GetBestAdapter(out adapterIndex);
 
             if (adapter != null)
             {
@@ -75,16 +76,20 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         /// <returns></returns>
-        private static Adapter GetBestAdapter()
+        private static Adapter GetBestAdapter(out int bestAdapterIndex)
         {
             using (var f = new Factory())
             {
                 Adapter bestAdapter = null;
+                bestAdapterIndex = -1;
+                int adapterIndex = -1;
                 long bestVideoMemory = 0;
                 long bestSystemMemory = 0;
 
                 foreach (var item in f.Adapters)
                 {
+                    adapterIndex++;
+
                     // not skip the render only WARP device
                     if (item.Description.VendorId != 0x1414 || item.Description.DeviceId != 0x8c)
                     {
@@ -108,6 +113,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     if ((bestAdapter == null) || (videoMemory > bestVideoMemory) || ((videoMemory == bestVideoMemory) && (systemMemory > bestSystemMemory)))
                     {
                         bestAdapter = item;
+                        bestAdapterIndex = adapterIndex;
                         bestVideoMemory = videoMemory;
                         bestSystemMemory = systemMemory;
                     }
@@ -123,6 +129,11 @@ namespace HelixToolkit.Wpf.SharpDX
         public global::SharpDX.Direct3D11.Device Device { get { return device; } }
 
         /// <summary>
+        /// Gets the index of the adapter in use.
+        /// </summary>
+        public int AdapterIndex { get { return adapterIndex; } }
+
+        /// <summary>
         /// Gets the device's driver type.
         /// </summary>
         public DriverType DriverType { get { return driverType; } }
@@ -131,6 +142,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         protected global::SharpDX.Direct3D11.Device device;
+
+        /// <summary>
+        /// The index of the adapter in use.
+        /// </summary>
+        private int adapterIndex;
 
         /// <summary>
         /// The driver type.


### PR DESCRIPTION
This PR should fix #224. I could reproduce the "white window" issue by activating the onboad Intel GPU, attaching a monitor to it and making it the primary adaper in Windows. Another monitor is still attached to the nVidia GPU. So both adapters have outputs and the "best adapter" is still the nVidia GPU, but it's not the primary adapter (index 0) anymore (but index 1). Prior to this PR, the EffectsManager used the "best adapter" and DX11ImageSource always used adapter index 0 (primary adapter). Now both use the "best adapter". 

@LordBenjamin: Thanks for pointing it out.
