### PR TITLE
#289 ZoomAroundMouseDownPoint calculation changed.

### DIFF
--- a/Source/Examples/WPF/ExampleBrowser/Examples/CursorPosition/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/CursorPosition/MainWindow.xaml
@@ -38,10 +38,12 @@
                 <TextBox Grid.Row="2" Grid.Column="1" BorderThickness="0" TextAlignment="Right" Background="{Binding Path=Background, RelativeSource={RelativeSource TemplatedParent}}"
                          Text="{Binding Path=ConstructionPlane.Normal, ElementName=view1, StringFormat={}{0:f1}, FallbackValue=---, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
+            <Separator/>
+            <CheckBox x:Name="cbZoomPoint" Content="Zoom to Mouse Point" Margin="5" IsChecked="{Binding Path=ZoomAroundMouseDownPoint, ElementName=view1}"/>
 
         </StackPanel>
         <Grid>
-            <helix:HelixViewport3D x:Name="view1" CalculateCursorPosition="True" ShowCameraInfo="True">
+            <helix:HelixViewport3D x:Name="view1" CalculateCursorPosition="True" ShowCameraInfo="True" >
                 <helix:HelixViewport3D.DefaultCamera>
                     <PerspectiveCamera Position="100,100,100" LookDirection="-100,-100,-100" UpDirection="0,0,1" FieldOfView="61" NearPlaneDistance="0.001"/>
                 </helix:HelixViewport3D.DefaultCamera>                

--- a/Source/Examples/WPF/ExampleBrowser/Examples/CursorPosition/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/CursorPosition/MainWindow.xaml
@@ -43,7 +43,7 @@
 
         </StackPanel>
         <Grid>
-            <helix:HelixViewport3D x:Name="view1" CalculateCursorPosition="True" ShowCameraInfo="True" >
+            <helix:HelixViewport3D x:Name="view1" CalculateCursorPosition="True" ShowCameraInfo="True">
                 <helix:HelixViewport3D.DefaultCamera>
                     <PerspectiveCamera Position="100,100,100" LookDirection="-100,-100,-100" UpDirection="0,0,1" FieldOfView="61" NearPlaneDistance="0.001"/>
                 </helix:HelixViewport3D.DefaultCamera>                

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
@@ -2261,12 +2261,21 @@ namespace HelixToolkit.Wpf
             if (this.ZoomAroundMouseDownPoint)
             {
                 var point = e.GetPosition(this);
+                
                 Point3D nearestPoint;
                 Vector3D normal;
                 DependencyObject visual;
                 if (this.Viewport.FindNearest(point, out nearestPoint, out normal, out visual))
                 {
                     this.AddZoomForce(-e.Delta * 0.001, nearestPoint);
+                    e.Handled = true;
+                    return;
+                }
+
+                var pos = this.Viewport.UnProject(point);
+                if (pos.HasValue)
+                {
+                    this.AddZoomForce(-e.Delta * 0.001, pos.Value);
                     e.Handled = true;
                     return;
                 }

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/MouseGestureHandler.cs
@@ -487,11 +487,13 @@ namespace HelixToolkit.Wpf
             {
                 this.MouseDownNearestPoint3D = nearestPoint;
             }
-            
-            var pos = this.Viewport.UnProject(this.MouseDownPoint);
-            if (pos.HasValue)
+            else
             {
-                this.MouseDownNearestPoint3D = pos.Value;
+                var pos = this.Viewport.UnProject(this.MouseDownPoint);
+                if (pos.HasValue)
+                {
+                    this.MouseDownNearestPoint3D = pos.Value;
+                }
             }
 
             this.MouseDownPoint3D = this.UnProject(this.MouseDownPoint);

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/MouseGestureHandler.cs
@@ -478,6 +478,8 @@ namespace HelixToolkit.Wpf
         {
             this.MouseDownPoint = position;
 
+            this.MouseDownNearestPoint3D = null;
+
             Point3D nearestPoint;
             Vector3D normal;
             DependencyObject visual;
@@ -485,9 +487,11 @@ namespace HelixToolkit.Wpf
             {
                 this.MouseDownNearestPoint3D = nearestPoint;
             }
-            else
+            
+            var pos = this.Viewport.UnProject(this.MouseDownPoint);
+            if (pos.HasValue)
             {
-                this.MouseDownNearestPoint3D = null;
+                this.MouseDownNearestPoint3D = pos.Value;
             }
 
             this.MouseDownPoint3D = this.UnProject(this.MouseDownPoint);


### PR DESCRIPTION
Now the Zoom method can zoom around mouse position, even if there is no geometry data.

The Example "CursorPosition" has a new checkbox to enable/disable the ZoomAroundMousedownPoint property. 

This change will change the zoom behaviour. But I think zooming with the Weel is now better.

I am not sure, if we could delete the previous calculation Method with FindeNearest (Lines 2265-2273)?

Kind regards,
Christof