### PR TITLE
Added Dependency property to change RenderCycles #381 

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Controls/CanvasMock.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Controls/CanvasMock.cs
@@ -19,7 +19,12 @@ namespace HelixToolkit.Wpf.SharpDX.Tests.Controls
             EffectsManager = new DefaultEffectsManager(RenderTechniquesManager);
             Device = EffectsManager.Device;
         }
-
+        private int renderCycles = 1;
+        public int RenderCycles
+        {
+            set { renderCycles = value; }
+            get { return renderCycles; }
+        }
         public Device Device { get; private set; }
         public Color4 ClearColor { get; private set; }
         public bool IsShadowMapEnabled { get; private set; }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/IRenderHost.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/IRenderHost.cs
@@ -66,5 +66,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Indicates if DPFCanvas busy on rendering.
         /// </summary>
         bool IsBusy { get; }
+
+        int RenderCycles { set; get; }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -698,6 +698,20 @@ namespace HelixToolkit.Wpf.SharpDX
             "FixedRotationPointEnabled", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(false));
 
         /// <summary>
+        /// Set render cycles to 2 if experiences lagging during rotation. Benefits on some old laptop graphics cards.
+        /// Default value = <value>1</value>
+        /// </summary>
+        public static readonly DependencyProperty RenderCyclesProperty = DependencyProperty.Register("RenderCylces", typeof(int),
+            typeof(Viewport3DX), new PropertyMetadata(1, (d,e)=> 
+            {
+                var viewport = d as Viewport3DX;
+                if (viewport.RenderHost != null)
+                {
+                    viewport.RenderHost.RenderCycles = (int)e.NewValue;
+                }
+            }));
+
+        /// <summary>
         /// Background Color
         /// </summary>
         [TypeConverter(typeof(Color4Converter))]
@@ -2417,6 +2431,22 @@ namespace HelixToolkit.Wpf.SharpDX
             get
             {
                 return (bool)GetValue(FixedRotationPointEnabledProperty);
+            }
+        }
+
+        /// <summary>
+        /// Set render cycles to 2 if experiences lagging during rotation. Benefits on some old laptop graphics cards.
+        /// Default value = <value>1</value>
+        /// </summary>
+        public int RenderCylces
+        {
+            set
+            {
+                SetValue(RenderCyclesProperty, value);
+            }
+            get
+            {
+                return (int)GetValue(RenderCyclesProperty);
             }
         }
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -655,6 +655,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
             this.RenderHost = this.GetTemplateChild("PART_Canvas") as IRenderHost;
             this.RenderHost.MSAA = this.MSAA;
+            this.RenderHost.RenderCycles = this.RenderCylces;
             if (this.RenderHost != null)
             {
                 this.RenderHost.ExceptionOccurred += this.HandleRenderException;
@@ -927,7 +928,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         /// <param name="host">The host.</param>
         void IRenderer.Attach(IRenderHost host)
-        {
+        {            
             foreach (IRenderable e in this.Items)
             {
                 e.Attach(host);


### PR DESCRIPTION
Added Dependency property to change RenderCycles to accommodate different graphics card performances. Some old laptop graphics card needs to set render cycles to 2 (default is 1) to achieve smooth mouse rotation. #381 