### PR TITLE
Enhancement of Triangulator with holes

### DIFF
--- a/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
@@ -59,7 +59,7 @@ namespace PolygonTriangulationDemo
                         lineTriangulatedPolygon.Geometry = null;
                     }
                 }
-            }); 
+            });
         }
 
         /// <summary>

--- a/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
@@ -90,29 +90,38 @@ namespace PolygonTriangulationDemo
         {
             // Generate random Polygon
             var random = new Random();
-            var cnt = /*mViewModel.PointCount*/12;
+            var cnt = mViewModel.PointCount;
             mPolygonPoints = new List<Vector2>();
             var angle = 0f;
             var angleDiff = 2f * (Single)Math.PI / cnt;
             var radius = 4f;
             // Random Radii for the Polygon
             var radii = new List<float>();
+            var innerRadii = new List<float>();
             for (int i = 0; i < cnt; i++)
             {
-                radii.Add(radius/* + random.NextFloat(-radius / 10, radius / 10)*/);
+                radii.Add(random.NextFloat(radius * 0.9f, radius * 1.1f));
+                innerRadii.Add(random.NextFloat(radius * 0.2f, radius * 0.3f));
             }
-            var hole = new List<Vector2>();
+            var hole1 = new List<Vector2>();
+            var hole2 = new List<Vector2>();
+            var holeDistance = 2f;
+            var holeAngle = random.NextFloat(0, (float)Math.PI * 2);
+            var cos = (float)Math.Cos(holeAngle);
+            var sin = (float)Math.Sin(holeAngle);
+            var offset1 = new Vector2(holeDistance * cos, holeDistance * sin);
+            var offset2 = new Vector2(-holeDistance * cos, -holeDistance * sin);
             for (int i = 0; i < cnt; i++)
             {
                 // Flatten a bit
                 var radiusUse = radii[i];
-                mPolygonPoints.Add(new Vector2(radiusUse * (Single)Math.Cos(angle), radiusUse * (Single)Math.Sin(angle)));
+                mPolygonPoints.Add(new Vector2(radii[i] * (Single)Math.Cos(angle), radii[i] * (Single)Math.Sin(angle)));
+                hole1.Add(offset1 + new Vector2(innerRadii[i] * (Single)Math.Cos(-angle), innerRadii[i] * (Single)Math.Sin(-angle)));
+                hole2.Add(offset2 + new Vector2(innerRadii[i] * (Single)Math.Cos(-angle), innerRadii[i] * (Single)Math.Sin(-angle)));
                 angle += angleDiff;
             }
-            var holes = new List<List<Vector2>>();
-            var offset = new Vector2(random.NextFloat(-2, 2), random.NextFloat(-2, 2));
-            holes.Add(MeshBuilder.GetCircle(12, true).Select(p => p + new Vector2(.5f, .5f)).ToList());
-            //holes.Add(MeshBuilder.GetCircle(12, true).Select(p => p + new Vector2(-2, -2)).ToList());
+
+            var holes = new List<List<Vector2>>() { hole1, hole2 };
 
             // Triangulate and measure the Time needed for the Triangulation
             var before = DateTime.Now;

--- a/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
@@ -22,10 +22,12 @@ namespace PolygonTriangulationDemo
         /// List of Polygon Points to display
         /// </summary>
         List<Vector2> mPolygonPoints;
+        
         /// <summary>
         /// The ViewModel
         /// </summary>
         MainViewModel mViewModel;
+        
         /// <summary>
         /// Constructor for the MainWindow
         /// </summary>
@@ -95,29 +97,33 @@ namespace PolygonTriangulationDemo
             var radius = 4f;
             // Random Radii for the Polygon
             var radii = new List<float>();
+            var innerRadii = new List<float>();
             for (int i = 0; i < cnt; i++)
             {
-                radii.Add(radius + random.NextFloat(-radius, radius));
+                radii.Add(radius + random.NextFloat(-radius / 10, radius / 10));
+                innerRadii.Add(radius/2 + random.NextFloat(-radius / 10, radius / 10));
             }
+            var hole = new List<Vector2>();
             for (int i = 0; i < cnt; i++)
             {
-                var last = i > 0 ? i - 1 : cnt - 1;
-                var next = i < cnt - 1 ? i + 1 : 0;
                 // Flatten a bit
-                var radiusUse = radii[last] * 0.25f + radii[i] * 0.5f + radii[next] * 0.25f;
+                var radiusUse = radii[i];
                 mPolygonPoints.Add(new Vector2(radiusUse * (Single)Math.Cos(angle), radiusUse * (Single)Math.Sin(angle)));
+                hole.Add(new Vector2(innerRadii[i] * (Single)Math.Cos(angle), innerRadii[i] * (Single)Math.Sin(angle)));
                 angle += angleDiff;
             }
+            var holes = new List<List<Vector2>>() { hole };
+
             // Triangulate and measure the Time needed for the Triangulation
             var before = DateTime.Now;
-            var sLTI = SweepLinePolygonTriangulator.Triangulate(mPolygonPoints);
+            var sLTI = SweepLinePolygonTriangulator.Triangulate(mPolygonPoints, holes);
             var after = DateTime.Now;
             
             // Generate the Output
             var geometry = new HelixToolkit.Wpf.SharpDX.MeshGeometry3D();
             geometry.Positions = new HelixToolkit.Wpf.SharpDX.Core.Vector3Collection();
             geometry.Normals = new HelixToolkit.Wpf.SharpDX.Core.Vector3Collection();
-            foreach (var point in mPolygonPoints)
+            foreach (var point in mPolygonPoints.Union(holes.SelectMany(h => h)))
             {
                 geometry.Positions.Add(new Vector3(point.X, 0, point.Y + 5));
                 geometry.Normals.Add(new Vector3(0, 1, 0));

--- a/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
@@ -111,8 +111,8 @@ namespace PolygonTriangulationDemo
             }
             var holes = new List<List<Vector2>>();
             var offset = new Vector2(random.NextFloat(-2, 2), random.NextFloat(-2, 2));
-            holes.Add(MeshBuilder.GetCircle(12, true).Select(p => p + offset).ToList());
-            //holes.Add(MeshBuilder.GetCircle(12, true).Select(p => p + new Vector2(0.4562409f-1, 0.978230834f)).ToList());
+            holes.Add(MeshBuilder.GetCircle(12, true).Select(p => p + new Vector2(.5f, .5f)).ToList());
+            //holes.Add(MeshBuilder.GetCircle(12, true).Select(p => p + new Vector2(-2, -2)).ToList());
 
             // Triangulate and measure the Time needed for the Triangulation
             var before = DateTime.Now;

--- a/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/PolygonTriangulationDemo/MainWindow.xaml.cs
@@ -90,18 +90,16 @@ namespace PolygonTriangulationDemo
         {
             // Generate random Polygon
             var random = new Random();
-            var cnt = mViewModel.PointCount;
+            var cnt = /*mViewModel.PointCount*/12;
             mPolygonPoints = new List<Vector2>();
             var angle = 0f;
             var angleDiff = 2f * (Single)Math.PI / cnt;
             var radius = 4f;
             // Random Radii for the Polygon
             var radii = new List<float>();
-            var innerRadii = new List<float>();
             for (int i = 0; i < cnt; i++)
             {
-                radii.Add(radius + random.NextFloat(-radius / 10, radius / 10));
-                innerRadii.Add(radius/2 + random.NextFloat(-radius / 10, radius / 10));
+                radii.Add(radius/* + random.NextFloat(-radius / 10, radius / 10)*/);
             }
             var hole = new List<Vector2>();
             for (int i = 0; i < cnt; i++)
@@ -109,10 +107,12 @@ namespace PolygonTriangulationDemo
                 // Flatten a bit
                 var radiusUse = radii[i];
                 mPolygonPoints.Add(new Vector2(radiusUse * (Single)Math.Cos(angle), radiusUse * (Single)Math.Sin(angle)));
-                hole.Add(new Vector2(innerRadii[i] * (Single)Math.Cos(angle), innerRadii[i] * (Single)Math.Sin(angle)));
                 angle += angleDiff;
             }
-            var holes = new List<List<Vector2>>() { hole };
+            var holes = new List<List<Vector2>>();
+            var offset = new Vector2(random.NextFloat(-2, 2), random.NextFloat(-2, 2));
+            holes.Add(MeshBuilder.GetCircle(12, true).Select(p => p + offset).ToList());
+            //holes.Add(MeshBuilder.GetCircle(12, true).Select(p => p + new Vector2(0.4562409f-1, 0.978230834f)).ToList());
 
             // Triangulate and measure the Time needed for the Triangulation
             var before = DateTime.Now;

--- a/Source/HelixToolkit.Wpf.SharpDX/Core/SweepLinePolygonTriangulator.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Core/SweepLinePolygonTriangulator.cs
@@ -1104,50 +1104,5 @@ namespace HelixToolkit.Wpf.SharpDX
                 polyPoints[i].EdgeOne = edge;
             }
         }
-
-        /// <summary>
-        /// Get all Points (including) between the Points with the provided Indices.
-        /// </summary>
-        /// <param name="from">Startpoint</param>
-        /// <param name="to">Endpoint</param>
-        /// <returns>List of PolygonPoints between the two Points</returns>
-        internal List<PolygonPoint> GetEdgePoints(int from, int to)
-        {
-            var result = new List<PolygonPoint>();
-            var currentPoint = mPoints.FirstOrDefault(p => p.Index == from);
-            do
-            {
-                result.Add(currentPoint);
-                currentPoint = currentPoint.Next;
-            }
-            while (currentPoint.Index != to) ;
-            result.Add(currentPoint);
-            return result;
-        }
-
-        /// <summary>
-        /// Check if two Points defined by their Indices are connected
-        /// </summary>
-        /// <param name="from">The First Point Index</param>
-        /// <param name="to">The second Point Index</param>
-        /// <returns></returns>
-        /*internal Boolean Connected(int from, int to)
-        {
-            // Save the visited Points (to be able to abort the Search)
-            var visited = new HashSet<int>();
-            // Get the first Point
-            var currentPoint = mPoints.FirstOrDefault(p => p.Index == from);
-            // Loop until the Point was found or the Point already exists in the visited List
-            while (!visited.Contains(currentPoint.Index) && currentPoint.Index != to)
-            {
-                visited.Add(currentPoint.Index);
-                currentPoint = currentPoint.Next;
-            }
-            // If the current Point has the searched Index, they are connected
-            if (currentPoint.Index == to)
-                return true;
-            // Not connected
-            return false;
-        }*/
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Core/SweepLinePolygonTriangulator.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Core/SweepLinePolygonTriangulator.cs
@@ -78,12 +78,6 @@ namespace HelixToolkit.Wpf.SharpDX
 
             var poly = new PolygonData(points);
 
-            var mapping = new Dictionary<int, int>();
-            for (int i = 0; i < poly.Points.Count; i++)
-            {
-                mapping[poly.Points[i].Index] = i;
-            }
-
             if (holes != null)
             {
                 foreach (var hole in holes)
@@ -97,13 +91,11 @@ namespace HelixToolkit.Wpf.SharpDX
             events.Sort();
 
             // Calculate the Diagonals in the Down Sweep
-            var diagonals = CalculateDiagonals(events, mapping);
-
+            var diagonals = CalculateDiagonals(events);
             // Reverse the Order of the Events
             events.Reverse();
-            
             // Add the Diagonals in the Up Sweep (and remove duplicates)
-            diagonals.AddRange(CalculateDiagonals(events, mapping, false));
+            diagonals.AddRange(CalculateDiagonals(events,  false));
             diagonals = diagonals.Distinct().ToList();
 
             // Use Diagonals to split into nonotone Polygons
@@ -277,10 +269,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Calculate the Diagonals to add inside the Polygon.
         /// </summary>
         /// <param name="events">The Events in sorted Form</param>
-        /// <param name="mapping">Mapping from main Polygon to the current Polygon</param>
         /// <param name="sweepDown">True in the first Stage (sweeping down), false in the following Stages (sweeping up)</param>
         /// <returns></returns>
-        private static List<Tuple<int, int>> CalculateDiagonals(List<PolygonPoint> events, Dictionary<int, int> mapping, Boolean sweepDown = true)
+        private static List<Tuple<int, int>> CalculateDiagonals(List<PolygonPoint> events, Boolean sweepDown = true)
         {
             // Diagonals to add to the Polygon to make it monotone after the Down- and Up-Sweeps
             var diagonals = new List<Tuple<int, int>>();

--- a/Source/HelixToolkit.Wpf.SharpDX/Core/SweepLinePolygonTriangulator.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Core/SweepLinePolygonTriangulator.cs
@@ -595,13 +595,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 // Calculate the x-Coordinate of the Intersection between
                 // a horizontal Line from the Point to the Left and the Edge of the StatusHelperElement
-                Double xValue = Double.NaN;
-                if (point.Y == she.Edge.PointOne.Y)
-                    xValue = she.Edge.PointOne.X;
-                else if (point.Y == she.Edge.PointTwo.Y)
-                    xValue = she.Edge.PointTwo.X;
-                else
-                    xValue = she.Edge.PointOne.X + ((point.Y - she.Edge.PointOne.Y) / (she.Edge.PointTwo.Y - she.Edge.PointOne.Y)) * (she.Edge.PointTwo.X - she.Edge.PointOne.X);
+                Double xValue = she.Edge.PointOne.X + ((point.Y - she.Edge.PointOne.Y) / she.Vector.Y) * she.Vector.X;
                 
                 // If the xValue is smaller than or equal to the Point's x-Coordinate
                 // (i.e. it lies on the left Side of it - allows a small Error)
@@ -640,6 +634,21 @@ namespace HelixToolkit.Wpf.SharpDX
         public PolygonPoint Helper { get; set; }
 
         /// <summary>
+        /// Vector that points From the Edge's Start to Endpoint
+        /// </summary>
+        private Point mVector;
+
+        /// <summary>
+        /// Accessor to the Vector
+        /// </summary>
+        public Point Vector
+        {
+            get { return mVector; }
+            set { mVector = value; }
+        }
+
+
+        /// <summary>
         /// Constructor taking an Edge and a Helper
         /// </summary>
         /// <param name="edge">The Edge of the StatusHelperElement</param>
@@ -648,6 +657,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             this.Edge = edge;
             this.Helper = point;
+            this.mVector = edge.PointTwo.Point - edge.PointOne.Point;
         }
     }
     

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/MeshBuilder.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/MeshBuilder.cs
@@ -599,7 +599,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
             // Since Vector2Collection is not Freezable,
             // return new IList<Vector> to avoid manipulation of the Cached Values
-            IList<Vector2> result = null;
+            IList<Vector2> result = new List<Vector2>();
             foreach (var point in circle)
             {
                 result.Add(new Vector2(point.X, point.Y));


### PR DESCRIPTION
The previously created faster Triangulator was now enhanced to also work with multiple Holes.
The Holes need to be positioned completely inside the Polygon-Boundary.
Multiple Holes may not overlap, otherwise the triangulation may not work!

It is now a little slower than before but the added functionality is worth it.