### PR TITLE
Reverted a change that is causing stuttering in camera rotation animations

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -648,23 +648,18 @@ namespace HelixToolkit.Wpf.SharpDX
             {                
                 if (pendingValidationCycles > 0)
                 {
-                    var cycle = System.Threading.Interlocked.Decrement(ref pendingValidationCycles);
+                    System.Threading.Interlocked.Decrement(ref pendingValidationCycles);
 
                     var t0 = renderTimer.Elapsed;
 
                     if (surfaceD3D != null && renderRenderable != null)
                     {
-                    // Update all renderables before rendering 
-                    // giving them the chance to invalidate the current render.                                                            
+                        // Update all renderables before rendering 
+                        // giving them the chance to invalidate the current render.                                                            
                         renderRenderable.Update(t0);
-                        if (cycle == 1)
-                        {
-                            Render();
-                        }
-                        else
-                        {
-                            surfaceD3D.InvalidateD3DImage();
-                        }
+
+                        Render();
+                        surfaceD3D.InvalidateD3DImage();
                     }
 
                     lastRenderingDuration = renderTimer.Elapsed - t0;


### PR DESCRIPTION
In addidtion to animation stuttering I also experienced FPS drops in complex scenes. It is hardly recognizable in the Helix examples, but there are some stuttering during the stop animation when releasing the mouse button while rotating. I went from 40 to 60fps in one of my own projects after this. Looks like it was first implemented in commit d236ded08d6dcb7b13597e11f622687bc1e1078e.
