### PR TITLE
Fix memory leak and implement Geometry property changed for other 3D models.

### DIFF
--- a/Source/Examples/WPF.SharpDX/DynamicTextureDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/DynamicTextureDemo/MainViewModel.cs
@@ -82,6 +82,8 @@ namespace DynamicTextureDemo
         public bool DynamicVertices { set; get; } = false;
         public bool DynamicTriangles { set; get; } = false;
 
+        public bool ReverseInnerRotation { set; get; } = false;
+
         private Media3D.Vector3D camLookDir = new Media3D.Vector3D(-10, -10, -10);
         public Media3D.Vector3D CamLookDir
         {
@@ -192,7 +194,16 @@ namespace DynamicTextureDemo
                 }
                 texture[texture.Count-1] = Floor.TextureCoordinates[0];
                 Floor.TextureCoordinates = texture;
-                InnerFloor.TextureCoordinates = texture;
+                if (ReverseInnerRotation)
+                {
+                    var texture1 = new Vector2Collection(texture);
+                    texture1.Reverse();
+                    InnerFloor.TextureCoordinates = texture1;
+                }
+                else
+                {
+                    InnerFloor.TextureCoordinates = texture;
+                }
             }
             if(DynamicVertices)
             {
@@ -217,7 +228,7 @@ namespace DynamicTextureDemo
                 var indices = new IntCollection(initialIndicies);
                 if (isRemoving)
                 {
-                    removedIndex += 12;
+                    removedIndex += 3*8;
                     if(removedIndex >= initialIndicies.Count)
                     {
                         removedIndex = initialIndicies.Count;
@@ -226,7 +237,7 @@ namespace DynamicTextureDemo
                 }
                 else
                 {
-                    removedIndex -= 12;
+                    removedIndex -= 3*8;
                     if (removedIndex <= 0)
                     {
                         isRemoving = true;

--- a/Source/Examples/WPF.SharpDX/DynamicTextureDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/DynamicTextureDemo/MainWindow.xaml
@@ -53,6 +53,7 @@
             <CheckBox IsChecked="{Binding DynamicVertices}">Dynamic Vertex Positions</CheckBox>
             <CheckBox IsChecked="{Binding DynamicTriangles}">Dynamic Triangles</CheckBox>
             <CheckBox IsChecked="{Binding ShowWireframe}">Show Wireframe</CheckBox>
+            <CheckBox IsChecked="{Binding ReverseInnerRotation}">Reverse Inner Rotation</CheckBox>
         </StackPanel>
     </Grid>
 </Window>

--- a/Source/HelixToolkit.Wpf.SharpDX.sln
+++ b/Source/HelixToolkit.Wpf.SharpDX.sln
@@ -51,11 +51,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileLoadDemo", "Examples\WP
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PolygonTriangulationDemo", "Examples\WPF.SharpDX\PolygonTriangulationDemo\PolygonTriangulationDemo.csproj", "{AEE87C0E-AA98-4D82-9ED8-9EBEA107DDD6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicTextureDemo", "Examples\WPF.SharpDX\DynamicTextureDemo\DynamicTextureDemo.csproj", "{C7F68E1A-85B4-494A-BA4E-F4270FFF3852}"
+EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "HelixToolkit.Shared", "HelixToolkit.Shared\HelixToolkit.Shared.shproj", "{4EE18E80-7609-4FFF-BD4B-F02728EC0688}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "HelixToolkit.SharpDX.Shared", "HelixToolkit.SharpDX.Shared\HelixToolkit.SharpDX.Shared.shproj", "{1EAF532E-D750-497B-BB8F-EE85359C78A2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicTextureDemo", "Examples\WPF.SharpDX\DynamicTextureDemo\DynamicTextureDemo.csproj", "{C7F68E1A-85B4-494A-BA4E-F4270FFF3852}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -40,12 +40,21 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// Attaches the element to the specified host.
+        /// Override this function to set render technique during Attach Host.
+        /// </summary>
+        /// <param name="host"></param>
+        protected virtual void SetRenderTechnique(IRenderHost host)
+        {
+            renderTechnique = this.renderTechnique == null ? host.RenderTechnique : this.renderTechnique;
+        }
+        /// <summary>
+        /// Attaches the element to the specified host. 
+        /// To set different render technique instead of using technique from host, override <see cref="SetRenderTechnique"/>
         /// </summary>
         /// <param name="host">The host.</param>
         public virtual void Attach(IRenderHost host)
         {
-            renderTechnique = this.renderTechnique == null ? host.RenderTechnique : this.renderTechnique;
+            SetRenderTechnique(host);
             renderHost = host;
             effect = renderHost.EffectsManager.GetEffect(renderTechnique);
             InvalidateRender();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -240,20 +240,42 @@ namespace HelixToolkit.Wpf.SharpDX
             //count++;
         }
 
+        public override void Attach(IRenderHost host)
+        {
+            base.Attach(host);
+            AttachOnGeometryPropertyChanged();
+        }
+
+        public override void Detach()
+        {
+            DetachOnGeometryPropertyChanged();
+            base.Detach();
+        }
+
         private void GeometryModel3D_Loaded(object sender, RoutedEventArgs e)
         {
-            if (Geometry != null)
-            {
-                (Geometry as INotifyPropertyChanged).PropertyChanged -= OnGeometryPropertyChangedPrivate;
-                (Geometry as INotifyPropertyChanged).PropertyChanged += OnGeometryPropertyChangedPrivate;
-            }
+            AttachOnGeometryPropertyChanged();
         }
 
         private void GeometryModel3D_Unloaded(object sender, RoutedEventArgs e)
         {
+            DetachOnGeometryPropertyChanged();
+        }
+
+        private void AttachOnGeometryPropertyChanged()
+        {
             if (Geometry != null)
             {
-                (Geometry as INotifyPropertyChanged).PropertyChanged -= OnGeometryPropertyChangedPrivate;
+                Geometry.PropertyChanged -= OnGeometryPropertyChangedPrivate;
+                Geometry.PropertyChanged += OnGeometryPropertyChangedPrivate;
+            }
+        }
+
+        private void DetachOnGeometryPropertyChanged()
+        {
+            if (Geometry != null)
+            {
+                Geometry.PropertyChanged -= OnGeometryPropertyChangedPrivate;
             }
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -44,6 +44,25 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        public static readonly DependencyProperty ReuseVertexArrayBufferProperty = DependencyProperty.Register("ReuseVertexArrayBuffer", typeof(bool), typeof(GeometryModel3D),
+            new PropertyMetadata(false));
+
+        /// <summary>
+        /// Reuse previous vertext array buffer during CreateBuffer. Reduce excessive memory allocation during rapid geometry model changes. 
+        /// Example: Repeatly updates textures, or geometries with close number of vertices.
+        /// </summary>
+        public bool ReuseVertexArrayBuffer
+        {
+            set
+            {
+                SetValue(ReuseVertexArrayBufferProperty, value);
+            }
+            get
+            {
+                return (bool)GetValue(ReuseVertexArrayBufferProperty);
+            }
+        }
+
         public static readonly DependencyProperty GeometryProperty =
             DependencyProperty.Register("Geometry", typeof(Geometry3D), typeof(GeometryModel3D), new UIPropertyMetadata(GeometryChanged));
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -52,11 +52,12 @@ namespace HelixToolkit.Wpf.SharpDX
             var model = d as GeometryModel3D;
             if (e.OldValue != null)
             {
-                (e.OldValue as Geometry3D).PropertyChanged -= model.OnGeometryPropertyChanged;
+                (e.OldValue as INotifyPropertyChanged).PropertyChanged -= model.OnGeometryPropertyChangedPrivate;
             }
             if (e.NewValue != null)
             {
-                (e.NewValue as Geometry3D).PropertyChanged += model.OnGeometryPropertyChanged;
+                (e.NewValue as INotifyPropertyChanged).PropertyChanged -= model.OnGeometryPropertyChangedPrivate;
+                (e.NewValue as INotifyPropertyChanged).PropertyChanged += model.OnGeometryPropertyChangedPrivate;
             }
             model.OnGeometryChanged(e);
         }
@@ -83,6 +84,14 @@ namespace HelixToolkit.Wpf.SharpDX
                 var host = this.renderHost;
                 this.Detach();
                 this.Attach(host);
+            }
+        }
+
+        private void OnGeometryPropertyChangedPrivate(object sender, PropertyChangedEventArgs e)
+        {
+            if (this.IsAttached)
+            {
+                OnGeometryPropertyChanged(sender, e);
             }
         }
 
@@ -207,7 +216,26 @@ namespace HelixToolkit.Wpf.SharpDX
             this.MouseUp3D += OnMouse3DUp;
             this.MouseMove3D += OnMouse3DMove;
             this.IsThrowingShadow = true;
+            this.Unloaded += GeometryModel3D_Unloaded;
+            this.Loaded += GeometryModel3D_Loaded;
             //count++;
+        }
+
+        private void GeometryModel3D_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (Geometry != null)
+            {
+                (Geometry as INotifyPropertyChanged).PropertyChanged -= OnGeometryPropertyChangedPrivate;
+                (Geometry as INotifyPropertyChanged).PropertyChanged += OnGeometryPropertyChangedPrivate;
+            }
+        }
+
+        private void GeometryModel3D_Unloaded(object sender, RoutedEventArgs e)
+        {
+            if (Geometry != null)
+            {
+                (Geometry as INotifyPropertyChanged).PropertyChanged -= OnGeometryPropertyChangedPrivate;
+            }
         }
 
         ~GeometryModel3D()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -235,8 +235,6 @@ namespace HelixToolkit.Wpf.SharpDX
             this.MouseUp3D += OnMouse3DUp;
             this.MouseMove3D += OnMouse3DMove;
             this.IsThrowingShadow = true;
-            this.Unloaded += GeometryModel3D_Unloaded;
-            this.Loaded += GeometryModel3D_Loaded;
             //count++;
         }
 
@@ -250,16 +248,6 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             DetachOnGeometryPropertyChanged();
             base.Detach();
-        }
-
-        private void GeometryModel3D_Loaded(object sender, RoutedEventArgs e)
-        {
-            AttachOnGeometryPropertyChanged();
-        }
-
-        private void GeometryModel3D_Unloaded(object sender, RoutedEventArgs e)
-        {
-            DetachOnGeometryPropertyChanged();
         }
 
         private void AttachOnGeometryPropertyChanged()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -164,7 +164,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             // -- set geometry if given
             vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer,
-                VertexSizeInBytes, CreateBillboardVertexArray());
+                VertexSizeInBytes, CreateBillboardVertexArray(), geometry.Positions.Count);
             // --- material 
             // this.AttachMaterial();
             billboardTextureVariable = effect.GetVariableByName("billboardTexture").AsShaderResource();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -152,7 +152,7 @@ namespace HelixToolkit.Wpf.SharpDX
             OnRasterStateChanged();
 
             /// --- flush
-            Device.ImmediateContext.Flush();
+            //Device.ImmediateContext.Flush();
         }
 
         public override void Detach()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -10,30 +10,6 @@ namespace HelixToolkit.Wpf.SharpDX
 {
     public class BillboardTextModel3D : MaterialGeometryModel3D
     {
-        public static readonly DependencyProperty ReuseVertexArrayBufferProperty = DependencyProperty.Register("ReuseVertexArrayBuffer", typeof(bool), typeof(BillboardTextModel3D),
-           new PropertyMetadata(false, (s, e) =>
-           {
-               if (!(bool)e.NewValue)
-               {
-                   (s as BillboardTextModel3D).vertexArrayBuffer = null;
-               }
-           }));
-
-        /// <summary>
-        /// Reuse previous vertext array buffer during CreateBuffer. Reduce excessive memory allocation during rapid geometry model changes. 
-        /// Example: Repeatly updates textures, or geometries with close number of vertices.
-        /// </summary>
-        public bool ReuseVertexArrayBuffer
-        {
-            set
-            {
-                SetValue(ReuseVertexArrayBufferProperty, value);
-            }
-            get
-            {
-                return (bool)GetValue(ReuseVertexArrayBufferProperty);
-            }
-        }
         #region Private Class Data Members
 
         private EffectVectorVariable vViewport;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -115,12 +115,15 @@ namespace HelixToolkit.Wpf.SharpDX
             return h;
         }
 
+        protected override void SetRenderTechnique(IRenderHost host)
+        {
+            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.BillboardText];
+        }
+
         public override void Attach(IRenderHost host)
         {
             // --- attach
-            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.BillboardText];
-            effect = host.EffectsManager.GetEffect(renderTechnique);
-            renderHost = host;
+            base.Attach(host);
 
             // --- get variables
             vertexLayout = renderHost.EffectsManager.GetLayout(renderTechnique);

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
@@ -165,48 +165,53 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         private void ChildrenChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            switch (e.Action)
+            if (e.OldItems != null)
             {
-                case NotifyCollectionChangedAction.Remove:
-                case NotifyCollectionChangedAction.Replace:
-                    foreach (Model3D item in e.OldItems)
-                    {
-                        // todo: detach?
-                        // yes, always
-                        item.Detach();
-                        if (item.Parent == this)
+                switch (e.Action)
+                {
+                    case NotifyCollectionChangedAction.Reset:
+                    case NotifyCollectionChangedAction.Remove:
+                    case NotifyCollectionChangedAction.Replace:
+                        foreach (Model3D item in e.OldItems)
                         {
-                            this.RemoveLogicalChild(item);                            
-                        }
-                    }
-
-                    break;
-            }
-
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                case NotifyCollectionChangedAction.Replace:
-                    foreach (Model3D item in e.NewItems)
-                    {
-                        if (this.IsAttached)
-                        {
-                            // todo: attach?
-                            // yes, always  
-                            // where to get a refrence to renderHost?
-                            // store it as private memeber of the class?
-                            if (item.Parent == null)
+                            // todo: detach?
+                            // yes, always
+                            item.Detach();
+                            if (item.Parent == this)
                             {
-                                this.AddLogicalChild(item);
+                                this.RemoveLogicalChild(item);                            
                             }
-
-                            item.Attach(this.renderHost);
                         }
-                    }
-
-                    break;
+                        break;
+                }
             }
 
+            if (e.NewItems != null)
+            {
+                switch (e.Action)
+                {
+                    case NotifyCollectionChangedAction.Reset:
+                    case NotifyCollectionChangedAction.Add:
+                    case NotifyCollectionChangedAction.Replace:
+                        foreach (Model3D item in e.NewItems)
+                        {
+                            if (this.IsAttached)
+                            {
+                                // todo: attach?
+                                // yes, always  
+                                // where to get a refrence to renderHost?
+                                // store it as private memeber of the class?
+                                if (item.Parent == null)
+                                {
+                                    this.AddLogicalChild(item);
+                                }
+
+                                item.Attach(this.renderHost);
+                            }
+                        }
+                        break;
+                }
+            }
             UpdateBounds();
         }
         

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
@@ -81,12 +81,14 @@ namespace HelixToolkit.Wpf.SharpDX
                 obj.bHasCubeMap.Set((bool)e.NewValue);
         }
 
+        protected override void SetRenderTechnique(IRenderHost host)
+        {
+            base.SetRenderTechnique(host); this.renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.CubeMap];
+        }
         public override void Attach(IRenderHost host)
         {
             /// --- attach
-            this.renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.CubeMap];
             base.Attach(host);
-
             /// --- get variables               
             this.vertexLayout = renderHost.EffectsManager.GetLayout(this.renderTechnique);
             this.effectTechnique = effect.GetTechniqueByName(this.renderTechnique.Name);

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
@@ -138,7 +138,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
 
             /// --- flush
-            this.Device.ImmediateContext.Flush();
+            //this.Device.ImmediateContext.Flush();
         }
 
         public override void Detach()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
@@ -80,13 +80,18 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </exception>
         private void ItemsSourceChanged(DependencyPropertyChangedEventArgs e)
         {
-            mDictionary.Clear();
-            Children.Clear();
-
             if (e.OldValue is INotifyCollectionChanged)
             {
                 (e.OldValue as INotifyCollectionChanged).CollectionChanged -= ItemsModel3D_CollectionChanged;
             }
+
+            foreach(Model3D item in Children)
+            {
+                item.DataContext = null;
+            }
+            mDictionary.Clear();
+            Children.Clear();
+
             if (e.NewValue is INotifyCollectionChanged)
             {
                 (e.NewValue as INotifyCollectionChanged).CollectionChanged -= ItemsModel3D_CollectionChanged;
@@ -153,7 +158,7 @@ namespace HelixToolkit.Wpf.SharpDX
                             if (mDictionary.ContainsKey(item))
                             {
                                 var model = mDictionary[item];
-                                model.Detach();
+                                model.DataContext = null;
                                 this.Children.Remove(model);
                                 mDictionary.Remove(item);
                             }
@@ -165,7 +170,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     var array = this.Children.ToArray();
                     foreach (var item in array)
                     {
-                        item.Detach();
+                        item.DataContext = null;
                         this.Children.Remove(item);
                     }
                     mDictionary.Clear();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
@@ -140,25 +140,6 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override void Detach()
-        {
-            if (ItemsSource is INotifyCollectionChanged)
-            {
-                (ItemsSource as INotifyCollectionChanged).CollectionChanged -= ItemsModel3D_CollectionChanged;
-            }
-            base.Detach();
-        }
-
-        public override void Attach(IRenderHost host)
-        {
-            base.Attach(host);
-            if (ItemsSource is INotifyCollectionChanged)
-            {
-                (ItemsSource as INotifyCollectionChanged).CollectionChanged -= ItemsModel3D_CollectionChanged;
-                (ItemsSource as INotifyCollectionChanged).CollectionChanged += ItemsModel3D_CollectionChanged;
-            }
-        }
-
         protected void ItemsModel3D_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             switch (e.Action)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
@@ -89,6 +89,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             if (e.NewValue is INotifyCollectionChanged)
             {
+                (e.NewValue as INotifyCollectionChanged).CollectionChanged -= ItemsModel3D_CollectionChanged;
                 (e.NewValue as INotifyCollectionChanged).CollectionChanged += ItemsModel3D_CollectionChanged;
             }
 
@@ -136,6 +137,25 @@ namespace HelixToolkit.Wpf.SharpDX
                         throw new InvalidOperationException("Cannot create a Model3D from ItemTemplate.");
                     }
                 }
+            }
+        }
+
+        public override void Detach()
+        {
+            if (ItemsSource is INotifyCollectionChanged)
+            {
+                (ItemsSource as INotifyCollectionChanged).CollectionChanged -= ItemsModel3D_CollectionChanged;
+            }
+            base.Detach();
+        }
+
+        public override void Attach(IRenderHost host)
+        {
+            base.Attach(host);
+            if (ItemsSource is INotifyCollectionChanged)
+            {
+                (ItemsSource as INotifyCollectionChanged).CollectionChanged -= ItemsModel3D_CollectionChanged;
+                (ItemsSource as INotifyCollectionChanged).CollectionChanged += ItemsModel3D_CollectionChanged;
             }
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -338,7 +338,7 @@ namespace HelixToolkit.Wpf.SharpDX
            
 
             /// --- flush
-            Device.ImmediateContext.Flush();
+            //Device.ImmediateContext.Flush();
         }        
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -259,14 +259,17 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        protected override void SetRenderTechnique(IRenderHost host)
+        {
+            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Lines];
+        }
         /// <summary>
         /// 
         /// </summary>
         /// <param name="host"></param>
         public override void Attach(IRenderHost host)
         {
-            /// --- attach            
-            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Lines];
+            /// --- attach                        
             base.Attach(host);
 
             if (this.Geometry == null

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -214,6 +214,39 @@ namespace HelixToolkit.Wpf.SharpDX
             CreateVertexBuffer();
         }
 
+        protected override void OnGeometryPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnGeometryPropertyChanged(sender, e);
+            if (sender is LineGeometry3D)
+            {
+                if (e.PropertyName.Equals(nameof(LineGeometry3D.Positions)))
+                {
+                    OnUpdateVertexBuffer(CreateLinesVertexArray);
+                }
+                else if (e.PropertyName.Equals(nameof(LineGeometry3D.Colors)))
+                {
+                    OnUpdateVertexBuffer(CreateLinesVertexArray);
+                }
+                else if (e.PropertyName.Equals(nameof(LineGeometry3D.Indices)) || e.PropertyName.Equals(Geometry3D.TriangleBuffer))
+                {
+                    Disposer.RemoveAndDispose(ref this.indexBuffer);
+                    this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array);
+                    InvalidateRender();
+                }
+                else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
+                {
+                    OnUpdateVertexBuffer(CreateLinesVertexArray);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void OnUpdateVertexBuffer(Func<LinesVertex[]> updateFunction)
+        {
+            CreateVertexBuffer();
+            this.InvalidateRender();
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CreateVertexBuffer()
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -211,6 +211,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             if (this.IsAttached && Geometry!=null)
             {
+                Disposer.RemoveAndDispose(ref vertexBuffer);
                 /// --- set up buffers            
                 this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, this.CreateLinesVertexArray());
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -199,7 +199,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.OnRasterStateChanged();
 
             /// --- flush
-            this.Device.ImmediateContext.Flush();
+            //this.Device.ImmediateContext.Flush();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -147,7 +147,6 @@ namespace HelixToolkit.Wpf.SharpDX
         public override void Attach(IRenderHost host)
         {
             // --- attach
-            this.renderTechnique = host.RenderTechnique;
             base.Attach(host);
 
             if (this.Geometry == null

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -70,31 +70,6 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public static readonly DependencyProperty ReuseVertexArrayBufferProperty = DependencyProperty.Register("ReuseVertexArrayBuffer", typeof(bool), typeof(MeshGeometryModel3D),
-            new PropertyMetadata(false, (s, e) =>
-            {
-                if (!(bool)e.NewValue)
-                {
-                    (s as MeshGeometryModel3D).vertexArrayBuffer = null;
-                }
-            }));
-
-        /// <summary>
-        /// Reuse previous vertext array buffer during CreateBuffer. Reduce excessive memory allocation during rapid geometry model changes. 
-        /// Example: Repeatly updates textures, or geometries with close number of vertices.
-        /// </summary>
-        public bool ReuseVertexArrayBuffer
-        {
-            set
-            {
-                SetValue(ReuseVertexArrayBufferProperty, value);
-            }
-            get
-            {
-                return (bool)GetValue(ReuseVertexArrayBufferProperty);
-            }
-        }
-
         public override int VertexSizeInBytes
         {
             get
@@ -157,7 +132,8 @@ namespace HelixToolkit.Wpf.SharpDX
                     Disposer.RemoveAndDispose(ref this.indexBuffer);
                     this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array);
                     InvalidateRender();
-                }else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
+                }
+                else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
                 {
                     OnUpdateVertexBuffer(CreateDefaultVertexArray);
                 }
@@ -201,7 +177,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 //throw new HelixToolkitException("Geometry not found!");                
 
                 /// --- init vertex buffer
-                this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, this.CreateDefaultVertexArray(), geometry.Positions.Count);
+                CreateVertexBuffer(CreateDefaultVertexArray);
 
                 /// --- init index buffer
                 this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array);
@@ -229,15 +205,21 @@ namespace HelixToolkit.Wpf.SharpDX
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void OnUpdateVertexBuffer(Func<DefaultVertex[]> updateFunction)
         {
+            CreateVertexBuffer(updateFunction);
+            InvalidateRender();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void CreateVertexBuffer(Func<DefaultVertex[]> updateFunction)
+        {
             // --- get geometry
             var geometry = this.Geometry as MeshGeometry3D;
 
             // -- set geometry if given
-            if (geometry != null)
+            if (IsAttached && geometry != null && geometry.Positions!=null)
             {
                 Disposer.RemoveAndDispose(ref this.vertexBuffer);
                 this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, updateFunction(), geometry.Positions.Count);
-                this.InvalidateRender();
             }
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -117,14 +117,17 @@ namespace HelixToolkit.Wpf.SharpDX
 
         }
 
+        protected override void SetRenderTechnique(IRenderHost host)
+        {
+            renderTechnique = host.RenderTechnique;
+        }
         /// <summary>
         /// 
         /// </summary>
         /// <param name="host"></param>
         public override void Attach(IRenderHost host)
         {
-            /// --- attach
-            renderTechnique = host.RenderTechnique;
+            /// --- attach           
             base.Attach(host);
 
             if (this.Geometry == null

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -177,7 +177,7 @@ namespace HelixToolkit.Wpf.SharpDX
             vTessellationVariables.Set(new Vector4((float)TessellationFactor, 0, 0, 0));
 
             /// --- flush
-            Device.ImmediateContext.Flush();
+            //Device.ImmediateContext.Flush();
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -107,31 +107,6 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public static readonly DependencyProperty ReuseVertexArrayBufferProperty = DependencyProperty.Register("ReuseVertexArrayBuffer", typeof(bool), typeof(PatchGeometryModel3D),
-            new PropertyMetadata(false, (s, e) =>
-            {
-                if (!(bool)e.NewValue)
-                {
-                    (s as PatchGeometryModel3D).vertexArrayBuffer = null;
-                }
-            }));
-
-        /// <summary>
-        /// Reuse previous vertext array buffer during CreateBuffer. Reduce excessive memory allocation during rapid geometry model changes. 
-        /// Example: Repeatly updates textures, or geometries with close number of vertices.
-        /// </summary>
-        public bool ReuseVertexArrayBuffer
-        {
-            set
-            {
-                SetValue(ReuseVertexArrayBufferProperty, value);
-            }
-            get
-            {
-                return (bool)GetValue(ReuseVertexArrayBufferProperty);
-            }
-        }
-
         private DefaultVertex[] vertexArrayBuffer = null;
         /// <summary>
         /// 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -12,9 +12,11 @@
     using HelixToolkit.Wpf.SharpDX.Utilities;
 
     using Color = global::SharpDX.Color;
+    using System.Runtime.CompilerServices;
 
     public class PointGeometryModel3D : GeometryModel3D
     {
+        private Geometry3D.PointsVertex[] vertexArrayBuffer;
         protected InputLayout vertexLayout;
         protected Buffer vertexBuffer;
         protected EffectTechnique effectTechnique;
@@ -183,11 +185,19 @@
 
         private void OnColorChanged()
         {
-            if (this.IsAttached && Geometry != null && Geometry.Positions != null)
+            CreateVertexBuffer();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+
+        private void CreateVertexBuffer()
+        {
+            var geometry = Geometry as LineGeometry3D;
+            if (this.IsAttached && geometry != null && geometry.Positions != null)
             {
                 Disposer.RemoveAndDispose(ref vertexBuffer);
                 /// --- set up buffers            
-                this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, CreateVertexArray());
+                this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, CreateVertexArray(), geometry.Positions.Count);
             }
         }
 
@@ -214,15 +224,7 @@
 
             effectTransforms = new EffectTransformVariables(effect);
 
-            // --- get geometry
-            var geometry = Geometry as PointGeometry3D;
-
-            // -- set geometry if given
-            if (geometry != null)
-            {
-                /// --- set up buffers            
-                vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, CreateVertexArray());
-            }
+            CreateVertexBuffer();
 
             /// --- set up const variables
             vViewport = effect.GetVariableByName("vViewport").AsVector();
@@ -331,27 +333,28 @@
             var positions = this.Geometry.Positions.Array;
             var vertexCount = this.Geometry.Positions.Count;
             var color = this.Color;
-            var result = new Geometry3D.PointsVertex[vertexCount];
+            if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
+                vertexArrayBuffer = new Geometry3D.PointsVertex[vertexCount];
 
             if (this.Geometry.Colors != null && this.Geometry.Colors.Any())
             {
                 var colors = this.Geometry.Colors;
                 for (var i = 0; i < vertexCount; i++)
                 {
-                    result[i].Position = new Vector4(positions[i], 1f);
-                    result[i].Color = color * colors[i];
+                    vertexArrayBuffer[i].Position = new Vector4(positions[i], 1f);
+                    vertexArrayBuffer[i].Color = color * colors[i];
                 }
             }
             else
             {
                 for (var i = 0; i < vertexCount; i++)
                 {
-                    result[i].Position = new Vector4(positions[i], 1f);
-                    result[i].Color = color;
+                    vertexArrayBuffer[i].Position = new Vector4(positions[i], 1f);
+                    vertexArrayBuffer[i].Color = color;
                 }
             }
 
-            return result;
+            return vertexArrayBuffer;
         }
 
         public enum PointFigure

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -185,6 +185,7 @@
         {
             if (this.IsAttached && Geometry != null && Geometry.Positions != null)
             {
+                Disposer.RemoveAndDispose(ref vertexBuffer);
                 /// --- set up buffers            
                 this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, CreateVertexArray());
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -264,7 +264,7 @@
             OnRasterStateChanged();
 
             /// --- flush
-            Device.ImmediateContext.Flush();
+            //Device.ImmediateContext.Flush();
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -189,7 +189,6 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-
         private void CreateVertexBuffer()
         {
             var geometry = Geometry as LineGeometry3D;
@@ -199,6 +198,32 @@
                 /// --- set up buffers            
                 this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, CreateVertexArray(), geometry.Positions.Count);
             }
+        }
+
+        protected override void OnGeometryPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnGeometryPropertyChanged(sender, e);
+            if (sender is PointGeometry3D)
+            {
+                if (e.PropertyName.Equals(nameof(PointGeometry3D.Positions)))
+                {
+                    OnUpdateVertexBuffer(CreateVertexArray);
+                }
+                else if (e.PropertyName.Equals(nameof(PointGeometry3D.Colors)))
+                {
+                    OnUpdateVertexBuffer(CreateVertexArray);
+                }
+                else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
+                {
+                    OnUpdateVertexBuffer(CreateVertexArray);
+                }
+            }
+        }
+
+        private void OnUpdateVertexBuffer(System.Func<Geometry3D.PointsVertex[]> updateFunction)
+        {
+            CreateVertexBuffer();
+            this.InvalidateRender();
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -226,13 +226,16 @@
             this.InvalidateRender();
         }
 
+        protected override void SetRenderTechnique(IRenderHost host)
+        {
+            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Points];
+        }
         /// <summary>
         /// 
         /// </summary>
         /// <param name="host"></param>
         public override void Attach(IRenderHost host)
         {
-            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Points];
             base.Attach(host);
 
             if (this.Geometry == null

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/AmbientLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/AmbientLight3D.cs
@@ -30,7 +30,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.vLightAmbient.Set(this.Color);
 
             /// --- flush
-            this.Device.ImmediateContext.Flush();            
+            //this.Device.ImmediateContext.Flush();            
         }
 
         public override void Detach()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/DirectionalLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/DirectionalLight3D.cs
@@ -30,7 +30,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Directional;
 
             /// --- flush
-            this.Device.ImmediateContext.Flush();
+            //this.Device.ImmediateContext.Flush();
         }
 
         public override void Detach()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/PointLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/PointLight3D.cs
@@ -32,7 +32,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Point;
 
             /// --- flush
-            this.Device.ImmediateContext.Flush();
+            //this.Device.ImmediateContext.Flush();
         }
 
         public override void Detach()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
@@ -87,7 +87,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Spot;
 
             /// --- flush
-            this.Device.ImmediateContext.Flush();
+           // this.Device.ImmediateContext.Flush();
         }
 
         public override void Detach()


### PR DESCRIPTION
1. Fix memory leak in ItemsModel3D and CompositeModel3D
2. Implement Geometry property changed and reuse vertex array for other 3D models.
3. Move set render technique into virtual function(SetRenderTechnique) from Attach. So it is much easier to set different render technique for subclass of 3D classes.
4. Seems like Device.ImmediateContext.Flush() does not need to call in every attach. Comment them out.