### PR TITLE
Added ReuseVertexArrayBuffer property to reuse existing DefaultVertex array

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -651,13 +651,12 @@ namespace HelixToolkit.Wpf.SharpDX
                     var cycle = System.Threading.Interlocked.Decrement(ref pendingValidationCycles);
 
                     var t0 = renderTimer.Elapsed;
-                    // Update all renderables before rendering 
-                    // giving them the chance to invalidate the current render.
-                    renderRenderable.Update(t0);
-                                        
-                    // Safety check because of dispatcher deferred render call
-                    if (surfaceD3D != null)
+
+                    if (surfaceD3D != null && renderRenderable != null)
                     {
+                    // Update all renderables before rendering 
+                    // giving them the chance to invalidate the current render.                                                            
+                        renderRenderable.Update(t0);
                         if (cycle == 1)
                         {
                             Render();

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/RenderUtil.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/RenderUtil.cs
@@ -46,33 +46,28 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// 
+        /// Create buffer
         /// </summary>
-        public static Direct3D11.Buffer CreateBuffer<T>(this Direct3D11.Device device, BindFlags flags, int sizeofT, T[] range)
+        public static Direct3D11.Buffer CreateBuffer<T>(this Direct3D11.Device device, BindFlags flags, int sizeofT, T[] range, int length)
             where T : struct
         {
             return Direct3D11.Buffer.Create<T>(device, range, new BufferDescription()
             {
                 BindFlags = flags,
-                SizeInBytes = (int)range.Length * sizeofT,
+                SizeInBytes = length * sizeofT,
                 CpuAccessFlags = CpuAccessFlags.None,
                 OptionFlags = ResourceOptionFlags.None,
                 Usage = ResourceUsage.Default,
             });
-            ////sizeofT = sizeofT == 0 ? sizeofT = Marshal.SizeOf(typeof(T)) : sizeofT;
-            //using (var stream = new DataStream(range.Length * sizeofT, true, true))
-            //{                
-            //    stream.WriteRange(range);
-            //    stream.Position = 0;
-            //    return new Direct3D11.Buffer(device, stream, new BufferDescription
-            //    {
-            //        BindFlags = flags,
-            //        SizeInBytes = (int)stream.Length,
-            //        CpuAccessFlags = CpuAccessFlags.None,
-            //        OptionFlags = ResourceOptionFlags.None,
-            //        Usage = ResourceUsage.Default,
-            //    });
-            //}
+        }
+
+        /// <summary>
+        /// Create buffer
+        /// </summary>
+        public static Direct3D11.Buffer CreateBuffer<T>(this Direct3D11.Device device, BindFlags flags, int sizeofT, T[] range)
+            where T : struct
+        {
+            return CreateBuffer<T>(device, flags, sizeofT, range, range.Length);
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -16,6 +16,7 @@ namespace HelixToolkit.Wpf.SharpDX
         private ShaderResourceView billboardTextureView;
         private EffectShaderResourceVariable billboardTextureVariable;
         private BillboardType billboardType;
+        private BillboardVertex[] vertexArrayBuffer;
         #endregion
 
         #region Overridable Methods
@@ -259,22 +260,20 @@ namespace HelixToolkit.Wpf.SharpDX
 
             var position = billboardGeometry.Positions.Array;
             var vertexCount = billboardGeometry.Positions.Count;
-            var result = new BillboardVertex[vertexCount];
+            if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
+                vertexArrayBuffer = new BillboardVertex[vertexCount];
 
             var allOffsets = billboardGeometry.TextureOffsets;
 
             for (var i = 0; i < vertexCount; i++)
             {
                 var tc = billboardGeometry.TextureCoordinates[i];
-                result[i] = new BillboardVertex
-                {
-                    Position = new Vector4(position[i], 1.0f),
-                    Color = billboardGeometry.Colors[i],
-                    TexCoord = new Vector4(tc.X, tc.Y, allOffsets[i].X, allOffsets[i].Y)
-                };
+                vertexArrayBuffer[i].Position = new Vector4(position[i], 1.0f);
+                vertexArrayBuffer[i].Color = billboardGeometry.Colors[i];
+                vertexArrayBuffer[i].TexCoord = new Vector4(tc.X, tc.Y, allOffsets[i].X, allOffsets[i].Y);
             }
 
-            return result.ToArray();
+            return vertexArrayBuffer.ToArray();
         }
 
         #endregion

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -8,8 +8,32 @@ using System.Diagnostics;
 
 namespace HelixToolkit.Wpf.SharpDX
 {
-    public class BillboardTextModel3D : MeshGeometryModel3D
+    public class BillboardTextModel3D : MaterialGeometryModel3D
     {
+        public static readonly DependencyProperty ReuseVertexArrayBufferProperty = DependencyProperty.Register("ReuseVertexArrayBuffer", typeof(bool), typeof(BillboardTextModel3D),
+           new PropertyMetadata(false, (s, e) =>
+           {
+               if (!(bool)e.NewValue)
+               {
+                   (s as BillboardTextModel3D).vertexArrayBuffer = null;
+               }
+           }));
+
+        /// <summary>
+        /// Reuse previous vertext array buffer during CreateBuffer. Reduce excessive memory allocation during rapid geometry model changes. 
+        /// Example: Repeatly updates textures, or geometries with close number of vertices.
+        /// </summary>
+        public bool ReuseVertexArrayBuffer
+        {
+            set
+            {
+                SetValue(ReuseVertexArrayBufferProperty, value);
+            }
+            get
+            {
+                return (bool)GetValue(ReuseVertexArrayBufferProperty);
+            }
+        }
         #region Private Class Data Members
 
         private EffectVectorVariable vViewport;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -273,7 +273,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 vertexArrayBuffer[i].TexCoord = new Vector4(tc.X, tc.Y, allOffsets[i].X, allOffsets[i].Y);
             }
 
-            return vertexArrayBuffer.ToArray();
+            return vertexArrayBuffer;
         }
 
         #endregion

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -453,22 +453,16 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 for (var i = 0; i < vertexCount; i++)
                 {
-                    result[i] = new LinesVertex
-                    {
-                        Position = new Vector4(positions[i], 1f),
-                        Color = color * colors[i],
-                    };
+                    result[i].Position = new Vector4(positions[i], 1f);
+                    result[i].Color = color * colors[i];
                 }
             }
             else
             {
                 for (var i = 0; i < vertexCount; i++)
                 {
-                    result[i] = new LinesVertex
-                    {
-                        Position = new Vector4(positions[i], 1f),
-                        Color = color,
-                    };
+                    result[i].Position = new Vector4(positions[i], 1f);
+                    result[i].Color = color;
                 }
             }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -370,15 +370,12 @@ namespace HelixToolkit.Wpf.SharpDX
 
             for (var i = 0; i < vertexCount; i++)
             {
-                vertexArrayBuffer[i] = new DefaultVertex
-                {
-                    Position = new Vector4(positions[i], 1f),
-                    Color = colors != null ? colors[i] : Color4.White,
-                    TexCoord = textureCoordinates != null ? texScale * textureCoordinates[i] : Vector2.Zero,
-                    Normal = normals != null ? normals[i] : Vector3.Zero,
-                    Tangent = tangents != null ? tangents[i] : Vector3.Zero,
-                    BiTangent = bitangents != null ? bitangents[i] : Vector3.Zero,
-                };
+                vertexArrayBuffer[i].Position = new Vector4(positions[i], 1f);
+                vertexArrayBuffer[i].Color = colors != null ? colors[i] : Color4.White;
+                vertexArrayBuffer[i].TexCoord = textureCoordinates != null ? texScale * textureCoordinates[i] : Vector2.Zero;
+                vertexArrayBuffer[i].Normal = normals != null ? normals[i] : Vector3.Zero;
+                vertexArrayBuffer[i].Tangent = tangents != null ? tangents[i] : Vector3.Zero;
+                vertexArrayBuffer[i].BiTangent = bitangents != null ? bitangents[i] : Vector3.Zero;
             }
 
             return vertexArrayBuffer;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -82,6 +82,31 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        public static readonly DependencyProperty ReuseVertexArrayBufferProperty = DependencyProperty.Register("ReuseVertexArrayBuffer", typeof(bool), typeof(MeshGeometryModel3D),
+            new PropertyMetadata(false, (s, e) =>
+            {
+                if (!(bool)e.NewValue)
+                {
+                    (s as MeshGeometryModel3D).vertexArrayBuffer = null;
+                }
+            }));
+
+        /// <summary>
+        /// Reuse previous vertext array buffer during CreateBuffer. Reduce excessive memory allocation during rapid geometry model changes. 
+        /// Example: Repeatly updates textures, or geometries with close number of vertices.
+        /// </summary>
+        public bool ReuseVertexArrayBuffer
+        {
+            set
+            {
+                SetValue(ReuseVertexArrayBufferProperty, value);
+            }
+            get
+            {
+                return (bool)GetValue(ReuseVertexArrayBufferProperty);
+            }
+        }
+
         public override int VertexSizeInBytes
         {
             get
@@ -89,6 +114,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 return DefaultVertex.SizeInBytes;
             }
         }
+
+        private DefaultVertex[] vertexArrayBuffer = null;
 
         protected override void OnRasterStateChanged()
         {
@@ -157,7 +184,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 //throw new HelixToolkitException("Geometry not found!");                
 
                 /// --- init vertex buffer
-                this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, this.CreateDefaultVertexArray());
+                this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, this.CreateDefaultVertexArray(), geometry.Positions.Count);
 
                 /// --- init index buffer
                 this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array);
@@ -338,11 +365,12 @@ namespace HelixToolkit.Wpf.SharpDX
             var bitangents = geometry.BiTangents != null ? geometry.BiTangents.Array : null;
             var positions = geometry.Positions.Array;
             var vertexCount = geometry.Positions.Count;
-            var result = new DefaultVertex[vertexCount];
+            if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
+                vertexArrayBuffer = new DefaultVertex[vertexCount];
 
             for (var i = 0; i < vertexCount; i++)
             {
-                result[i] = new DefaultVertex
+                vertexArrayBuffer[i] = new DefaultVertex
                 {
                     Position = new Vector4(positions[i], 1f),
                     Color = colors != null ? colors[i] : Color4.White,
@@ -353,7 +381,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 };
             }
 
-            return result;
+            return vertexArrayBuffer;
         }
 
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -202,7 +202,7 @@ namespace HelixToolkit.Wpf.SharpDX
             vTessellationVariables.Set(new Vector4((float)TessellationFactor, 0, 0, 0));
 
             /// --- flush
-            //Device.ImmediateContext.Flush();
+            Device.ImmediateContext.Flush();
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -337,22 +337,16 @@
                 var colors = this.Geometry.Colors;
                 for (var i = 0; i < vertexCount; i++)
                 {
-                    result[i] = new Geometry3D.PointsVertex
-                    {
-                        Position = new Vector4(positions[i], 1f),
-                        Color = color * colors[i],
-                    };
+                    result[i].Position = new Vector4(positions[i], 1f);
+                    result[i].Color = color * colors[i];
                 }
             }
             else
             {
                 for (var i = 0; i < vertexCount; i++)
                 {
-                    result[i] = new Geometry3D.PointsVertex
-                    {
-                        Position = new Vector4(positions[i], 1f),
-                        Color = color,
-                    };
+                    result[i].Position = new Vector4(positions[i], 1f);
+                    result[i].Color = color;
                 }
             }
 


### PR DESCRIPTION
1. Added ReuseVertexArrayBuffer property to reuse existing DefaultVertex array and reduce memory allocation during realtime geometry/texture changes.
2. Remove unnecessary new struct object during struct array element operation.