### PR TITLE
Added TypeConverter to Light3D.Attenuation

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
@@ -258,6 +258,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Z = quadratic attenuation.
         /// For details see: http://msdn.microsoft.com/en-us/library/windows/desktop/bb172279(v=vs.85).aspx
         /// </summary>
+        [TypeConverter(typeof(Vector3Converter))]
         public Vector3 Attenuation
         {
             get { return (Vector3)this.GetValue(AttenuationProperty); }


### PR DESCRIPTION
Allows Attenuation values to be set in XAML, which is the best place to put them for static lights IMHO. Seems to have been forgotten when new converters were introduced in https://github.com/helix-toolkit/helix-toolkit/commit/eecffd3be16da3449dfe5f39315ad64dccc46368.