### PR TITLE
GetProjectionMatrix returned different projection matrix than the camera

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraExtensions.cs
@@ -399,21 +399,13 @@ namespace HelixToolkit.Wpf.SharpDX
             var perspectiveCamera = camera as PerspectiveCamera;
             if (perspectiveCamera != null)
             {
-                return Matrix.PerspectiveFovRH(
-                    (float)perspectiveCamera.FieldOfView,
-                    (float)(aspectRatio),
-                    (float)perspectiveCamera.NearPlaneDistance,
-                    (float)perspectiveCamera.FarPlaneDistance);
+                return perspectiveCamera.CreateProjectionMatrix(aspectRatio);
             }
 
             var orthographicCamera = camera as OrthographicCamera;
             if (orthographicCamera != null)
             {
-                return Matrix.OrthoRH(
-                    (float)orthographicCamera.Width,
-                    (float)(orthographicCamera.Width / aspectRatio),
-                    (float)orthographicCamera.NearPlaneDistance,
-                    (float)orthographicCamera.FarPlaneDistance);
+                return orthographicCamera.CreateProjectionMatrix(aspectRatio);
             }
             throw new HelixToolkitException("Unknown camera type.");
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Camera/PerspectiveCamera.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Camera/PerspectiveCamera.cs
@@ -70,10 +70,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <returns>Frustum as Vector4</returns>
         public FrustumCameraParams CreateFrustum(double aspectRatio)
         {
+            var fov = this.FieldOfView * Math.PI / 180;
+
             return new FrustumCameraParams()
             {
                 AspectRatio = (float)aspectRatio,
-                FOV = (float)this.FieldOfView,
+                FOV = (float)fov,
                 LookAtDir = this.Target.ToVector3(),
                 Position = this.Position.ToVector3(),
                 UpDir = this.UpDirection.ToVector3(),


### PR DESCRIPTION
This caused an issue with hit testing that should be fixed now.

Also changed the fov in CreateFrustum to radians in PerspectiveCamera.