### PR TITLE
Some updates, includes Remove duplicate functions in Viewport3DX #386 

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraController.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraController.cs
@@ -291,7 +291,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <remarks>
         /// Implemented as a list since we want to remove items at the bottom of the stack.
         /// </remarks>
-        private readonly List<CameraSetting> cameraHistory = new List<CameraSetting>();
+        private readonly LinkedList<CameraSetting> cameraHistory = new LinkedList<CameraSetting>();
 
         /// <summary>
         /// The rendering event listener.
@@ -1542,10 +1542,10 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public void PushCameraSetting()
         {
-            this.cameraHistory.Add(new CameraSetting(this.ActualCamera));
+            this.cameraHistory.AddLast(new CameraSetting(this.ActualCamera));
             if (this.cameraHistory.Count > 100)
             {
-                this.cameraHistory.RemoveAt(0);
+                this.cameraHistory.RemoveFirst();
             }
         }
 
@@ -1587,8 +1587,8 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             if (this.cameraHistory.Count > 0)
             {
-                var cs = this.cameraHistory[this.cameraHistory.Count - 1];
-                this.cameraHistory.RemoveAt(this.cameraHistory.Count - 1);
+                var cs = this.cameraHistory.Last.Value;
+                this.cameraHistory.RemoveLast();
                 cs.UpdateCamera(this.ActualCamera);
                 return true;
             }
@@ -2134,7 +2134,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="e">
         /// The <see cref="System.Windows.Input.KeyEventArgs"/> instance containing the event data.
         /// </param>
-        private void OnKeyDown(object sender, KeyEventArgs e)
+        public void OnKeyDown(object sender, KeyEventArgs e)
         {
             this.OnKeyDown(e);
             var shift = Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift);
@@ -2388,7 +2388,6 @@ namespace HelixToolkit.Wpf.SharpDX
         private void SubscribeEvents()
         {
             this.MouseWheel += this.OnMouseWheel;
-            this.KeyDown += this.OnKeyDown;
             RenderingEventManager.AddListener(this.renderingEventListener);
         }
 
@@ -2412,7 +2411,6 @@ namespace HelixToolkit.Wpf.SharpDX
         private void UnSubscribeEvents()
         {
             this.MouseWheel -= this.OnMouseWheel;
-            this.KeyDown -= this.OnKeyDown;
             RenderingEventManager.RemoveListener(this.renderingEventListener);
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/MouseHandlers/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/MouseHandlers/MouseGestureHandler.cs
@@ -202,7 +202,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 return;
             }
 
-            this.Viewport.PushCameraSetting();
+            this.Viewport.MouseMove -= this.OnMouseMove;
+            this.Viewport.MouseUp -= this.OnMouseUp;
             this.Viewport.MouseMove += this.OnMouseMove;
             this.Viewport.MouseUp += this.OnMouseUp;
             this.OnMouseDown(sender, null);

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -712,6 +712,12 @@ namespace HelixToolkit.Wpf.SharpDX
             }));
 
         /// <summary>
+        /// Enable mouse button hit test
+        /// </summary>
+        public static readonly DependencyProperty EnableMouseButtonHitTestProperty = DependencyProperty.Register(
+            "EnableMouseButtonHitTest", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true));
+
+        /// <summary>
         /// Background Color
         /// </summary>
         [TypeConverter(typeof(Color4Converter))]
@@ -2447,6 +2453,21 @@ namespace HelixToolkit.Wpf.SharpDX
             get
             {
                 return (int)GetValue(RenderCyclesProperty);
+            }
+        }
+
+        /// <summary>
+        /// Enable mouse button hit test
+        /// </summary>
+        public bool EnableMouseButtonHitTest
+        {
+            set
+            {
+                SetValue(EnableMouseButtonHitTestProperty, value);
+            }
+            get
+            {
+                return (bool)GetValue(EnableMouseButtonHitTestProperty);
             }
         }
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -1616,6 +1616,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         private void MouseDownHitTest(Point pt, InputEventArgs originalInputEventArgs = null)
         {
+            if (!EnableMouseButtonHitTest)
+            {
+                return;
+            }
+            mouseHitModels.Clear();
             var hits = this.FindHits(pt);
             if (hits.Count > 0)
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -144,11 +144,6 @@ namespace HelixToolkit.Wpf.SharpDX
         private Viewport3D coordinateView;
 
         /// <summary>
-        /// The frame counter.
-        /// </summary>
-        private int frameCounter;
-
-        /// <summary>
         /// The "control has been loaded before" flag.
         /// </summary>
         private bool hasBeenLoadedBefore;
@@ -162,11 +157,6 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The is subscribed to rendering event.
         /// </summary>
         private bool isSubscribedToRenderingEvent;
-
-        /// <summary>
-        ///   The last tick.
-        /// </summary>
-        private long lastTick;
 
 
         /// <summary>
@@ -1298,19 +1288,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         private void OnCompositionTargetRendering(object sender, RenderingEventArgs e)
         {
-            var ticks = e.RenderingTime.Ticks;
-            double time = 100e-9 * (ticks - this.lastTick);
-
-            this.lastTick = ticks;
-
-            this.frameCounter++;
             if (this.ShowFrameRate && this.fpsWatch.ElapsedMilliseconds > 500)
             {
-                this.FrameRate = (int)(this.frameCounter / (0.001 * this.fpsWatch.ElapsedMilliseconds));             
+                this.FrameRate = (int)this.FpsCounter.Value;
                 this.FrameRateText = this.FrameRate + " FPS";
-                this.frameCounter = 0;
-                this.fpsWatch.Reset();
-                this.fpsWatch.Start();
+                this.fpsWatch.Restart();
             }
 
             // update the info fields every 100 frames

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
@@ -287,9 +287,9 @@ namespace HelixToolkit.Wpf
         /// The camera history stack.
         /// </summary>
         /// <remarks>
-        /// Implemented as a list since we want to remove items at the bottom of the stack.
+        /// Implemented as a linkedlist since we want to remove items at the bottom of the stack.
         /// </remarks>
-        private readonly List<CameraSetting> cameraHistory = new List<CameraSetting>();
+        private readonly LinkedList<CameraSetting> cameraHistory = new LinkedList<CameraSetting>();
 
         /// <summary>
         /// The rendering event listener.
@@ -1540,10 +1540,10 @@ namespace HelixToolkit.Wpf
         /// </summary>
         public void PushCameraSetting()
         {
-            this.cameraHistory.Add(new CameraSetting(this.ActualCamera));
+            this.cameraHistory.AddLast(new CameraSetting(this.ActualCamera));
             if (this.cameraHistory.Count > 100)
             {
-                this.cameraHistory.RemoveAt(0);
+                this.cameraHistory.RemoveFirst();
             }
         }
 
@@ -1585,8 +1585,8 @@ namespace HelixToolkit.Wpf
         {
             if (this.cameraHistory.Count > 0)
             {
-                var cs = this.cameraHistory[this.cameraHistory.Count - 1];
-                this.cameraHistory.RemoveAt(this.cameraHistory.Count - 1);
+                var cs = this.cameraHistory.Last.Value;
+                this.cameraHistory.RemoveLast();
                 cs.UpdateCamera(this.ActualCamera);
                 return true;
             }


### PR DESCRIPTION
1. Remove duplicate functions in Viewport3DX. Use the same function in CameraController instead. #386 

2. Tunnel the keydown event from Viewport into camera controller to fix the camera controller not firing keydown event issue.

3. Improve FpsCounter.

4. Added EnableMouseButtonHitTest property