### PR TITLE
Some updates

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/RenderUtil.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/RenderUtil.cs
@@ -51,20 +51,28 @@ namespace HelixToolkit.Wpf.SharpDX
         public static Direct3D11.Buffer CreateBuffer<T>(this Direct3D11.Device device, BindFlags flags, int sizeofT, T[] range)
             where T : struct
         {
-            //sizeofT = sizeofT == 0 ? sizeofT = Marshal.SizeOf(typeof(T)) : sizeofT;
-            using (var stream = new DataStream(range.Length * sizeofT, true, true))
-            {                
-                stream.WriteRange(range);
-                stream.Position = 0;
-                return new Direct3D11.Buffer(device, stream, new BufferDescription
-                {
-                    BindFlags = flags,
-                    SizeInBytes = (int)stream.Length,
-                    CpuAccessFlags = CpuAccessFlags.None,
-                    OptionFlags = ResourceOptionFlags.None,
-                    Usage = ResourceUsage.Default,
-                });
-            }
+            return Direct3D11.Buffer.Create<T>(device, range, new BufferDescription()
+            {
+                BindFlags = flags,
+                SizeInBytes = (int)range.Length * sizeofT,
+                CpuAccessFlags = CpuAccessFlags.None,
+                OptionFlags = ResourceOptionFlags.None,
+                Usage = ResourceUsage.Default,
+            });
+            ////sizeofT = sizeofT == 0 ? sizeofT = Marshal.SizeOf(typeof(T)) : sizeofT;
+            //using (var stream = new DataStream(range.Length * sizeofT, true, true))
+            //{                
+            //    stream.WriteRange(range);
+            //    stream.Position = 0;
+            //    return new Direct3D11.Buffer(device, stream, new BufferDescription
+            //    {
+            //        BindFlags = flags,
+            //        SizeInBytes = (int)stream.Length,
+            //        CpuAccessFlags = CpuAccessFlags.None,
+            //        OptionFlags = ResourceOptionFlags.None,
+            //        Usage = ResourceUsage.Default,
+            //    });
+            //}
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -110,12 +110,12 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty DepthBiasProperty =
             DependencyProperty.Register("DepthBias", typeof(int), typeof(GeometryModel3D), new UIPropertyMetadata(0, RasterStateChanged));
 
-        private static void RasterStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        protected static void RasterStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ((GeometryModel3D)d).OnRasterStateChanged((int)e.NewValue);
+            ((GeometryModel3D)d).OnRasterStateChanged();
         }
 
-        protected virtual void OnRasterStateChanged(int depthBias) { }
+        protected virtual void OnRasterStateChanged() { }
 
         public static readonly RoutedEvent MouseDown3DEvent =
             EventManager.RegisterRoutedEvent("MouseDown3D", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(Model3D));

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -158,7 +158,7 @@ namespace HelixToolkit.Wpf.SharpDX
             billboardTextureView = ShaderResourceView.FromMemory(Device, textureBytes);
 
             /// --- set rasterstate
-            OnRasterStateChanged(DepthBias);
+            OnRasterStateChanged();
 
             /// --- flush
             Device.ImmediateContext.Flush();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
@@ -126,6 +126,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         public override void Render(RenderContext context)
         {
+            if (!this.IsRendering)
+                return;
+
+            if (this.Visibility != System.Windows.Visibility.Visible)
+                return;
+
             base.Render(context);
 
             // you mean like this?

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -179,7 +179,7 @@ namespace HelixToolkit.Wpf.SharpDX
             return result.IsValid;
         }
 
-        protected override void OnRasterStateChanged(int depthBias)
+        protected override void OnRasterStateChanged()
         {
             if (this.IsAttached)
             {
@@ -189,7 +189,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     FillMode = FillMode.Solid,
                     CullMode = CullMode.None,
-                    DepthBias = depthBias,
+                    DepthBias = DepthBias,
                     DepthBiasClamp = -1000,
                     SlopeScaledDepthBias = -2,
                     IsDepthClipEnabled = true,
@@ -277,7 +277,7 @@ namespace HelixToolkit.Wpf.SharpDX
             //}
 
             /// --- create raster state
-            OnRasterStateChanged(DepthBias);
+            OnRasterStateChanged();
             
 
             

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -26,6 +26,62 @@ namespace HelixToolkit.Wpf.SharpDX
 
     public class MeshGeometryModel3D : MaterialGeometryModel3D
     {
+        public static readonly DependencyProperty FrontCounterClockwiseProperty = DependencyProperty.Register("FrontCounterClockwise", typeof(bool), typeof(MeshGeometryModel3D), new PropertyMetadata(true, RasterStateChanged));
+
+        public bool FrontCounterClockwise
+        {
+            set
+            {
+                SetValue(FrontCounterClockwiseProperty, value);
+            }
+            get
+            {
+                return (bool)GetValue(FrontCounterClockwiseProperty);
+            }
+        }
+
+        public static readonly DependencyProperty CullModeProperty = DependencyProperty.Register("CullMode", typeof(CullMode), typeof(MeshGeometryModel3D), new PropertyMetadata(CullMode.None, RasterStateChanged));
+
+        public CullMode CullMode
+        {
+            set
+            {
+                SetValue(CullModeProperty, value);
+            }
+            get
+            {
+                return (CullMode)GetValue(CullModeProperty);
+            }
+        }
+
+        public static readonly DependencyProperty FillModeProperty = DependencyProperty.Register("FillMode", typeof(FillMode), typeof(MeshGeometryModel3D), new PropertyMetadata(FillMode.Solid, RasterStateChanged));
+
+        public FillMode FillMode
+        {
+            set
+            {
+                SetValue(FillModeProperty, value);
+            }
+            get
+            {
+                return (FillMode)GetValue(FillModeProperty);
+            }
+        }
+
+        public static readonly DependencyProperty IsDepthClipEnabledProperty = DependencyProperty.Register("IsDepthClipEnabled", typeof(bool), typeof(MeshGeometryModel3D), new PropertyMetadata(true, RasterStateChanged));
+
+        public bool IsDepthClipEnabled
+        {
+            set
+            {
+                SetValue(IsDepthClipEnabledProperty, value);
+            }
+            get
+            {
+                return (bool)GetValue(IsDepthClipEnabledProperty);
+            }
+        }
+
         public override int VertexSizeInBytes
         {
             get
@@ -34,11 +90,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="depthBias"></param>
-        protected override void OnRasterStateChanged(int depthBias)
+        protected override void OnRasterStateChanged()
         {
             if (this.IsAttached)
             {
@@ -46,13 +98,13 @@ namespace HelixToolkit.Wpf.SharpDX
                 /// --- set up rasterizer states
                 var rasterStateDesc = new RasterizerStateDescription()
                 {
-                    FillMode = FillMode.Solid,
-                    CullMode = CullMode.None,
-                    DepthBias = depthBias,
+                    FillMode = FillMode,
+                    CullMode = CullMode,
+                    DepthBias = DepthBias,
                     DepthBiasClamp = -1000,
                     SlopeScaledDepthBias = +0,
-                    IsDepthClipEnabled = true,
-                    IsFrontCounterClockwise = true,
+                    IsDepthClipEnabled = IsDepthClipEnabled,
+                    IsFrontCounterClockwise = FrontCounterClockwise,
 
                     //IsMultisampleEnabled = true,
                     //IsAntialiasedLineEnabled = true,                    
@@ -122,7 +174,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
 
             /// --- set rasterstate
-            this.OnRasterStateChanged(this.DepthBias);
+            this.OnRasterStateChanged();
 
             /// --- flush
             this.Device.ImmediateContext.Flush();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -183,7 +183,7 @@
 
         private void OnColorChanged()
         {
-            if (this.IsAttached)
+            if (this.IsAttached && Geometry != null && Geometry.Positions != null)
             {
                 /// --- set up buffers            
                 this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, CreateVertexArray());
@@ -199,7 +199,7 @@
             renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Points];
             base.Attach(host);
 
-            if (Geometry == null)
+            if (Geometry == null || Geometry.Positions == null)
                 return;
 
             if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -156,7 +156,7 @@
             return result.IsValid;
         }
 
-        protected override void OnRasterStateChanged(int depthBias)
+        protected override void OnRasterStateChanged()
         {
             if (this.IsAttached)
             {
@@ -166,7 +166,7 @@
                 {
                     FillMode = FillMode.Solid,
                     CullMode = CullMode.None,
-                    DepthBias = depthBias,
+                    DepthBias = DepthBias,
                     DepthBiasClamp = -1000,
                     SlopeScaledDepthBias = -2,
                     IsDepthClipEnabled = true,
@@ -232,7 +232,7 @@
             vPointParams.Set(pointParams);
 
             /// --- create raster state
-            OnRasterStateChanged(DepthBias);
+            OnRasterStateChanged();
 
             /// --- flush
             Device.ImmediateContext.Flush();


### PR DESCRIPTION
1. Create buffer directly to avoid redundant copy data to DataStream in RenderUtil.CreateBuffer<T>.
2. Bug fix. Null check for geometry in PointGeometryModel3D.
3. Added more raster state description properties to MeshGeometryModel3D. Use common OnRasterStateChanged to handle raster related property change.  This will allow multiple MeshGeometryModel3D to share same geometry and show its 3D model, its wireframe and inner surface at the same time by using different raster settings.