### PR TITLE
Add AddBox(Rect3D rectangle, BoxFaces faces) to MeshBuilder

### DIFF
--- a/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
+++ b/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
@@ -782,11 +782,12 @@ namespace HelixToolkit.Wpf
         /// <param name="rectangle">
         /// The 3-D "rectangle".
         /// </param>
-        public void AddBox(Rect3D rectangle)
+        /// <param name="faces">The faces to include.</param>
+        public void AddBox(Rect3D rectangle, BoxFaces faces = BoxFaces.All)
         {
             this.AddBox(
                 new Point3D((DoubleOrSingle)(rectangle.X + (rectangle.SizeX * 0.5f)), (DoubleOrSingle)(rectangle.Y + (rectangle.SizeY * 0.5f)), (DoubleOrSingle)(rectangle.Z + (rectangle.SizeZ * 0.5f))),
-                (DoubleOrSingle)rectangle.SizeX, (DoubleOrSingle)rectangle.SizeY, (DoubleOrSingle)rectangle.SizeZ, BoxFaces.All);
+                (DoubleOrSingle)rectangle.SizeX, (DoubleOrSingle)rectangle.SizeY, (DoubleOrSingle)rectangle.SizeZ, faces);
         }
         /// <summary>
         /// Adds a box with the specified faces, aligned with the X, Y and Z axes.


### PR DESCRIPTION
Fix #362 
Add the missing `AddBox` overload to `MeshBuilder`.