### PR TITLE
Fixed FieldOfView for Perspective Camera in HelixToolkit.WPF.SharpDX

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Camera/PerspectiveCamera.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Camera/PerspectiveCamera.cs
@@ -7,6 +7,8 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
+
 namespace HelixToolkit.Wpf.SharpDX
 {
     using System.Windows;
@@ -47,17 +49,19 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </returns>
         public override Matrix CreateProjectionMatrix(double aspectRatio)
         {
+            var fov = this.FieldOfView*Math.PI/180;
+
             if (this.CreateLeftHandSystem)
             {
                 return global::SharpDX.Matrix.PerspectiveFovLH(
-                    (float)this.FieldOfView, 
-                    (float)aspectRatio, 
-                    (float)this.NearPlaneDistance, 
+                    (float)fov,
+                    (float)aspectRatio,
+                    (float)this.NearPlaneDistance,
                     (float)this.FarPlaneDistance);
             }
 
             return global::SharpDX.Matrix.PerspectiveFovRH(
-                (float)this.FieldOfView, (float)aspectRatio, (float)this.NearPlaneDistance, (float)this.FarPlaneDistance);
+                (float)fov, (float)aspectRatio, (float)this.NearPlaneDistance, (float)this.FarPlaneDistance);
         }
 
         /// <summary>


### PR DESCRIPTION
The SharpDX.Matrix.PerspectiveFovLH should use fov in radians, not angles.

See: https://msdn.microsoft.com/en-us/library/windows/desktop/bb281727%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396