### PR TITLE
Added overridable OnAttach, OnRender, and OnDetach to replace overriding Attach/Render/Detach public functions

### DIFF
--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
@@ -59,6 +59,7 @@ namespace CustomShaderDemo
         protected override void OnRasterStateChanged()
         {
             Disposer.RemoveAndDispose(ref rasterState);
+            if (!IsAttached) { return; }
             /// --- set up rasterizer states
             var rasterStateDesc = new RasterizerStateDescription()
             {

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
@@ -126,7 +126,7 @@ namespace CustomShaderDemo
             return true;
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref vertexBuffer);
             Disposer.RemoveAndDispose(ref indexBuffer);
@@ -142,7 +142,7 @@ namespace CustomShaderDemo
             effectTechnique = null;
             vertexLayout = null;
 
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override void OnRender(RenderContext renderContext)

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
@@ -58,31 +58,28 @@ namespace CustomShaderDemo
 
         protected override void OnRasterStateChanged()
         {
-            if (IsAttached)
+            Disposer.RemoveAndDispose(ref rasterState);
+            /// --- set up rasterizer states
+            var rasterStateDesc = new RasterizerStateDescription()
             {
-                Disposer.RemoveAndDispose(ref rasterState);
-                /// --- set up rasterizer states
-                var rasterStateDesc = new RasterizerStateDescription()
-                {
-                    FillMode = FillMode.Solid,
-                    CullMode = CullMode.Back,
-                    DepthBias = DepthBias,
-                    DepthBiasClamp = -1000,
-                    SlopeScaledDepthBias = +0,
-                    IsDepthClipEnabled = true,
-                    IsFrontCounterClockwise = true,
+                FillMode = FillMode.Solid,
+                CullMode = CullMode.Back,
+                DepthBias = DepthBias,
+                DepthBiasClamp = -1000,
+                SlopeScaledDepthBias = +0,
+                IsDepthClipEnabled = true,
+                IsFrontCounterClockwise = true,
 
-                    //IsMultisampleEnabled = true,
-                    //IsAntialiasedLineEnabled = true,                    
-                    //IsScissorEnabled = true,
-                };
-                try
-                {
-                    rasterState = new RasterizerState(Device, rasterStateDesc);
-                }
-                catch (Exception)
-                {
-                }
+                //IsMultisampleEnabled = true,
+                //IsAntialiasedLineEnabled = true,                    
+                //IsScissorEnabled = true,
+            };
+            try
+            {
+                rasterState = new RasterizerState(Device, rasterStateDesc);
+            }
+            catch (Exception)
+            {
             }
         }
 

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
@@ -86,14 +86,16 @@ namespace CustomShaderDemo
             }
         }
 
-        public override void Attach(IRenderHost host)
+        protected override RenderTechnique SetRenderTechnique(IRenderHost host)
         {
-            base.Attach(host);
-
-            renderTechnique = host.RenderTechniquesManager.RenderTechniques["RenderCustom"];
-
-            if (Geometry == null)
-                return;
+            return host.RenderTechniquesManager.RenderTechniques["RenderCustom"];
+        }
+        protected override bool OnAttach(IRenderHost host)
+        {
+            if (!base.OnAttach(host))
+            {
+                return false;
+            }
 
             vertexLayout = renderHost.EffectsManager.GetLayout(renderTechnique);
             effectTechnique = effect.GetTechniqueByName(renderTechnique.Name);
@@ -123,7 +125,8 @@ namespace CustomShaderDemo
 
             OnRasterStateChanged();
 
-            Device.ImmediateContext.Flush();
+           // Device.ImmediateContext.Flush();
+            return true;
         }
 
         public override void Detach()
@@ -145,24 +148,8 @@ namespace CustomShaderDemo
             base.Detach();
         }
 
-        public override void Render(RenderContext renderContext)
+        protected override void OnRender(RenderContext renderContext)
         {
-            /// --- check to render the model
-            {
-                if (!IsRendering)
-                    return;
-
-                if (Geometry == null)
-                    return;
-
-                if (Visibility != Visibility.Visible)
-                    return;
-
-                if (renderContext.IsShadowPass)
-                    if (!IsThrowingShadow)
-                        return;
-            }
-
             /// --- set constant paramerers             
             var worldMatrix = modelMatrix * renderContext.WorldMatrix;
             effectTransforms.mWorld.SetMatrix(ref worldMatrix);

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/SelectableLineGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/SelectableLineGeometryModel3D.cs
@@ -31,17 +31,21 @@ namespace CustomShaderDemo
                 return CustomLinesVertex.SizeInBytes;
             }
         }
-        public override void Attach(IRenderHost host)
-        {          
-            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Lines];
-            base.Attach(host);
 
-            if (Geometry == null)
-                return;
+        protected override RenderTechnique SetRenderTechnique(IRenderHost host)
+        {
+            return host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Lines];
+        }
+        protected override bool OnAttach(IRenderHost host)
+        {
+            if (!base.OnAttach(host))
+            {
+                return false;
+            }
 
             if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
                 renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
-                return;
+                return false;
 
             vertexLayout = renderHost.EffectsManager.GetLayout(renderTechnique);
             effectTechnique = effect.GetTechniqueByName(renderTechnique.Name);
@@ -71,7 +75,8 @@ namespace CustomShaderDemo
 
             OnRasterStateChanged();
 
-            Device.ImmediateContext.Flush();
+            //  Device.ImmediateContext.Flush();
+            return true;
         }
 
         private CustomLinesVertex[] CreateVertexArray()

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/SelectablePointGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/SelectablePointGeometryModel3D.cs
@@ -37,21 +37,24 @@ namespace CustomShaderDemo
             }
         }
 
+        protected override RenderTechnique SetRenderTechnique(IRenderHost host)
+        {
+            return host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Points];
+        }
         /// <summary>
         /// By overriding Attach, we can provide our own vertex array.
         /// </summary>
         /// <param name="host">An object whose type implements IRenderHost.</param>
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
-            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Points];
-            base.Attach(host);
-
-            if (Geometry == null)
-                return;
+            if (!base.OnAttach(host))
+            {
+                return false;
+            }
 
             if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
                 renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
-                return;
+                return false;
 
             vertexLayout = renderHost.EffectsManager.GetLayout(renderTechnique);
             effectTechnique = effect.GetTechniqueByName(renderTechnique.Name);
@@ -79,7 +82,8 @@ namespace CustomShaderDemo
             OnRasterStateChanged();
 
             /// --- flush
-            Device.ImmediateContext.Flush();
+            //  Device.ImmediateContext.Flush();
+            return true;
         }
 
         private CustomPointsVertex[] CreateVertexArray()

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/Shaders/BillboardText.fx
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/Shaders/BillboardText.fx
@@ -1,10 +1,8 @@
+
 Texture2D billboardTexture; // billboard text image
-
-DepthStencilState DSSOff
-{
-	DepthEnable = false;
-};
-
+Texture2D billboardAlphaTexture;
+bool   bHasAlphaTexture = false;
+bool   bHasTexture = false;
 //--------------------------------------------------------------------------------------
 // VERTEX AND PIXEL SHADER INPUTS
 //--------------------------------------------------------------------------------------
@@ -66,6 +64,35 @@ float4 PShaderBillboardText(PSInputBT input) : SV_Target
 	return intermediateColor * input.c;
 }
 
+float4 PShaderBillboardBackground(PSInputBT input) : SV_Target
+{
+	return input.c;
+}
+
+float4 PShaderBillboardImage(PSInputBT input) : SV_Target
+{
+	// Take the color off the texture using mask color
+	float4 pixelColor = 1;
+	if (bHasTexture)
+	{
+		pixelColor *= billboardTexture.Sample(PointSampler, input.t);
+	}
+
+	if (bHasAlphaTexture)
+	{
+		pixelColor *= billboardAlphaTexture.Sample(PointSampler, input.t);
+	}
+
+	if (input.c.w != 0 && length(pixelColor - input.c) < 0.00001)
+	{
+		return float4(0.0, 0.0, 0.0, 0.0);
+	}
+	else
+	{
+		return pixelColor;
+	}
+}
+
 //--------------------------------------------------------------------------------------
 // Techniques
 //-------------------------------------------------------------------------------------
@@ -75,7 +102,7 @@ technique11 RenderBillboard
 	pass P0
 	{
 		//SetDepthStencilState( DSSDepthLess, 0 );
-		SetDepthStencilState(DSSOff, 0);
+		SetDepthStencilState(DSSDepthLessEqual, 0);
 		SetRasterizerState(RSSolid);
 		SetBlendState(BSBlending, float4(0.0f, 0.0f, 0.0f, 0.0f), 0xFFFFFFFF);
 		SetVertexShader(CompileShader(vs_4_0, VShaderBillboardText()));
@@ -83,5 +110,29 @@ technique11 RenderBillboard
 		SetDomainShader(NULL);
 		SetGeometryShader(NULL);
 		SetPixelShader(CompileShader(ps_4_0, PShaderBillboardText()));
+	}
+	pass P1
+	{
+		//SetDepthStencilState( DSSDepthLess, 0 );
+		SetDepthStencilState(DSSDepthLessEqual, 0);
+		SetRasterizerState(RSSolid);
+		SetBlendState(BSBlending, float4(0.0f, 0.0f, 0.0f, 0.0f), 0xFFFFFFFF);
+		SetVertexShader(CompileShader(vs_4_0, VShaderBillboardText()));
+		SetHullShader(NULL);
+		SetDomainShader(NULL);
+		SetGeometryShader(NULL);
+		SetPixelShader(CompileShader(ps_4_0, PShaderBillboardBackground()));
+	}
+	pass P2
+	{
+		//SetDepthStencilState( DSSDepthLess, 0 );
+		SetDepthStencilState(DSSDepthLessEqual, 0);
+		SetRasterizerState(RSSolid);
+		SetBlendState(BSBlending, float4(0.0f, 0.0f, 0.0f, 0.0f), 0xFFFFFFFF);
+		SetVertexShader(CompileShader(vs_4_0, VShaderBillboardText()));
+		SetHullShader(NULL);
+		SetDomainShader(NULL);
+		SetGeometryShader(NULL);
+		SetPixelShader(CompileShader(ps_4_0, PShaderBillboardImage()));
 	}
 }

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/Shaders/Material.fx
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/Shaders/Material.fx
@@ -16,6 +16,7 @@ float4 vMaterialSpecular = 0.0f;   //Ks := surface material's specular coefficie
 float4 vMaterialReflect = 0.0f;   //Kr := surface material's reflectivity coefficient
 float  sMaterialShininess = 1.0f;	  //Ps := surface material's shininess
 
+bool   bHasAlphaMap = false;
 bool   bHasDiffuseMap = false;
 bool   bHasNormalMap = false;
 bool   bHasDisplacementMap = false;
@@ -38,7 +39,7 @@ float4 vLightAmbient = float4(0.2f, 0.2f, 0.2f, 1.0f);
 //--------------------------------------------------------------------------------------
 // TEXTURES
 //--------------------------------------------------------------------------------------
-
+Texture2D   texAlphaMap;
 Texture2D	texDiffuseMap;
 Texture2D	texNormalMap;
 Texture2D	texDisplacementMap;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -79,13 +79,15 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="host"></param>       
         /// <returns>Return true if attached</returns>
         protected abstract bool OnAttach(IRenderHost host);
-
+        /// <summary>
+        /// Detaches the element from the host. Override <see cref="OnDetach"/>
+        /// </summary>
         public void Detach()
         {
             OnDetach();
         }
         /// <summary>
-        /// Detaches the element from the host.
+        /// Used to override Detach
         /// </summary>
         protected virtual void OnDetach()
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -61,8 +61,9 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// Attaches the element to the specified host. To overide Attach, please override <see cref="OnAttach(IRenderHost)"/> function.
-        /// To set different render technique instead of using technique from host, override <see cref="SetRenderTechnique"/>
+        /// <para>Attaches the element to the specified host. To overide Attach, please override <see cref="OnAttach(IRenderHost)"/> function.</para>
+        /// <para>To set different render technique instead of using technique from host, override <see cref="SetRenderTechnique"/></para>
+        /// <para>Attach Flow: <see cref="SetRenderTechnique(IRenderHost)"/> -> Set RenderHost -> Get Effect -> <see cref="OnAttach(IRenderHost)"/> -> <see cref="OnAttached"/> -> <see cref="InvalidateRender"/></para>
         /// </summary>
         /// <param name="host">The host.</param>
         public void Attach(IRenderHost host)
@@ -78,6 +79,9 @@ namespace HelixToolkit.Wpf.SharpDX
             InvalidateRender();
         }
 
+        /// <summary>
+        /// Called after <see cref="OnAttach(IRenderHost)"/>
+        /// </summary>
         protected virtual void OnAttached()
         {
 
@@ -125,15 +129,18 @@ namespace HelixToolkit.Wpf.SharpDX
         public virtual void Update(TimeSpan timeSpan) { }
 
         /// <summary>
-        /// Determine if this can be rendered. Default returns (IsAttached && IsRendering && Visibility == Visibility.Visible).
+        /// <para>Determine if this can be rendered.</para>
+        /// <para>Default returns <see cref="IsAttached"/> &amp;&amp; <see cref="IsRendering"/> &amp;&amp; <see cref="Visibility"/> == <see cref="Visibility.Visible"/></para>
         /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
         protected virtual bool CanRender(RenderContext context)
         {
             return IsAttached && IsRendering && Visibility == Visibility.Visible;
         }
         /// <summary>
-        /// Renders the element in the specified context. To override Render, please override <see cref="OnRender"/>
-        /// Render uses <see cref="CanRender"/>  to call OnRender or not. 
+        /// <para>Renders the element in the specified context. To override Render, please override <see cref="OnRender"/></para>
+        /// <para>Uses <see cref="CanRender"/>  to call OnRender or not. </para>
         /// </summary>
         /// <param name="context">The context.</param>
         public void Render(RenderContext context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -59,6 +59,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             return this.renderTechnique == null ? host.RenderTechnique : this.renderTechnique;           
         }
+
         /// <summary>
         /// Attaches the element to the specified host. To overide Attach, please override <see cref="OnAttach(IRenderHost)"/> function.
         /// To set different render technique instead of using technique from host, override <see cref="SetRenderTechnique"/>
@@ -70,9 +71,17 @@ namespace HelixToolkit.Wpf.SharpDX
             renderHost = host;
             effect = renderHost.EffectsManager.GetEffect(renderTechnique);
             IsAttached = OnAttach(host);
+            if (IsAttached)
+            {
+                OnAttached();
+            }
             InvalidateRender();
         }
 
+        protected virtual void OnAttached()
+        {
+
+        }
         /// <summary>
         /// To override Attach routine, please override this.
         /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -25,6 +25,9 @@ namespace HelixToolkit.Wpf.SharpDX
         protected IRenderHost renderHost;
 
         private bool isAttached = false;
+        /// <summary>
+        /// If this has been attached onto renderhost. 
+        /// </summary>
         public bool IsAttached
         {
             get
@@ -107,9 +110,8 @@ namespace HelixToolkit.Wpf.SharpDX
         public virtual void Update(TimeSpan timeSpan) { }
 
         /// <summary>
-        /// Determine if this can be rendered. 
+        /// Determine if this can be rendered. Default returns (IsAttached && IsRendering && Visibility == Visibility.Visible).
         /// </summary>
-        /// <returns>Default is return IsAttached && IsRendering && Visibility == Visibility.Visible.</returns>
         protected virtual bool CanRender(RenderContext context)
         {
             return IsAttached && IsRendering && Visibility == Visibility.Visible;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -80,10 +80,14 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <returns>Return true if attached</returns>
         protected abstract bool OnAttach(IRenderHost host);
 
+        public void Detach()
+        {
+            OnDetach();
+        }
         /// <summary>
         /// Detaches the element from the host.
         /// </summary>
-        public virtual void Detach()
+        protected virtual void OnDetach()
         {
             IsAttached = false;
             renderTechnique = null;            

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -274,11 +274,11 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             DetachOnGeometryPropertyChanged();
             Disposer.RemoveAndDispose(ref rasterState);
-            base.Detach();
+            base.OnDetach();
         }
 
         private void AttachOnGeometryPropertyChanged()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -329,7 +329,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         ~GeometryModel3D()
         {
-            this.Detach();
+            
         }
 
         //static ulong count = 0;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -159,7 +159,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// Make sure to check if RenderHost == null
+        /// Make sure to check if <see cref="Element3D.IsAttached"/> == true
         /// </summary>
         protected virtual void OnRasterStateChanged() { }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -277,6 +277,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public override void Detach()
         {
             DetachOnGeometryPropertyChanged();
+            Disposer.RemoveAndDispose(ref rasterState);
             base.Detach();
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -241,7 +241,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// Check geometry validity.
+        /// <para>Check geometry validity.</para>
         /// Return false if (this.Geometry == null || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0 || this.Geometry.Indices == null || this.Geometry.Indices.Count == 0)
         /// </summary>
         /// <returns>
@@ -306,6 +306,12 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        /// <summary>
+        /// <para>base.CanRender(context) &amp;&amp; <see cref="CheckGeometry"/> </para>
+        /// <para>If RenderContext IsShadowPass=true, return false if <see cref="IsThrowingShadow"/> = false</para>
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
         protected override bool CanRender(RenderContext context)
         {
             if (base.CanRender(context) && CheckGeometry())
@@ -323,10 +329,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         ~GeometryModel3D()
         {
-            //this.Dispose();
-            //this.MouseDown3D -= OnMouse3DDown;
-            //this.MouseUp3D -= OnMouse3DUp;
-            //this.MouseMove3D -= OnMouse3DMove;
+            this.Detach();
         }
 
         //static ulong count = 0;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -239,9 +239,9 @@ namespace HelixToolkit.Wpf.SharpDX
 
         /// <summary>
         /// Check geometry validity.
+        /// Return false if (this.Geometry == null || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0 || this.Geometry.Indices == null || this.Geometry.Indices.Count == 0)
         /// </summary>
         /// <returns>
-        /// Return false if (this.Geometry == null || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0 || this.Geometry.Indices == null || this.Geometry.Indices.Count == 0)
         /// </returns>
         protected virtual bool CheckGeometry()
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -158,6 +158,9 @@ namespace HelixToolkit.Wpf.SharpDX
             ((GeometryModel3D)d).OnRasterStateChanged();
         }
 
+        /// <summary>
+        /// Make sure to check if RenderHost == null
+        /// </summary>
         protected virtual void OnRasterStateChanged() { }
 
         public static readonly RoutedEvent MouseDown3DEvent =
@@ -257,10 +260,9 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// Overriding OnAttach, use <see cref="CheckGeometry" to check if it can be attached./>
+        /// Overriding OnAttach, use <see cref="CheckGeometry"/> to check if it can be attached.
         /// </summary>
         /// <param name="host"></param>
-        /// <returns></returns>
         protected override bool OnAttach(IRenderHost host)
         {
             if (CheckGeometry())
@@ -272,6 +274,12 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 return false;
             }
+        }
+
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            OnRasterStateChanged();
         }
 
         protected override void OnDetach()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -27,9 +27,8 @@ namespace HelixToolkit.Wpf.SharpDX
             this.Children = new Element3DCollection();
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
-            base.Attach(host);
             foreach (var c in this.Children)
             {
                 if (c.Parent == null)
@@ -39,6 +38,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 c.Attach(host);
             }
+            return true;
         }
 
         public override void Detach()
@@ -54,9 +54,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override void Render(RenderContext context)
+        protected override void OnRender(RenderContext context)
         {
-            base.Render(context);
             foreach (var c in this.Children)
             {
                 c.Render(context);

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -41,9 +41,9 @@ namespace HelixToolkit.Wpf.SharpDX
             return true;
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
-            base.Detach();
+            base.OnDetach();
             foreach (var c in this.Children)
             {
                 c.Detach();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
@@ -370,7 +370,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// 
         /// </summary>
-        public override void Detach()
+        protected override void OnDetach()
         {                    
             Disposer.RemoveAndDispose(ref this.vertexBuffer);
             Disposer.RemoveAndDispose(ref this.indexBuffer);
@@ -388,7 +388,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.effectTechnique = null;
             this.vertexLayout = null;
 
-            base.Detach();
+            base.OnDetach();
         }
 
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -119,15 +119,22 @@ namespace HelixToolkit.Wpf.SharpDX
             return h;
         }
 
-        protected override void SetRenderTechnique(IRenderHost host)
+        protected override RenderTechnique SetRenderTechnique(IRenderHost host)
         {
-            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.BillboardText];
+            return host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.BillboardText];
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool CheckGeometry()
+        {
+            return Geometry is IBillboardText;
+        }
+        protected override bool OnAttach(IRenderHost host)
         {
             // --- attach
-            base.Attach(host);
+            if (!base.OnAttach(host))
+            {
+                return false;
+            }
 
             // --- get variables
             vertexLayout = renderHost.EffectsManager.GetLayout(renderTechnique);
@@ -142,7 +149,7 @@ namespace HelixToolkit.Wpf.SharpDX
             var geometry = Geometry as IBillboardText;
             if (geometry == null)
             {
-                return;
+                throw new System.Exception("Geometry must implement IBillboardText");
             }
             // -- set geometry if given
             vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer,
@@ -168,6 +175,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
             /// --- flush
             //Device.ImmediateContext.Flush();
+            return true;
         }
 
         public override void Detach()
@@ -182,27 +190,13 @@ namespace HelixToolkit.Wpf.SharpDX
             base.Detach();
         }
 
-        public override void Render(RenderContext renderContext)
+        protected override void OnRender(RenderContext renderContext)
         {
             /// --- check to render the model
             var geometry = Geometry as IBillboardText;
             if (geometry == null)
             {
-                return;
-            }
-            {
-                if (!IsRendering)
-                    return;
-
-                if (Geometry == null)
-                    return;
-
-                if (Visibility != System.Windows.Visibility.Visible)
-                    return;
-
-                if (renderContext.IsShadowPass)
-                    if (!IsThrowingShadow)
-                        return;
+                throw new System.Exception("Geometry must implement IBillboardText");
             }
 
             if (renderContext.Camera is ProjectionCamera)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -178,7 +178,7 @@ namespace HelixToolkit.Wpf.SharpDX
             return true;
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref vViewport);
             Disposer.RemoveAndDispose(ref billboardTextureVariable);
@@ -187,7 +187,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Disposer.RemoveAndDispose(ref billboardAlphaTextureView);
             Disposer.RemoveAndDispose(ref bHasBillboardAlphaTexture);
             Disposer.RemoveAndDispose(ref bHasBillboardTexture);
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override void OnRender(RenderContext renderContext)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
@@ -52,7 +52,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 if (model.Parent == null)
                 {
-                    this.AddLogicalChild(model);                    
+                    this.AddLogicalChild(model);
                 }
 
                 model.Attach(host);
@@ -70,7 +70,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 model.Detach();
                 if (model.Parent == this)
                 {
-                    this.RemoveLogicalChild(model);                    
+                    this.RemoveLogicalChild(model);
                 }
             }
             base.OnDetach();
@@ -82,7 +82,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public override bool HitTest(Ray ray, ref List<HitTestResult> hits)
         {
             bool hit = base.HitTest(ray, ref hits);
-            
+
             foreach (var c in this.Children)
             {
                 var hc = c as IHitable;
@@ -108,7 +108,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
             }
             return hit;
-        }        
+        }
 
         /// <summary>
         /// 
@@ -118,6 +118,10 @@ namespace HelixToolkit.Wpf.SharpDX
             this.Detach();
         }
 
+        protected override bool CanRender(RenderContext context)
+        {
+            return IsRendering && Visibility == System.Windows.Visibility.Visible;
+        }
         /// <summary>
         /// Renders the specified context.
         /// </summary>
@@ -126,12 +130,6 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         protected override void OnRender(RenderContext context)
         {
-            if (!this.IsRendering)
-                return;
-
-            if (this.Visibility != System.Windows.Visibility.Visible)
-                return;
-
             // you mean like this?
             foreach (var c in this.Children)
             {
@@ -177,7 +175,7 @@ namespace HelixToolkit.Wpf.SharpDX
                             item.Detach();
                             if (item.Parent == this)
                             {
-                                this.RemoveLogicalChild(item);                            
+                                this.RemoveLogicalChild(item);
                             }
                         }
                         break;
@@ -212,7 +210,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             UpdateBounds();
         }
-        
+
         /// <summary>
         /// a Model3D does not have bounds, 
         /// if you want to have a model with bounds, use GeometryModel3D instead:
@@ -229,7 +227,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     bb = BoundingBox.Merge(bb, model.Bounds);
                 }
             }
-            this.Bounds = bb;            
+            this.Bounds = bb;
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
@@ -63,7 +63,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         ///     Detaches this instance.
         /// </summary>
-        public override void Detach()
+        protected override void OnDetach()
         {
             foreach (var model in this.Children)
             {
@@ -73,7 +73,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     this.RemoveLogicalChild(model);                    
                 }
             }
-            base.Detach();
+            base.OnDetach();
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
@@ -46,9 +46,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="host">
         /// The host.
         /// </param>
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
-            base.Attach(host);
             foreach (var model in this.Children)
             {
                 if (model.Parent == null)
@@ -58,6 +57,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 model.Attach(host);
             }
+            return true;
         }
 
         /// <summary>
@@ -124,15 +124,13 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="context">
         /// The context.
         /// </param>
-        public override void Render(RenderContext context)
+        protected override void OnRender(RenderContext context)
         {
             if (!this.IsRendering)
                 return;
 
             if (this.Visibility != System.Windows.Visibility.Visible)
                 return;
-
-            base.Render(context);
 
             // you mean like this?
             foreach (var c in this.Children)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
@@ -81,14 +81,12 @@ namespace HelixToolkit.Wpf.SharpDX
                 obj.bHasCubeMap.Set((bool)e.NewValue);
         }
 
-        protected override void SetRenderTechnique(IRenderHost host)
+        protected override RenderTechnique SetRenderTechnique(IRenderHost host)
         {
-            base.SetRenderTechnique(host); this.renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.CubeMap];
+            return host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.CubeMap];
         }
-        public override void Attach(IRenderHost host)
-        {
-            /// --- attach
-            base.Attach(host);
+        protected override bool OnAttach(IRenderHost host)
+        {           
             /// --- get variables               
             this.vertexLayout = renderHost.EffectsManager.GetLayout(this.renderTechnique);
             this.effectTechnique = effect.GetTechniqueByName(this.renderTechnique.Name);
@@ -137,10 +135,14 @@ namespace HelixToolkit.Wpf.SharpDX
                     IsDepthEnabled = true,
                 };
                 this.depthStencilState = new DepthStencilState(this.Device, depthStencilDesc);
+                /// --- flush
+                //this.Device.ImmediateContext.Flush();
+                return true;
             }
-
-            /// --- flush
-            //this.Device.ImmediateContext.Flush();
+            else
+            {
+                return false;
+            }
         }
 
         public override void Detach()
@@ -167,10 +169,8 @@ namespace HelixToolkit.Wpf.SharpDX
             base.Detach();
         }
 
-        public override void Render(RenderContext context)
+        protected override void OnRender(RenderContext context)
         {
-            if (!this.IsRendering) return;
-
             /// --- set context
             this.Device.ImmediateContext.InputAssembler.InputLayout = this.vertexLayout;
             this.Device.ImmediateContext.InputAssembler.PrimitiveTopology = Direct3D.PrimitiveTopology.TriangleList;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
@@ -145,7 +145,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             if (!this.IsAttached)
                 return;
@@ -166,7 +166,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Disposer.RemoveAndDispose(ref this.depthStencilState);
             Disposer.RemoveAndDispose(ref this.effectTransforms);
 
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override void OnRender(RenderContext context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
@@ -56,27 +56,9 @@ namespace HelixToolkit.Wpf.SharpDX
             this.modelMatrix = trafo.ToMatrix();
         }
 
-        public override void Attach(IRenderHost host)
+        protected override void OnRender(RenderContext renderContext)
         {
-            this.renderTechnique = host.RenderTechnique;
-            base.Attach(host);
-        }
-
-        public override void Render(RenderContext renderContext)
-        {
-            /// --- check to render the model
-            {
-                if (!this.IsRendering)
-                    return;
-
-                if (this.Visibility != System.Windows.Visibility.Visible)
-                    return;
-
-                //if (renderContext.IsShadowPass)
-                //    if (!this.IsThrowingShadow)
-                //        return;
-            }
-
+            base.OnRender(renderContext);
             foreach (var c in this.Children)
             {
                 var model = c as ITransformable;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Items3DControl.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Items3DControl.cs
@@ -263,8 +263,15 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         ///     Detaches this instance.
         /// </summary>
-        public virtual void Detach()
+        public void Detach()
         {
+            OnDetach();
+        }
+        /// <summary>
+        /// Override Detach
+        /// </summary>
+        protected virtual void OnDetach()
+        {           
             foreach (var item in this.children)
             {
                 var model = item as Element3D;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Light3DCollection.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Light3DCollection.cs
@@ -30,8 +30,9 @@ namespace HelixToolkit.Wpf.SharpDX
             return true;
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
+            base.OnDetach();
             foreach (var c in this.Children)
             {
                 c.Detach();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Light3DCollection.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Light3DCollection.cs
@@ -15,7 +15,7 @@ namespace HelixToolkit.Wpf.SharpDX
             private set; get;
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
             Light3DSceneShared = host.Light3DSceneShared;
             foreach (var c in this.Children)
@@ -27,6 +27,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 c.Attach(host);
             }
+            return true;
         }
 
         public override void Detach()
@@ -41,7 +42,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override void Render(RenderContext context)
+        protected override void OnRender(RenderContext context)
         {
             foreach (var c in this.Children)
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -184,6 +184,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override void OnRasterStateChanged()
         {
             Disposer.RemoveAndDispose(ref this.rasterState);
+            if (!IsAttached) { return; }
             /// --- set up rasterizer states
             var rasterStateDesc = new RasterizerStateDescription()
             {
@@ -322,23 +323,6 @@ namespace HelixToolkit.Wpf.SharpDX
             //    var texDiffuseMap = effect.GetVariableByName("texDiffuseMap").AsShaderResource();
             //    texDiffuseMap.SetResource(texDiffuseMapView);                
             //}
-
-            /// --- create raster state
-            OnRasterStateChanged();
-
-
-
-            //this.rasterState = new RasterizerState(this.device, rasterStateDesc);
-
-            /// --- set up depth stencil state
-            //var depthStencilDesc = new DepthStencilStateDescription()
-            //{
-            //    DepthComparison = Comparison.Less,
-            //    DepthWriteMask = global::SharpDX.Direct3D11.DepthWriteMask.All,
-            //    IsDepthEnabled = true,
-            //};
-            //this.depthStencilState = new DepthStencilState(this.device, depthStencilDesc);   
-
 
             /// --- flush
             //Device.ImmediateContext.Flush();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -348,7 +348,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// 
         /// </summary>
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref this.vertexBuffer);
             Disposer.RemoveAndDispose(ref this.indexBuffer);
@@ -364,7 +364,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.effectTechnique = null;
             this.vertexLayout = null;
 
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override bool CanRender(RenderContext context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -83,6 +83,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override void OnRasterStateChanged()
         {
             Disposer.RemoveAndDispose(ref this.rasterState);
+            if (!IsAttached) { return; }
             /// --- set up rasterizer states
             var rasterStateDesc = new RasterizerStateDescription()
             {
@@ -188,9 +189,6 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 this.instanceBuffer = Buffer.Create(this.Device, this.instanceArray, new BufferDescription(Matrix.SizeInBytes * this.instanceArray.Length, ResourceUsage.Dynamic, BindFlags.VertexBuffer, CpuAccessFlags.Write, ResourceOptionFlags.None, 0));
             }
-
-            /// --- set rasterstate
-            this.OnRasterStateChanged();
 
             /// --- flush
             //this.Device.ImmediateContext.Flush();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -225,7 +225,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// 
         /// </summary>
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref this.vertexBuffer);
             Disposer.RemoveAndDispose(ref this.indexBuffer);
@@ -242,7 +242,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.effectTechnique = null;
             this.vertexLayout = null;
 
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override void OnRender(RenderContext renderContext)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -258,11 +258,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// 
         /// </summary>
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref vTessellationVariables);
             Disposer.RemoveAndDispose(ref shaderPass);
-            base.Detach();
+            base.OnDetach();
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -170,6 +170,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override void OnRasterStateChanged()
         {
             Disposer.RemoveAndDispose(ref this.rasterState);
+            if (!IsAttached) { return; }
             /// --- set up rasterizer states
             var rasterStateDesc = new RasterizerStateDescription()
             {
@@ -249,7 +250,6 @@ namespace HelixToolkit.Wpf.SharpDX
             /// --- init tessellation vars
             vTessellationVariables = effect.GetVariableByName("vTessellation").AsVector();
             vTessellationVariables.Set(new Vector4((float)TessellationFactor, 0, 0, 0));
-            OnRasterStateChanged();
             /// --- flush
             //Device.ImmediateContext.Flush();
             return true;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -169,51 +169,42 @@ namespace HelixToolkit.Wpf.SharpDX
 
         protected override void OnRasterStateChanged()
         {
-            if (this.IsAttached)
+            Disposer.RemoveAndDispose(ref this.rasterState);
+            /// --- set up rasterizer states
+            var rasterStateDesc = new RasterizerStateDescription()
             {
-                Disposer.RemoveAndDispose(ref this.rasterState);
-                /// --- set up rasterizer states
-                var rasterStateDesc = new RasterizerStateDescription()
-                {
-                    FillMode = FillMode,
-                    CullMode = CullMode,
-                    DepthBias = -5,
-                    DepthBiasClamp = -10,
-                    SlopeScaledDepthBias = +0,
-                    IsDepthClipEnabled = IsDepthClipEnabled,
-                    IsFrontCounterClockwise = FrontCounterClockwise,
+                FillMode = FillMode,
+                CullMode = CullMode,
+                DepthBias = -5,
+                DepthBiasClamp = -10,
+                SlopeScaledDepthBias = +0,
+                IsDepthClipEnabled = IsDepthClipEnabled,
+                IsFrontCounterClockwise = FrontCounterClockwise,
 
-                    IsMultisampleEnabled = IsMultisampleEnabled,
-                    //IsAntialiasedLineEnabled = true,
-                    //IsScissorEnabled = true,
-                };
-                try
-                {
-                    this.rasterState = new RasterizerState(this.Device, rasterStateDesc);
-                }
-                catch (System.Exception)
-                {
-                }
+                IsMultisampleEnabled = IsMultisampleEnabled,
+                //IsAntialiasedLineEnabled = true,
+                //IsScissorEnabled = true,
+            };
+            try
+            {
+                this.rasterState = new RasterizerState(this.Device, rasterStateDesc);
+            }
+            catch (System.Exception)
+            {
             }
         }
 
-        protected override void SetRenderTechnique(IRenderHost host)
-        {
-            renderTechnique = host.RenderTechnique;
-        }
         /// <summary>
         /// 
         /// </summary>
         /// <param name="host"></param>
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
             /// --- attach           
-            base.Attach(host);
-
-            if (this.Geometry == null
-                || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0
-                || this.Geometry.Indices == null || this.Geometry.Indices.Count == 0)
-                return;
+            if (!base.OnAttach(host))
+            {
+                return false;
+            }
             // --- get variables
             vertexLayout = renderHost.EffectsManager.GetLayout(renderTechnique);
             effectTechnique = effect.GetTechniqueByName(renderTechnique.Name);
@@ -261,6 +252,7 @@ namespace HelixToolkit.Wpf.SharpDX
             OnRasterStateChanged();
             /// --- flush
             //Device.ImmediateContext.Flush();
+            return true;
         }
 
         /// <summary>
@@ -283,25 +275,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// 
         /// </summary>
-        public override void Render(RenderContext renderContext)
+        protected override void OnRender(RenderContext renderContext)
         {
-            /// --- check if to render the model
-            {
-                if (!IsRendering)
-                    return;
-
-                if (Geometry == null || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0
-                    || this.Geometry.Indices == null || this.Geometry.Indices.Count == 0)
-                    return;
-
-                if (Visibility != System.Windows.Visibility.Visible)
-                    return;
-
-                if (renderContext.IsShadowPass)
-                    if (!IsThrowingShadow)
-                        return;
-            }
-
             /// --- set model transform paramerers                         
             effectTransforms.mWorld.SetMatrix(ref modelMatrix);
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -160,26 +160,23 @@
 
         protected override void OnRasterStateChanged()
         {
-            if (this.IsAttached)
+            Disposer.RemoveAndDispose(ref this.rasterState);
+            /// --- set up rasterizer states
+            var rasterStateDesc = new RasterizerStateDescription()
             {
-                Disposer.RemoveAndDispose(ref this.rasterState);
-                /// --- set up rasterizer states
-                var rasterStateDesc = new RasterizerStateDescription()
-                {
-                    FillMode = FillMode.Solid,
-                    CullMode = CullMode.None,
-                    DepthBias = DepthBias,
-                    DepthBiasClamp = -1000,
-                    SlopeScaledDepthBias = -2,
-                    IsDepthClipEnabled = true,
-                    IsFrontCounterClockwise = false,
-                    IsMultisampleEnabled = true,
-                };
+                FillMode = FillMode.Solid,
+                CullMode = CullMode.None,
+                DepthBias = DepthBias,
+                DepthBiasClamp = -1000,
+                SlopeScaledDepthBias = -2,
+                IsDepthClipEnabled = true,
+                IsFrontCounterClockwise = false,
+                IsMultisampleEnabled = true,
+            };
 
-                try { this.rasterState = new RasterizerState(this.Device, rasterStateDesc); }
-                catch (System.Exception)
-                {
-                }
+            try { this.rasterState = new RasterizerState(this.Device, rasterStateDesc); }
+            catch (System.Exception)
+            {
             }
         }
 
@@ -192,11 +189,15 @@
         private void CreateVertexBuffer()
         {
             var geometry = Geometry as LineGeometry3D;
-            if (this.IsAttached && geometry != null && geometry.Positions != null)
+            if (geometry != null && geometry.Positions != null)
             {
                 Disposer.RemoveAndDispose(ref vertexBuffer);
                 /// --- set up buffers            
-                this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, CreateVertexArray(), geometry.Positions.Count);
+                var data = CreateVertexArray();
+                if (data != null)
+                {
+                    this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, VertexSizeInBytes, data, geometry.Positions.Count);
+                }
             }
         }
 
@@ -226,25 +227,24 @@
             this.InvalidateRender();
         }
 
-        protected override void SetRenderTechnique(IRenderHost host)
+        protected override RenderTechnique SetRenderTechnique(IRenderHost host)
         {
-            renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Points];
+            return host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Points];
         }
         /// <summary>
         /// 
         /// </summary>
         /// <param name="host"></param>
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
-            base.Attach(host);
-
-            if (this.Geometry == null
-                || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0)
-            { return; }
+            if (!base.OnAttach(host))
+            {
+                return false;
+            }
 
             if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
                 renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
-                return;
+                return false;
 
             // --- get device
             vertexLayout = renderHost.EffectsManager.GetLayout(renderTechnique);
@@ -268,6 +268,7 @@
 
             /// --- flush
             //Device.ImmediateContext.Flush();
+            return true;
         }
 
         /// <summary>
@@ -286,30 +287,25 @@
             base.Detach();
         }
 
+        protected override bool CanRender(RenderContext context)
+        {
+            if(base.CanRender(context))
+            {
+                if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
+                    renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
+                    return false;
+                else return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
         /// <summary>
         /// 
         /// </summary>
-        public override void Render(RenderContext renderContext)
-        {
-            /// --- do not render, if not enabled
-            if (!this.IsRendering)
-                return;
-
-            if (this.Geometry == null
-                || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0)
-            { return; }
-
-            if (this.Visibility != System.Windows.Visibility.Visible)
-                return;
-
-            if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
-                renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
-                return;
-
-            if (renderContext.IsShadowPass)
-                if (!this.IsThrowingShadow)
-                    return;
-
+        protected override void OnRender(RenderContext renderContext)
+        {       
             /// --- since these values are changed only per window resize, we set them only once here
             if (renderContext.Camera is ProjectionCamera)
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -274,7 +274,7 @@
         /// <summary>
         /// 
         /// </summary>
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref this.vertexBuffer);
             Disposer.RemoveAndDispose(ref this.vViewport);
@@ -284,7 +284,7 @@
             this.effectTechnique = null;
             this.vertexLayout = null;
 
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override bool CanRender(RenderContext context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -161,6 +161,7 @@
         protected override void OnRasterStateChanged()
         {
             Disposer.RemoveAndDispose(ref this.rasterState);
+            if (!IsAttached) { return; }
             /// --- set up rasterizer states
             var rasterStateDesc = new RasterizerStateDescription()
             {
@@ -262,9 +263,6 @@
             /// --- set effect per object const vars
             var pointParams = new Vector4((float)Size.Width, (float)Size.Height, (float)Figure, (float)FigureRatio);
             vPointParams.Set(pointParams);
-
-            /// --- create raster state
-            OnRasterStateChanged();
 
             /// --- flush
             //Device.ImmediateContext.Flush();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UICompositeManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UICompositeManipulator3D.cs
@@ -210,7 +210,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         /// <param name="context"></param>
-        public override void Render(RenderContext context)
+        protected override void OnRender(RenderContext context)
         {
             foreach (var c in this.Children)
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIRotateManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIRotateManipulator3D.cs
@@ -130,10 +130,10 @@ namespace HelixToolkit.Wpf.SharpDX
             this.Geometry = mb.ToMeshGeometry3D();
         }
 
-        public override void Render(RenderContext renderContext)
+        protected override void OnRender(RenderContext renderContext)
         {
+            base.OnRender(renderContext);
             var position = this.totalModelMatrix.TranslationVector;
-            base.Render(renderContext);
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/AmbientLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/AmbientLight3D.cs
@@ -39,14 +39,14 @@ namespace HelixToolkit.Wpf.SharpDX
             }      
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             if (this.vLightAmbient != null)
             {
                 this.vLightAmbient.Set(new global::SharpDX.Color4(0, 0, 0, 0));
                 Disposer.RemoveAndDispose(ref this.vLightAmbient);
             }
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override void OnColorChanged(DependencyPropertyChangedEventArgs e)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/AmbientLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/AmbientLight3D.cs
@@ -20,17 +20,23 @@ namespace HelixToolkit.Wpf.SharpDX
             this.LightType = LightType.Ambient;
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
             /// --- attach
-            base.Attach(host);
+            if (base.OnAttach(host))
+            {
+                /// --- light constant params              
+                this.vLightAmbient = this.effect.GetVariableByName("vLightAmbient").AsVector();
+                this.vLightAmbient.Set(this.Color);
 
-            /// --- light constant params              
-            this.vLightAmbient = this.effect.GetVariableByName("vLightAmbient").AsVector();
-            this.vLightAmbient.Set(this.Color);
-
-            /// --- flush
-            //this.Device.ImmediateContext.Flush();            
+                /// --- flush
+                //this.Device.ImmediateContext.Flush();     
+                return true;
+            }
+            else
+            {
+                return false;
+            }      
         }
 
         public override void Detach()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/DirectionalLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/DirectionalLight3D.cs
@@ -40,12 +40,12 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref this.vLightDir);
             Disposer.RemoveAndDispose(ref this.vLightColor);
             Disposer.RemoveAndDispose(ref this.iLightType);
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override bool CanRender(RenderContext context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/DirectionalLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/DirectionalLight3D.cs
@@ -16,21 +16,28 @@ namespace HelixToolkit.Wpf.SharpDX
             this.LightType = LightType.Directional;
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
             /// --- attach
-            base.Attach(host);
+            if (base.OnAttach(host))
+            {
 
-            /// --- light constant params            
-            this.vLightDir = this.effect.GetVariableByName("vLightDir").AsVector();
-            this.vLightColor = this.effect.GetVariableByName("vLightColor").AsVector();
-            this.iLightType = this.effect.GetVariableByName("iLightType").AsScalar();
+                /// --- light constant params            
+                this.vLightDir = this.effect.GetVariableByName("vLightDir").AsVector();
+                this.vLightColor = this.effect.GetVariableByName("vLightColor").AsVector();
+                this.iLightType = this.effect.GetVariableByName("iLightType").AsScalar();
 
-            /// --- Set light type
-            Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Directional;
+                /// --- Set light type
+                Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Directional;
 
-            /// --- flush
-            //this.Device.ImmediateContext.Flush();
+                /// --- flush
+                //this.Device.ImmediateContext.Flush();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public override void Detach()
@@ -41,15 +48,22 @@ namespace HelixToolkit.Wpf.SharpDX
             base.Detach();
         }
 
-        public override void Render(RenderContext context)
+        protected override bool CanRender(RenderContext context)
         {
             var manager = renderHost.RenderTechniquesManager;
-            if (renderHost.RenderTechnique == manager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
-                renderHost.RenderTechnique == manager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
+            if (base.CanRender(context))
             {
-                return;
+                if (renderHost.RenderTechnique == manager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
+                    renderHost.RenderTechnique == manager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
+                {
+                    return false;
+                }
+                return true;
             }
-
+            return false;
+        }
+        protected override void OnRender(RenderContext context)
+        {
             if (this.IsRendering)
             {
                 /// --- set lighting parameters

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
@@ -147,10 +147,8 @@ namespace HelixToolkit.Wpf.SharpDX
             Spot = 3,
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
-            this.renderTechnique = host.RenderTechnique;
-            base.Attach(host);
             Light3DSceneShared = host.Light3DSceneShared;
             if (this.LightType != LightType.Ambient)
             {
@@ -163,6 +161,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     this.mLightProj = this.effect.GetVariableByName("mLightProj").AsMatrix();
                 }
             }
+            return true;
         }
 
         public override void Detach()
@@ -173,6 +172,11 @@ namespace HelixToolkit.Wpf.SharpDX
                 Light3DSceneShared.LightColors[lightIndex] = new Color4(0, 0, 0, 0);
             }
             base.Detach();
+        }
+
+        protected override void OnRender(RenderContext context)
+        {
+            
         }
 
         public override void Dispose()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
@@ -164,14 +164,14 @@ namespace HelixToolkit.Wpf.SharpDX
             return true;
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             if (this.LightType != LightType.Ambient && Light3DSceneShared != null)
             {
                 // "turn-off" the light
                 Light3DSceneShared.LightColors[lightIndex] = new Color4(0, 0, 0, 0);
             }
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override void OnRender(RenderContext context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/PointLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/PointLight3D.cs
@@ -41,13 +41,13 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref this.vLightPos);
             Disposer.RemoveAndDispose(ref this.vLightColor);
             Disposer.RemoveAndDispose(ref this.vLightAtt);
             Disposer.RemoveAndDispose(ref this.iLightType);
-            base.Detach();
+            base.OnDetach();
         }
         protected override bool CanRender(RenderContext context)
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/PointLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/PointLight3D.cs
@@ -17,22 +17,28 @@ namespace HelixToolkit.Wpf.SharpDX
             this.LightType = LightType.Point;
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
             /// --- attach
-            base.Attach(host);
+            if (base.OnAttach(host))
+            {
+                /// --- light constant params            
+                this.vLightPos = this.effect.GetVariableByName("vLightPos").AsVector();
+                this.vLightColor = this.effect.GetVariableByName("vLightColor").AsVector();
+                this.vLightAtt = this.effect.GetVariableByName("vLightAtt").AsVector();
+                this.iLightType = this.effect.GetVariableByName("iLightType").AsScalar();
 
-            /// --- light constant params            
-            this.vLightPos = this.effect.GetVariableByName("vLightPos").AsVector();
-            this.vLightColor = this.effect.GetVariableByName("vLightColor").AsVector();
-            this.vLightAtt = this.effect.GetVariableByName("vLightAtt").AsVector();
-            this.iLightType = this.effect.GetVariableByName("iLightType").AsScalar();
+                /// --- Set light type
+                Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Point;
 
-            /// --- Set light type
-            Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Point;
-
-            /// --- flush
-            //this.Device.ImmediateContext.Flush();
+                /// --- flush
+                //this.Device.ImmediateContext.Flush();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public override void Detach()
@@ -43,15 +49,22 @@ namespace HelixToolkit.Wpf.SharpDX
             Disposer.RemoveAndDispose(ref this.iLightType);
             base.Detach();
         }
-
-        public override void Render(RenderContext context)
+        protected override bool CanRender(RenderContext context)
         {
-            if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
-                renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
+            var manager = renderHost.RenderTechniquesManager;
+            if (base.CanRender(context))
             {
-                return;
+                if (renderHost.RenderTechnique == manager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
+                    renderHost.RenderTechnique == manager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
+                {
+                    return false;
+                }
+                return true;
             }
-
+            return false;
+        }
+        protected override void OnRender(RenderContext context)
+        {
             if (this.IsRendering)
             {
                 /// --- turn-on the light            

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ShadowMap3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ShadowMap3D.cs
@@ -83,17 +83,19 @@ namespace HelixToolkit.Wpf.SharpDX
             set { this.SetValue(IntensityProperty, value); }
         }
 
-        public override void Attach(IRenderHost host)
+        protected override RenderTechnique SetRenderTechnique(IRenderHost host)
+        {
+            return host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Colors];
+        }
+
+        protected override bool OnAttach(IRenderHost host)
         {
             this.width = (int)(Resolution.X + 0.5f); //faktor* oneK;
             this.height = (int)(this.Resolution.Y + 0.5f); // faktor* oneK;
 
-            base.renderTechnique = host.RenderTechniquesManager.RenderTechniques[DefaultRenderTechniqueNames.Colors];
-            base.Attach(host);
-
             if (!host.IsShadowMapEnabled)
             {
-                return;
+                return false;
             }
 
             // gen shadow map
@@ -166,6 +168,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.vShadowMapInfoVariable = effect.GetVariableByName("vShadowMapInfo").AsVector();
             this.vShadowMapSizeVariable = effect.GetVariableByName("vShadowMapSize").AsVector();
             this.shadowPassContext = new RenderContext(host, this.effect);
+            return true;
         }
 
         public override void Detach()
@@ -186,13 +189,20 @@ namespace HelixToolkit.Wpf.SharpDX
             base.Detach();
         }
 
-        public override void Render(RenderContext context)
+        protected override bool CanRender(RenderContext context)
         {
-            if (!this.renderHost.IsShadowMapEnabled)
-            {                
-                return;
+            if (base.CanRender(context))
+            {
+                if (!this.renderHost.IsShadowMapEnabled)
+                {
+                    return false;
+                }
+                return true;
             }
-
+            return false;
+        }
+        protected override void OnRender(RenderContext context)
+        {
             /// --- set rasterizes state here with proper shadow-bias, as depth-bias and slope-bias in the rasterizer            
             this.Device.ImmediateContext.Rasterizer.SetViewport(0, 0, width, height, 0.0f, 1.0f);
             this.Device.ImmediateContext.OutputMerger.SetTargets(depthViewSM);            

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ShadowMap3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ShadowMap3D.cs
@@ -171,7 +171,7 @@ namespace HelixToolkit.Wpf.SharpDX
             return true;
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref this.depthBufferSM);
             Disposer.RemoveAndDispose(ref this.depthViewSM);
@@ -186,7 +186,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
             Disposer.RemoveAndDispose(ref this.shadowPassContext);
             //this.renderHost.IsShadowMapEnabled = false;            
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override bool CanRender(RenderContext context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
@@ -96,7 +96,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
             Disposer.RemoveAndDispose(ref this.vLightPos);
             Disposer.RemoveAndDispose(ref this.vLightDir);
@@ -104,7 +104,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Disposer.RemoveAndDispose(ref this.vLightColor);
             Disposer.RemoveAndDispose(ref this.vLightAtt);
             Disposer.RemoveAndDispose(ref this.iLightType);
-            base.Detach();
+            base.OnDetach();
         }
 
         protected override bool CanRender(RenderContext context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
@@ -70,24 +70,30 @@ namespace HelixToolkit.Wpf.SharpDX
             this.LightType = LightType.Spot;
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
             /// --- attach
-            base.Attach(host);
+            if (base.OnAttach(host))
+            {
+                /// --- light constant params            
+                this.vLightPos = this.effect.GetVariableByName("vLightPos").AsVector();
+                this.vLightDir = this.effect.GetVariableByName("vLightDir").AsVector();
+                this.vLightSpot = this.effect.GetVariableByName("vLightSpot").AsVector();
+                this.vLightColor = this.effect.GetVariableByName("vLightColor").AsVector();
+                this.vLightAtt = this.effect.GetVariableByName("vLightAtt").AsVector();
+                this.iLightType = this.effect.GetVariableByName("iLightType").AsScalar();
 
-            /// --- light constant params            
-            this.vLightPos = this.effect.GetVariableByName("vLightPos").AsVector();
-            this.vLightDir = this.effect.GetVariableByName("vLightDir").AsVector();
-            this.vLightSpot = this.effect.GetVariableByName("vLightSpot").AsVector();
-            this.vLightColor = this.effect.GetVariableByName("vLightColor").AsVector();
-            this.vLightAtt = this.effect.GetVariableByName("vLightAtt").AsVector();
-            this.iLightType = this.effect.GetVariableByName("iLightType").AsScalar();
+                /// --- Set light type
+                Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Spot;
 
-            /// --- Set light type
-            Light3DSceneShared.LightTypes[lightIndex] = (int)Light3D.Type.Spot;
-
-            /// --- flush
-           // this.Device.ImmediateContext.Flush();
+                /// --- flush
+                // this.Device.ImmediateContext.Flush();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         public override void Detach()
@@ -101,14 +107,22 @@ namespace HelixToolkit.Wpf.SharpDX
             base.Detach();
         }
 
-        public override void Render(RenderContext context)
+        protected override bool CanRender(RenderContext context)
         {
-            if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
-                renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
+            if (base.CanRender(context))
             {
-                return;
+                if (renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred) ||
+                    renderHost.RenderTechnique == renderHost.RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer))
+                {
+                    return false;
+                }
+                return true;
             }
+            return false;
+        }
 
+        protected override void OnRender(RenderContext context)
+        {
             if (this.IsRendering)
             {
                 /// --- turn-on the light            

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ThreePointLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ThreePointLight3D.cs
@@ -30,8 +30,9 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
             return true;
         }
 
-        public override void Detach()
+        protected override void OnDetach()
         {
+            base.OnDetach();
             foreach (var c in this.Children)
             {
                 c.Detach();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ThreePointLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ThreePointLight3D.cs
@@ -20,13 +20,14 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
             private set; get;
         }
 
-        public override void Attach(IRenderHost host)
+        protected override bool OnAttach(IRenderHost host)
         {
             Light3DSceneShared = host.Light3DSceneShared;
             foreach (var c in this.Children)
             {
                 c.Attach(host);
             }
+            return true;
         }
 
         public override void Detach()
@@ -37,7 +38,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
             }
         }
 
-        public override void Render(RenderContext context)
+        protected override void OnRender(RenderContext context)
         {
             foreach (var c in this.Children)
             {


### PR DESCRIPTION
Added overridable OnAttach, OnRender, and OnDetach to replace overriding Attach/Render/Detach public functions to simplify function overriding, improve code consistency. 

Reduce duplicate code to check can attach condition and can render conditions during function overriding.

Example fix on CustomShader.