### PR TITLE
Fix CS0436 warnings

### DIFF
--- a/Source/Examples/WPF.SharpDX/TessellationDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/TessellationDemo/MainViewModel.cs
@@ -40,7 +40,7 @@ namespace TessellationDemo
         
         public string[] MeshTopologyList { get; set; }
         
-        private string meshTopology = HelixToolkit.Wpf.MeshFaces.Default.ToString();
+        private string meshTopology = MeshFaces.Default.ToString();
         private RenderTechnique pnQuads;
         private RenderTechnique pnTriangles;
 
@@ -54,7 +54,7 @@ namespace TessellationDemo
                 this.RenderTechnique = this.meshTopology == "Quads" ? 
                     RenderTechniquesManager.RenderTechniques[TessellationRenderTechniqueNames.PNQuads] :
                     RenderTechniquesManager.RenderTechniques[TessellationRenderTechniqueNames.PNTriangles];
-                this.LoadModel(@"./Media/teapot_quads_tex.obj", this.meshTopology == "Quads" ? HelixToolkit.Wpf.MeshFaces.QuadPatches : HelixToolkit.Wpf.MeshFaces.Default);                                               
+                this.LoadModel(@"./Media/teapot_quads_tex.obj", this.meshTopology == "Quads" ? MeshFaces.QuadPatches : MeshFaces.Default);                                               
             }
         }
 
@@ -115,7 +115,7 @@ namespace TessellationDemo
         /// </summary>
         /// <param name="filename">filename</param>
         /// <param name="faces">Determines if facades should be treated as triangles (Default) or as quads (Quads)</param>
-        private void LoadModel(string filename, HelixToolkit.Wpf.MeshFaces faces)
+        private void LoadModel(string filename, MeshFaces faces)
         {
             // load model
             var reader = new ObjReader();

--- a/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
+++ b/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
@@ -6,8 +6,11 @@
 //   Builds MeshGeometry3D objects.
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
-
+#if SHARPDX
+namespace HelixToolkit.Wpf.SharpDX
+#else
 namespace HelixToolkit.Wpf
+#endif
 {
     using System;
     using System.Collections.Generic;

--- a/Source/HelixToolkit.Shared/Geometry/SweepLinePolygonTriangulator.cs
+++ b/Source/HelixToolkit.Shared/Geometry/SweepLinePolygonTriangulator.cs
@@ -6,8 +6,11 @@
 //   A polygon triangulator for simple polygons with no holes. Expected runtime is O(n log n)
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
-
+#if SHARPDX
+namespace HelixToolkit.Wpf.SharpDX
+#else
 namespace HelixToolkit.Wpf
+#endif
 {
     using System;
     using System.Collections.Generic;

--- a/Source/HelixToolkit.Shared/HelixToolkitException.cs
+++ b/Source/HelixToolkit.Shared/HelixToolkitException.cs
@@ -6,8 +6,11 @@
 //   Represents errors that occurs in the Helix 3D Toolkit.
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
-
+#if SHARPDX
+namespace HelixToolkit.Wpf.SharpDX
+#else
 namespace HelixToolkit.Wpf
+#endif
 {
     using System;
 


### PR DESCRIPTION
Separate the namespace into Helixtoolkit.WPF and Helixtoolkit.WPF.SharpDX to avoid CS0436 warnings during build.