### PR TITLE
Advanced ViewCube and speedUP of HitTesting in GeometryModel3D

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -609,7 +609,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty ViewCubeTopTextProperty = DependencyProperty.Register(
                 "ViewCubeTopText", typeof(string), typeof(Viewport3DX), new UIPropertyMetadata("U"));
 
-        // <summary>
+        /// <summary>
         /// Identifies the <see cref=" IsViewCubeEdgeClicksEnabled"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty IsViewCubeEdgeClicksEnabledProperty =
@@ -2206,7 +2206,12 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-
+        /// <summary>
+        /// Gets or sets if the view cube edge clickable.
+        /// </summary>
+        /// <value>
+        /// Boolean for enable or disable.
+        /// </value>
         public bool IsViewCubeEdgeClicksEnabled
         {
             get { return (bool)GetValue(IsViewCubeEdgeClicksEnabledProperty); }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -613,7 +613,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Identifies the <see cref=" IsViewCubeEdgeClicksEnabled"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty IsViewCubeEdgeClicksEnabledProperty =
-            DependencyProperty.Register("IsViewCubeEdgeClicksEnabled", typeof(bool), typeof(HelixViewport3D), new PropertyMetadata(false));
+            DependencyProperty.Register("IsViewCubeEdgeClicksEnabled", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(false));
 
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -60,18 +60,18 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The camera property
         /// </summary>
         public static readonly DependencyProperty CameraProperty = DependencyProperty.Register(
-            "Camera", 
-            typeof(Camera), 
-            typeof(Viewport3DX), 
+            "Camera",
+            typeof(Camera),
+            typeof(Viewport3DX),
             new UIPropertyMetadata((s, e) => ((Viewport3DX)s).CameraPropertyChanged()));
 
         /// <summary>
         /// The camera rotation mode property
         /// </summary>
         public static readonly DependencyProperty CameraRotationModeProperty = DependencyProperty.Register(
-                "CameraRotationMode", 
-                typeof(CameraRotationMode), 
-                typeof(Viewport3DX), 
+                "CameraRotationMode",
+                typeof(CameraRotationMode),
+                typeof(Viewport3DX),
                 new PropertyMetadata(CameraRotationMode.Turntable));
 
         /// <summary>
@@ -84,18 +84,18 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The change field of view gesture property.
         /// </summary>
         public static readonly DependencyProperty ChangeFieldOfViewGestureProperty = DependencyProperty.Register(
-                "ChangeFieldOfViewGesture", 
-                typeof(MouseGesture), 
-                typeof(Viewport3DX), 
+                "ChangeFieldOfViewGesture",
+                typeof(MouseGesture),
+                typeof(Viewport3DX),
                 new UIPropertyMetadata(new MouseGesture(MouseAction.RightClick, ModifierKeys.Alt)));
 
         /// <summary>
         /// The change field of view gesture property.
         /// </summary>
         public static readonly DependencyProperty ChangeLookAtGestureProperty = DependencyProperty.Register(
-                "ChangeLookAtGesture", 
-                typeof(MouseGesture), 
-                typeof(Viewport3DX), 
+                "ChangeLookAtGesture",
+                typeof(MouseGesture),
+                typeof(Viewport3DX),
                 new UIPropertyMetadata(new MouseGesture(MouseAction.RightDoubleClick)));
 
         /// <summary>
@@ -114,18 +114,18 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The coordinate system horizontal position property.
         /// </summary>
         public static readonly DependencyProperty CoordinateSystemHorizontalPositionProperty = DependencyProperty.Register(
-                "CoordinateSystemHorizontalPosition", 
-                typeof(HorizontalAlignment), 
-                typeof(Viewport3DX), 
+                "CoordinateSystemHorizontalPosition",
+                typeof(HorizontalAlignment),
+                typeof(Viewport3DX),
                 new UIPropertyMetadata(HorizontalAlignment.Left));
 
         /// <summary>
         /// The coordinate system label foreground property
         /// </summary>
         public static readonly DependencyProperty CoordinateSystemLabelForegroundProperty = DependencyProperty.Register(
-                "CoordinateSystemLabelForeground", 
-                typeof(Brush), 
-                typeof(Viewport3DX), 
+                "CoordinateSystemLabelForeground",
+                typeof(Brush),
+                typeof(Viewport3DX),
                 new PropertyMetadata(Brushes.Black));
 
         /// <summary>
@@ -150,9 +150,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The coordinate system vertical position property.
         /// </summary>
         public static readonly DependencyProperty CoordinateSystemVerticalPositionProperty = DependencyProperty.Register(
-                "CoordinateSystemVerticalPosition", 
-                typeof(VerticalAlignment), 
-                typeof(Viewport3DX), 
+                "CoordinateSystemVerticalPosition",
+                typeof(VerticalAlignment),
+                typeof(Viewport3DX),
                 new UIPropertyMetadata(VerticalAlignment.Bottom));
 
         /// <summary>
@@ -165,9 +165,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The current position property.
         /// </summary>
         public static readonly DependencyProperty CurrentPositionProperty = DependencyProperty.Register(
-                "CurrentPosition", 
-                typeof(Point3D), 
-                typeof(Viewport3DX), 
+                "CurrentPosition",
+                typeof(Point3D),
+                typeof(Viewport3DX),
                 new FrameworkPropertyMetadata(
                     new Point3D(0, 0, 0), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
 
@@ -182,7 +182,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public static readonly DependencyProperty DeferredRendererProperty = DependencyProperty.Register(
             "DeferredRenderer", typeof(DeferredRenderer), typeof(Viewport3DX), new PropertyMetadata(null));
-        
+
         /// <summary>
         /// The default camera property.
         /// </summary>
@@ -231,9 +231,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The front view gesture property.
         /// </summary>
         public static readonly DependencyProperty FrontViewGestureProperty = DependencyProperty.Register(
-                "FrontViewGesture", 
-                typeof(InputGesture), 
-                typeof(Viewport3DX), 
+                "FrontViewGesture",
+                typeof(InputGesture),
+                typeof(Viewport3DX),
                 new UIPropertyMetadata(new KeyGesture(Key.F, ModifierKeys.Control)));
 
         /// <summary>
@@ -246,9 +246,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The info background property.
         /// </summary>
         public static readonly DependencyProperty InfoBackgroundProperty = DependencyProperty.Register(
-            "InfoBackground", 
-            typeof(Brush), 
-            typeof(Viewport3DX), 
+            "InfoBackground",
+            typeof(Brush),
+            typeof(Viewport3DX),
             new UIPropertyMetadata(new SolidColorBrush(Color.FromArgb(0x80, 0xff, 0xff, 0xff))));
 
         /// <summary>
@@ -279,7 +279,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The Render Technique property
         /// </summary>
         public static readonly DependencyProperty RenderTechniqueProperty = DependencyProperty.Register(
-            "RenderTechnique", typeof(RenderTechnique), typeof(Viewport3DX), new PropertyMetadata(null, 
+            "RenderTechnique", typeof(RenderTechnique), typeof(Viewport3DX), new PropertyMetadata(null,
                 (s, e) => ((Viewport3DX)s).RenderTechniquePropertyChanged()));
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public static readonly DependencyProperty RenderTechniquesManagerProperty = DependencyProperty.Register(
             "RenderTechniquesManager", typeof(IRenderTechniquesManager), typeof(Viewport3DX), new FrameworkPropertyMetadata(
-                null, FrameworkPropertyMetadataOptions.AffectsRender, 
+                null, FrameworkPropertyMetadataOptions.AffectsRender,
                 (s, e) => ((Viewport3DX)s).RenderTechniquesManagerPropertyChanged()));
 
         /// <summary>
@@ -295,7 +295,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         //public static readonly DependencyProperty IsDeferredShadingEnabledProperty = DependencyProperty.Register(
         //    "IsDeferredShadingEnabled", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(false, (s, e) => ((Viewport3DX)s).ReAttach()));
-        
+
         /// <summary>
         /// The is deferred shading enabled propery
         /// </summary>
@@ -373,18 +373,18 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The orthographic property.
         /// </summary>
         public static readonly DependencyProperty OrthographicProperty = DependencyProperty.Register(
-            "Orthographic", 
-            typeof(bool), 
-            typeof(Viewport3DX), 
+            "Orthographic",
+            typeof(bool),
+            typeof(Viewport3DX),
             new UIPropertyMetadata(false, (s, e) => ((Viewport3DX)s).OrthographicChanged()));
 
         /// <summary>
         /// The orthographic toggle gesture property.
         /// </summary>
         public static readonly DependencyProperty OrthographicToggleGestureProperty = DependencyProperty.Register(
-            "OrthographicToggleGesture", 
-            typeof(InputGesture), 
-            typeof(Viewport3DX), 
+            "OrthographicToggleGesture",
+            typeof(InputGesture),
+            typeof(Viewport3DX),
             new UIPropertyMetadata(new KeyGesture(Key.O, ModifierKeys.Control | ModifierKeys.Shift)));
 
         /// <summary>
@@ -421,9 +421,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The show camera info property.
         /// </summary>
         public static readonly DependencyProperty ShowCameraInfoProperty = DependencyProperty.Register(
-            "ShowCameraInfo", 
-            typeof(bool), 
-            typeof(Viewport3DX), 
+            "ShowCameraInfo",
+            typeof(bool),
+            typeof(Viewport3DX),
             new UIPropertyMetadata(false, (s, e) => ((Viewport3DX)s).UpdateCameraInfo()));
 
         /// <summary>
@@ -442,9 +442,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The show field of view property.
         /// </summary>
         public static readonly DependencyProperty ShowFieldOfViewProperty = DependencyProperty.Register(
-            "ShowFieldOfView", 
-            typeof(bool), 
-            typeof(Viewport3DX), 
+            "ShowFieldOfView",
+            typeof(bool),
+            typeof(Viewport3DX),
             new UIPropertyMetadata(false, (s, e) => ((Viewport3DX)s).UpdateFieldOfViewInfo()));
 
         /// <summary>
@@ -547,9 +547,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The use default gestures property
         /// </summary>
         public static readonly DependencyProperty UseDefaultGesturesProperty = DependencyProperty.Register(
-                "UseDefaultGestures", 
-                typeof(bool), 
-                typeof(Viewport3DX), 
+                "UseDefaultGestures",
+                typeof(bool),
+                typeof(Viewport3DX),
                 new PropertyMetadata(true, (s, e) => ((Viewport3DX)s).UseDefaultGesturesChanged()));
 
         /// <summary>
@@ -580,9 +580,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The view cube horizontal position property.
         /// </summary>
         public static readonly DependencyProperty ViewCubeHorizontalPositionProperty = DependencyProperty.Register(
-                "ViewCubeHorizontalPosition", 
-                typeof(HorizontalAlignment), 
-                typeof(Viewport3DX), 
+                "ViewCubeHorizontalPosition",
+                typeof(HorizontalAlignment),
+                typeof(Viewport3DX),
                 new UIPropertyMetadata(HorizontalAlignment.Right));
 
         /// <summary>
@@ -594,7 +594,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// The view cube opacity property.
         /// </summary>
-        public static readonly DependencyProperty ViewCubeOpacityProperty =  DependencyProperty.Register(
+        public static readonly DependencyProperty ViewCubeOpacityProperty = DependencyProperty.Register(
                 "ViewCubeOpacity", typeof(double), typeof(Viewport3DX), new UIPropertyMetadata(0.5));
 
         /// <summary>
@@ -609,13 +609,20 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty ViewCubeTopTextProperty = DependencyProperty.Register(
                 "ViewCubeTopText", typeof(string), typeof(Viewport3DX), new UIPropertyMetadata("U"));
 
+        // <summary>
+        /// Identifies the <see cref=" IsViewCubeEdgeClicksEnabled"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty IsViewCubeEdgeClicksEnabledProperty =
+            DependencyProperty.Register("IsViewCubeEdgeClicksEnabled", typeof(bool), typeof(HelixViewport3D), new PropertyMetadata(false));
+
+
         /// <summary>
         /// The view cube vertical position property.
         /// </summary>
         public static readonly DependencyProperty ViewCubeVerticalPositionProperty = DependencyProperty.Register(
-                "ViewCubeVerticalPosition", 
-                typeof(VerticalAlignment), 
-                typeof(Viewport3DX), 
+                "ViewCubeVerticalPosition",
+                typeof(VerticalAlignment),
+                typeof(Viewport3DX),
                 new UIPropertyMetadata(VerticalAlignment.Bottom));
 
         /// <summary>
@@ -652,9 +659,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The zoom rectangle gesture property.
         /// </summary>
         public static readonly DependencyProperty ZoomRectangleGestureProperty = DependencyProperty.Register(
-            "ZoomRectangleGesture", 
-            typeof(MouseGesture), 
-            typeof(Viewport3DX), 
+            "ZoomRectangleGesture",
+            typeof(MouseGesture),
+            typeof(Viewport3DX),
             new UIPropertyMetadata(
                 new MouseGesture(MouseAction.RightClick, ModifierKeys.Control | ModifierKeys.Shift)));
 
@@ -1038,7 +1045,7 @@ namespace HelixToolkit.Wpf.SharpDX
             get { return (DeferredRenderer)this.GetValue(DeferredRendererProperty); }
             set { this.SetValue(DeferredRendererProperty, value); }
         }
-             
+
 
         /// <summary>
         /// Gets or sets the default camera.
@@ -2198,6 +2205,14 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.SetValue(ViewCubeTopTextProperty, value);
             }
         }
+
+
+        public bool IsViewCubeEdgeClicksEnabled
+        {
+            get { return (bool)GetValue(IsViewCubeEdgeClicksEnabledProperty); }
+            set { SetValue(IsViewCubeEdgeClicksEnabledProperty, value); }
+        }
+
 
         /// <summary>
         /// Gets or sets the vertical position of view cube viewport.

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -57,12 +57,12 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 this.Bounds = new BoundingBox();
                 return;
-            }            
-            
+            }
+
             //var m = this.Transform.ToMatrix();
             //var b = BoundingBox.FromPoints(this.Geometry.Positions.Select(x => Vector3.TransformCoordinate(x, m)).ToArray());
             var b = BoundingBox.FromPoints(this.Geometry.Positions.Array);
-            
+
             //var b = BoundingBox.FromPoints(this.Geometry.Positions);
             //b.Minimum = Vector3.TransformCoordinate(b.Minimum, m);
             //b.Maximum = Vector3.TransformCoordinate(b.Maximum, m);
@@ -79,12 +79,12 @@ namespace HelixToolkit.Wpf.SharpDX
 
         protected override void OnTransformChanged(DependencyPropertyChangedEventArgs e)
         {
-            base.OnTransformChanged(e);            
+            base.OnTransformChanged(e);
             if (this.Geometry != null)
-            {                
+            {
                 //var b = BoundingBox.FromPoints(this.Geometry.Positions.Select(x => Vector3.TransformCoordinate(x, this.modelMatrix)).ToArray());
-                var b = BoundingBox.FromPoints(this.Geometry.Positions.Array);
-                this.Bounds = b;
+                //var b = BoundingBox.FromPoints(this.Geometry.Positions.Array);
+                //this.Bounds = b;
                 //this.BoundsDiameter = (b.Maximum - b.Minimum).Length();
             }
         }
@@ -223,17 +223,19 @@ namespace HelixToolkit.Wpf.SharpDX
             }
 
             var g = this.Geometry as MeshGeometry3D;
-            var h = false;
+            var isHit = false;
             var result = new HitTestResult();
             result.Distance = double.MaxValue;
 
             if (g != null)
             {
                 var m = this.modelMatrix;
+
                 // put bounds to world space
-                var b = BoundingBox.FromPoints(this.Geometry.Positions.Select(x => Vector3.TransformCoordinate(x, m)).ToArray());
+                var b = BoundingBox.FromPoints(this.Bounds.GetCorners().Select(x => Vector3.TransformCoordinate(x, m)).ToArray());
+
                 //var b = this.Bounds;
-    
+
                 // this all happens now in world space now:
                 if (rayWS.Intersects(ref b))
                 {
@@ -245,7 +247,7 @@ namespace HelixToolkit.Wpf.SharpDX
                         var p2 = Vector3.TransformCoordinate(t.P2, m);
                         if (Collision.RayIntersectsTriangle(ref rayWS, ref p0, ref p1, ref p2, out d))
                         {
-                            if (d < result.Distance) // If d is NaN, the condition is false.
+                            if (d > 0 && d < result.Distance) // If d is NaN, the condition is false.
                             {
                                 result.IsValid = true;
                                 result.ModelHit = this;
@@ -257,19 +259,20 @@ namespace HelixToolkit.Wpf.SharpDX
                                 n.Normalize();
                                 // transform hit-info to world space now:
                                 result.NormalAtHit = n.ToVector3D();// Vector3.TransformNormal(n, m).ToVector3D();
-                                h = true;
+                                isHit = true;
+
                             }
                         }
                     }
                 }
             }
-            if (h)
+            if (isHit)
             {
-                hits.Add(result);                
+                hits.Add(result);
             }
-            return h;
+            return isHit;
         }
-        
+
         /*
         public virtual bool HitTestMS(Ray rayWS, ref List<HitTestResult> hits)
         {
@@ -345,7 +348,7 @@ namespace HelixToolkit.Wpf.SharpDX
             set { this.SetValue(IsSelectedProperty, value); }
         }
     }
-  
+
 
 
 
@@ -355,7 +358,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public Viewport3DX Viewport { get; private set; }
         public Point Position { get; private set; }
 
-        public Mouse3DEventArgs(RoutedEvent routedEvent, object source, HitTestResult hitTestResult, Point position,  Viewport3DX viewport = null)
+        public Mouse3DEventArgs(RoutedEvent routedEvent, object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
             : base(routedEvent, source)
         {
             this.HitTestResult = hitTestResult;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -83,6 +83,8 @@ namespace HelixToolkit.Wpf.SharpDX
             if (this.Geometry != null)
             {
                 //var b = BoundingBox.FromPoints(this.Geometry.Positions.Select(x => Vector3.TransformCoordinate(x, this.modelMatrix)).ToArray());
+
+                //Bounds do not change when transformation changes, only the position of it changes.
                 //var b = BoundingBox.FromPoints(this.Geometry.Positions.Array);
                 //this.Bounds = b;
                 //this.BoundsDiameter = (b.Maximum - b.Minimum).Length();
@@ -260,6 +262,7 @@ namespace HelixToolkit.Wpf.SharpDX
                                 // transform hit-info to world space now:
                                 result.NormalAtHit = n.ToVector3D();// Vector3.TransformNormal(n, m).ToVector3D();
                                 isHit = true;
+
 
                             }
                         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Themes/Generic.xaml
+++ b/Source/HelixToolkit.Wpf.SharpDX/Themes/Generic.xaml
@@ -116,6 +116,7 @@
                                                     BackText="{Binding ViewCubeBackText, RelativeSource={RelativeSource TemplatedParent}}"
                                                     LeftText="{Binding ViewCubeLeftText, RelativeSource={RelativeSource TemplatedParent}}"
                                                     RightText="{Binding ViewCubeRightText, RelativeSource={RelativeSource TemplatedParent}}"
+                                                    EnableEdgeClicks="{Binding IsViewCubeEdgeClicksEnabled, RelativeSource={RelativeSource TemplatedParent}}"
                                                     />
                             </Viewport3D>
 

--- a/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
+++ b/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
@@ -1872,7 +1872,10 @@ namespace HelixToolkit.Wpf
                 this.SetValue(IsMoveEnabledProperty, value);
             }
         }
-
+        
+        /// <summary>
+        /// Gets or sets the view cube edge clickable.
+        /// </summary>
         public bool IsViewCubeEdgeClicksEnabled
         {
             get { return (bool)GetValue(IsViewCubeEdgeClicksEnabledProperty); }

--- a/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
+++ b/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
@@ -201,7 +201,7 @@ namespace HelixToolkit.Wpf
                 "EnableCurrentPosition", typeof(bool), typeof(HelixViewport3D), new UIPropertyMetadata(false));
 
         /// <summary>
-        /// Identifies the <see cref="CalculateCursorPosition"/> dependency property. 
+        /// Identifies the <see cref="CalculateCursorPosition"/> dependency property.
         /// It enables (true) or disables (false) the calculation of the cursor position in the 3D Viewport
         /// </summary>
         public static readonly DependencyProperty CalculateCursorPositionProperty =
@@ -211,7 +211,7 @@ namespace HelixToolkit.Wpf
         /// <summary>
         /// Identifies the <see cref="CursorPosition"/> dependency property.
         /// </summary>
-        /// <remarks> 
+        /// <remarks>
         /// The return value equals ConstructionPlanePosition or CursorModelSnapPosition if CursorSnapToModels is not null.
         /// </remarks>
         public static readonly DependencyProperty CursorPositionProperty =
@@ -224,7 +224,7 @@ namespace HelixToolkit.Wpf
         /// <summary>
         /// Identifies the <see cref="CursorOnElementPosition"/> dependency property.
         /// </summary>
-        /// <remarks> 
+        /// <remarks>
         /// This property returns the position of the nearest model.
         /// </remarks>
         public static readonly DependencyProperty CursorOnElementPositionProperty =
@@ -238,7 +238,7 @@ namespace HelixToolkit.Wpf
         /// <summary>
         /// Identifies the <see cref="CursorOnConstructionPlanePosition"/> dependency property.
         /// </summary>
-        /// <remarks> 
+        /// <remarks>
         /// This property returns the point on the cursor plane..
         /// </remarks>
         public static readonly DependencyProperty CursorOnConstructionPlanePositionProperty =
@@ -368,6 +368,12 @@ namespace HelixToolkit.Wpf
         /// </summary>
         public static readonly DependencyProperty IsMoveEnabledProperty = DependencyProperty.Register(
             "IsMoveEnabled", typeof(bool), typeof(HelixViewport3D), new UIPropertyMetadata(true));
+
+        /// <summary>
+        /// Identifies the <see cref=" IsViewCubeEdgeClicksEnabled"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty IsViewCubeEdgeClicksEnabledProperty =
+            DependencyProperty.Register("IsViewCubeEdgeClicksEnabled", typeof(bool), typeof(HelixViewport3D), new PropertyMetadata(false));
 
         /// <summary>
         /// Identifies the <see cref="IsRotationEnabled"/> dependency property.
@@ -1865,6 +1871,12 @@ namespace HelixToolkit.Wpf
             {
                 this.SetValue(IsMoveEnabledProperty, value);
             }
+        }
+
+        public bool IsViewCubeEdgeClicksEnabled
+        {
+            get { return (bool)GetValue(IsViewCubeEdgeClicksEnabledProperty); }
+            set { SetValue(IsViewCubeEdgeClicksEnabledProperty, value); }
         }
 
         /// <summary>
@@ -3480,11 +3492,13 @@ namespace HelixToolkit.Wpf
                 case NotifyCollectionChangedAction.Add:
                     this.AddItems(e.NewItems);
                     break;
+
                 case NotifyCollectionChangedAction.Move:
                     throw new NotImplementedException("Move operation not implemented.");
                 case NotifyCollectionChangedAction.Remove:
                     this.RemoveItems(e.OldItems);
                     break;
+
                 case NotifyCollectionChangedAction.Replace:
                     throw new NotImplementedException("Replace operation not implemented.");
                 case NotifyCollectionChangedAction.Reset:

--- a/Source/HelixToolkit.Wpf/Themes/Generic.xaml
+++ b/Source/HelixToolkit.Wpf/Themes/Generic.xaml
@@ -148,6 +148,7 @@
                                         Opacity="0.5" Visibility="{TemplateBinding ShowViewCube, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <local:ViewCubeVisual3D x:Name="PART_ViewCube" 
                                                         IsEnabled="{Binding IsRotationEnabled, RelativeSource={RelativeSource TemplatedParent}}"
+                                                        EnableEdgeClicks="{Binding IsViewCubeEdgeClicksEnabled, RelativeSource={RelativeSource TemplatedParent}}"
                                                         ModelUpDirection="{Binding ModelUpDirection, RelativeSource={RelativeSource TemplatedParent}}" 
                                                         TopText="{Binding ViewCubeTopText, RelativeSource={RelativeSource TemplatedParent}}"
                                                         BottomText="{Binding ViewCubeBottomText, RelativeSource={RelativeSource TemplatedParent}}"

--- a/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
@@ -373,7 +373,147 @@ namespace HelixToolkit.Wpf
             circle.Fill = Brushes.Gray;
             circle.EndEdit();
             this.Children.Add(circle);
+
+            AddCorners();
+            AddEdges();
         }
+
+        private void AddEdges()
+        {
+            var a = this.Size / 2;
+            var sideLength = a / 2;
+
+            Point3D[] xAligned = { new Point3D(0, -1, -1), new Point3D(0, 1, -1), new Point3D(0, -1, 1), new Point3D(0, 1, 1) }; //x
+            foreach (var p in xAligned)
+            {
+                var builder = new MeshBuilder(false, true);
+
+                Point3D center = p.Multiply(a);
+                builder.AddBox(center, 1.5 * a, sideLength, sideLength);
+
+                var geometry = builder.ToMesh();
+                geometry.Freeze();
+
+                var model = new GeometryModel3D { Geometry = geometry, Material = MaterialHelper.CreateMaterial(Colors.Silver) };
+                var element = new ModelUIElement3D { Model = model };
+                element.MouseLeftButtonDown += this.FaceMouseLeftButtonDown;
+
+                this.faceNormals.Add(element, p.ToVector3D());
+                this.faceUpVectors.Add(element, ModelUpDirection);
+
+                element.MouseEnter += EdggesMouseEnters;
+                element.MouseLeave += EdgesMouseLeaves;
+
+                this.Children.Add(element);
+            }
+
+            Point3D[] yAligned = { new Point3D(-1, 0, -1), new Point3D(1, 0, -1), new Point3D(-1, 0, 1), new Point3D(1, 0, 1) };//y
+            foreach (var p in yAligned)
+            {
+                var builder = new MeshBuilder(false, true);
+
+                Point3D center = p.Multiply(a);
+                builder.AddBox(center, sideLength, 1.5 * a, sideLength);
+
+                var geometry = builder.ToMesh();
+                geometry.Freeze();
+
+                var model = new GeometryModel3D { Geometry = geometry, Material = MaterialHelper.CreateMaterial(Colors.Silver) };
+                var element = new ModelUIElement3D { Model = model };
+                element.MouseLeftButtonDown += this.FaceMouseLeftButtonDown;
+
+                this.faceNormals.Add(element, p.ToVector3D());
+                this.faceUpVectors.Add(element, ModelUpDirection);
+
+                element.MouseEnter += EdggesMouseEnters;
+                element.MouseLeave += EdgesMouseLeaves;
+
+                this.Children.Add(element);
+            }
+
+            Point3D[] zAligned = { new Point3D(-1, -1, 0), new Point3D(-1, 1, 0), new Point3D(1, -1, 0), new Point3D(1, 1, 0) };//z
+            foreach (var p in zAligned)
+            {
+                var builder = new MeshBuilder(false, true);
+
+                Point3D center = p.Multiply(a);
+                builder.AddBox(center, sideLength, sideLength, 1.5 * a);
+
+                var geometry = builder.ToMesh();
+                geometry.Freeze();
+
+                var model = new GeometryModel3D { Geometry = geometry, Material = MaterialHelper.CreateMaterial(Colors.Silver) };
+                var element = new ModelUIElement3D { Model = model };
+                element.MouseLeftButtonDown += this.FaceMouseLeftButtonDown;
+
+                this.faceNormals.Add(element, p.ToVector3D());
+                this.faceUpVectors.Add(element, ModelUpDirection);
+
+                element.MouseEnter += EdggesMouseEnters;
+                element.MouseLeave += EdgesMouseLeaves;
+
+                this.Children.Add(element);
+            }
+        }
+
+        private void AddCorners()
+        {
+            var a = this.Size / 2;
+            var sideLength = a / 2;
+
+            Point3D[] points =   {
+                new Point3D(-1,-1,-1 ), new Point3D(1, -1, -1), new Point3D(1, 1, -1), new Point3D(-1, 1, -1),
+                new Point3D(-1,-1,1 ),new Point3D(1,-1,1 ),new Point3D(1,1,1 ),new Point3D(-1,1,1 )};
+
+            foreach (var p in points)
+            {
+                var builder = new MeshBuilder(false, true);
+
+                Point3D center = p.Multiply(a);
+                builder.AddBox(center, sideLength, sideLength, sideLength);
+                var geometry = builder.ToMesh();
+                geometry.Freeze();
+
+                var model = new GeometryModel3D { Geometry = geometry, Material = MaterialHelper.CreateMaterial(Colors.Gold) };
+                var element = new ModelUIElement3D { Model = model };
+                element.MouseLeftButtonDown += this.FaceMouseLeftButtonDown;
+
+                this.faceNormals.Add(element, p.ToVector3D());
+                this.faceUpVectors.Add(element, ModelUpDirection);
+
+                element.MouseEnter += CornersMouseEnters;
+                element.MouseLeave += CornersMouseLeave;
+
+                this.Children.Add(element);
+            }
+        }
+
+
+        private void EdgesMouseLeaves(object sender, MouseEventArgs e)
+        {
+            ModelUIElement3D s = sender as ModelUIElement3D;
+            (s.Model as GeometryModel3D).Material = MaterialHelper.CreateMaterial(Colors.Silver);
+        }
+
+        private void EdggesMouseEnters(object sender, MouseEventArgs e)
+        {
+            ModelUIElement3D s = sender as ModelUIElement3D;
+            (s.Model as GeometryModel3D).Material = MaterialHelper.CreateMaterial(Colors.Goldenrod);
+        }
+
+        private void CornersMouseLeave(object sender, MouseEventArgs e)
+        {
+            ModelUIElement3D s = sender as ModelUIElement3D;
+            (s.Model as GeometryModel3D).Material = MaterialHelper.CreateMaterial(Colors.Gold);
+        }
+
+        private void CornersMouseEnters(object sender, MouseEventArgs e)
+        {
+            ModelUIElement3D s = sender as ModelUIElement3D;
+            (s.Model as GeometryModel3D).Material = MaterialHelper.CreateMaterial(Colors.Goldenrod);
+        }
+
+
 
         /// <summary>
         /// Adds a cube face.
@@ -395,13 +535,13 @@ namespace HelixToolkit.Wpf
             var grid = new Grid { Width = 20, Height = 20, Background = b };
             grid.Children.Add(
                 new TextBlock
-                    {
-                        Text = text,
-                        VerticalAlignment = VerticalAlignment.Center,
-                        HorizontalAlignment = HorizontalAlignment.Center,
-                        FontSize = 15,
-                        Foreground = Brushes.White
-                    });
+                {
+                    Text = text,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    FontSize = 15,
+                    Foreground = Brushes.White
+                });
             grid.Arrange(new Rect(new Point(0, 0), new Size(20, 20)));
 
             var bmp = new RenderTargetBitmap((int)grid.Width, (int)grid.Height, 96, 96, PixelFormats.Default);

--- a/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
@@ -93,7 +93,10 @@ namespace HelixToolkit.Wpf
         /// </summary>
         public static readonly DependencyProperty ViewportProperty = DependencyProperty.Register(
             "Viewport", typeof(Viewport3D), typeof(ViewCubeVisual3D), new PropertyMetadata(null));
-
+            
+        /// <summary>
+        /// Set or Get if view cube edge clickable.
+        /// </summary>
         public bool EnableEdgeClicks
         {
             get { return (bool)GetValue(EnableEdgeClicksProperty); }


### PR DESCRIPTION
Added the ability to click on every corner and every Edge on the ViewCube (#1) 

Speed up Hittesting ing the Geometrymodel3D by not using the whole geometry but only the Bounds 
