### PR TITLE
Support complex template objects as DataTemplate3D with bindings on any level.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ ando23 <andreas@herzig-net.de>
 Benglin (Ben) Goh <benglin@outlook.com>
 Brad Phelan <bradphelan@xtargets.com>
 Carl Philipp Bickmeier <c.bickmeier@diomex.de>
+ccHanibal <oliver91daum@hotmail.de>
 christophano@hotmail.com
 Christof Konstantinopoulos <chrkon@web.de>
 Christof <chrkon@mail.de>

--- a/Source/Examples/WPF/ExampleBrowser/ExampleBrowser.csproj
+++ b/Source/Examples/WPF/ExampleBrowser/ExampleBrowser.csproj
@@ -95,6 +95,17 @@
     <Compile Include="Examples\CursorPosition\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Examples\DataTemplate\BindingConverter.cs" />
+    <Compile Include="Examples\DataTemplate\BindingExtensions.cs" />
+    <Compile Include="Examples\DataTemplate\DataTemplateSelector3D.cs" />
+    <Compile Include="Examples\DataTemplate\DefaultDatTemplateSelctor3D.cs" />
+    <Compile Include="Examples\DataTemplate\CubeElement.cs" />
+    <Compile Include="Examples\DataTemplate\Extensions.cs" />
+    <Compile Include="Examples\DataTemplate\ModelElement1.cs" />
+    <Compile Include="Examples\DataTemplate\ModelElement.cs" />
+    <Compile Include="Examples\DataTemplate\MultiBindingConverter.cs" />
+    <Compile Include="Examples\DataTemplate\MultiConverterPassThrough.cs" />
+    <Compile Include="Examples\DataTemplate\SphereElement.cs" />
     <Compile Include="Examples\ExtrudedText\Extensions.cs" />
     <Compile Include="Examples\ExtrudedText\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/BindingConverter.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/BindingConverter.cs
@@ -1,0 +1,33 @@
+﻿namespace DataTemplateDemo
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Windows;
+    using System.Windows.Data;
+    using System.Windows.Markup;
+
+    public class BindingConverter : ExpressionConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(MarkupExtension))
+                return true;
+            else
+                return false;
+        }
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(MarkupExtension))
+            {
+                var bindingExpression = value as BindingExpression;
+                if (bindingExpression == null)
+                    throw new ArgumentNullException(nameof(bindingExpression));
+
+                return bindingExpression.ParentBinding;
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/BindingExtensions.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/BindingExtensions.cs
@@ -1,0 +1,75 @@
+﻿namespace DataTemplateDemo
+{
+    using System.Windows.Data;
+
+    public static class BindingExtensions
+    {
+        /// <summary>
+        /// Clones <paramref name="binding"/>.
+        /// </summary>
+        /// <param name="binding">The binding to clone.</param>
+        /// <returns>A clone of <paramref name="binding"/>.</returns>
+        /// <remarks>
+        /// ElementName, RelativeSource, Source and ValidationRules are not being copied.
+        /// </remarks>
+        public static Binding Clone(this Binding binding)
+        {
+            return new Binding
+            {
+                AsyncState = binding.AsyncState,
+                BindingGroupName = binding.BindingGroupName,
+                BindsDirectlyToSource = binding.BindsDirectlyToSource,
+                Converter = binding.Converter,
+                ConverterCulture = binding.ConverterCulture,
+                ConverterParameter = binding.ConverterParameter,
+                Delay = binding.Delay,
+                FallbackValue = binding.FallbackValue,
+                IsAsync = binding.IsAsync,
+                Mode = binding.Mode,
+                NotifyOnSourceUpdated = binding.NotifyOnSourceUpdated,
+                NotifyOnTargetUpdated = binding.NotifyOnTargetUpdated,
+                NotifyOnValidationError = binding.NotifyOnValidationError,
+                Path = binding.Path,
+                StringFormat = binding.StringFormat,
+                TargetNullValue = binding.TargetNullValue,
+                UpdateSourceExceptionFilter = binding.UpdateSourceExceptionFilter,
+                UpdateSourceTrigger = binding.UpdateSourceTrigger,
+                ValidatesOnDataErrors = binding.ValidatesOnDataErrors,
+                ValidatesOnExceptions = binding.ValidatesOnExceptions,
+                ValidatesOnNotifyDataErrors = binding.ValidatesOnNotifyDataErrors,
+                XPath = binding.XPath
+            };
+        }
+        /// <summary>
+        /// Clones <paramref name="multiBinding"/>.
+        /// </summary>
+        /// <param name="multiBinding">The binding to clone.</param>
+        /// <returns>A clone of <paramref name="multiBinding"/>.</returns>
+        /// <remarks>
+        /// Bindings and ValidationRules are not being copied.
+        /// </remarks>
+        public static MultiBinding Clone(this MultiBinding multiBinding)
+        {
+            return new MultiBinding
+            {
+                BindingGroupName = multiBinding.BindingGroupName,
+                Converter = multiBinding.Converter,
+                ConverterCulture = multiBinding.ConverterCulture,
+                ConverterParameter = multiBinding.ConverterParameter,
+                Delay = multiBinding.Delay,
+                FallbackValue = multiBinding.FallbackValue,
+                Mode = multiBinding.Mode,
+                NotifyOnSourceUpdated = multiBinding.NotifyOnSourceUpdated,
+                NotifyOnTargetUpdated = multiBinding.NotifyOnTargetUpdated,
+                NotifyOnValidationError = multiBinding.NotifyOnValidationError,
+                StringFormat = multiBinding.StringFormat,
+                TargetNullValue = multiBinding.TargetNullValue,
+                UpdateSourceExceptionFilter = multiBinding.UpdateSourceExceptionFilter,
+                UpdateSourceTrigger = multiBinding.UpdateSourceTrigger,
+                ValidatesOnDataErrors = multiBinding.ValidatesOnDataErrors,
+                ValidatesOnExceptions = multiBinding.ValidatesOnExceptions,
+                ValidatesOnNotifyDataErrors = multiBinding.ValidatesOnNotifyDataErrors
+            };
+        }
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/CubeElement.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/CubeElement.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CubeElementFixedWidth.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// <summary>
+//   Represents an element.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DataTemplateDemo
+{
+    /// <summary>
+    /// Represents an element.
+    /// </summary>
+    public class CubeElement : Element
+    {
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/DataTemplate3D.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/DataTemplate3D.cs
@@ -7,62 +7,408 @@
 namespace DataTemplateDemo
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Linq;
     using System.Reflection;
+    using System.Text;
+    using System.Text.RegularExpressions;
     using System.Windows;
     using System.Windows.Data;
     using System.Windows.Markup;
     using System.Windows.Media.Media3D;
     using System.Windows.Threading;
+    using System.Xml;
 
     [ContentProperty("Content")]
     public class DataTemplate3D : DispatcherObject
     {
-        public Visual3D Content { get; set; }
-
-        public Visual3D CreateItem(object source)
+        static DataTemplate3D()
         {
-            var type = this.Content.GetType();
-            var types = new List<Type>();
-            types.Add(type);
-            var current = type;
-            while (current.BaseType != null)
+            // add converters for XamlWriter.Save
+            TypeDescriptor.AddAttributes(typeof(BindingExpression), new TypeConverterAttribute(typeof(BindingConverter)));
+            TypeDescriptor.AddAttributes(typeof(MultiBindingExpression), new TypeConverterAttribute(typeof(MultiBindingConverter)));
+        }
+
+        /// <summary>
+        /// Regex to match binding expressions.
+        /// </summary>
+        private static readonly Regex bindingRegex = new Regex("{(.+:)?Binding.*}");
+
+        private XmlDocument contentXamlSerialized;
+        private List<PathInfo>[] listOfBindingPaths;
+
+        /// <summary>
+        /// Gets or sets the template object.
+        /// </summary>
+        public Visual3D Content { get; set; }
+        /// <summary>
+        /// Gets or sets whether the model has a generated content or not.
+        /// </summary>
+        public bool HasGeneratedContent { get; set; }
+
+        public DataTemplate3D()
+        {
+            HasGeneratedContent = true;
+        }
+
+        /// <summary>
+        /// Creates a copy of the template with <paramref name="dataContext"/> as source on all bindings.
+        /// </summary>
+        /// <param name="dataContext">The source object for all data bindings on the new object.</param>
+        /// <returns>A clone of the template object.</returns>
+        public Visual3D CreateItem(object dataContext)
+        {
+            if (contentXamlSerialized == null)
             {
-                types.Add(current.BaseType);
-                current = current.BaseType;
+                // cache serialized xml document
+                var xmlDoc = ObjectToXaml(Content);
+                contentXamlSerialized = xmlDoc;
             }
 
-            var visual = (Visual3D)Activator.CreateInstance(type);
-            var boundProperties = new HashSet<string>();
-            foreach (var t in types)
+            var clonedObj = (Visual3D)XamlReader.Parse(contentXamlSerialized.InnerXml);
+            if (listOfBindingPaths == null)
             {
-                foreach (var fi in t.GetFields(BindingFlags.Public | BindingFlags.Static))
+                // find and cache all bindings paths
+                listOfBindingPaths = FindBindingsInTree(contentXamlSerialized)
+                                        .Concat(FindMutiBindingsInTree(contentXamlSerialized))
+                                        .ToArray();
+            }
+
+            // clear references fro previous runs because they belong to another object (reflection result do not need to be cleared)
+            foreach (var path in listOfBindingPaths.SelectMany(x => x))
+                path.Reference = null;
+
+            var listOfBindingPathsClone = new LinkedList<List<PathInfo>>(listOfBindingPaths);
+
+            while (listOfBindingPathsClone.Count > 0)
+            {
+                var curPath = listOfBindingPathsClone.First.Value;
+                listOfBindingPathsClone.RemoveFirst();
+
+                if (UpdateBindingSource(clonedObj, dataContext, curPath))
+                {
+                    // update newly discovered references on the yet to proccess paths
+                    UpdateKnownReferencesInTree(curPath, listOfBindingPathsClone);
+                }
+            }
+
+            return clonedObj;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PathInfo"/> from an <see cref="XmlNode"/>.
+        /// </summary>
+        /// <param name="cur">The xml node.</param>
+        private PathInfo CreatePathSegment(XmlNode cur)
+        {
+            var pi = new PathInfo();
+
+            string name = cur.Name;
+            var collonIndex = name.IndexOf(':');
+            if (collonIndex >= 0)
+                name = name.Substring(collonIndex + 1);
+
+            var pointIndex = name.LastIndexOf('.');
+            if (pointIndex >= 0)
+            {
+                name = name.Substring(pointIndex + 1);
+                pi.IsProperty = true;
+            }
+            else
+            {
+                pi.IsProperty = false;
+            }
+
+            pi.Name = name;
+
+            var parent = cur.ParentNode;
+            if (parent != null && parent.ChildNodes.Count > 1)
+            {
+                int index = 0;
+                foreach (var node1 in parent.ChildNodes)
+                {
+                    if (node1 == cur)
+                    {
+                        pi.Position = index;
+                        break;
+                    }
+
+                    index++;
+                }
+            }
+            else
+            {
+                pi.Position = 0;
+            }
+
+            return pi;
+        }
+        /// <summary>
+        /// Performs the action described by <paramref name="path"/>.
+        /// </summary>
+        /// <param name="obj">The root object.</param>
+        /// <param name="path">A <see cref="PathInfo"/> describing how to retrieve the next object.</param>
+        /// <returns>The next object as decribed by <paramref name="path"/>.</returns>
+        private object GetValueOf(object obj, PathInfo path)
+        {
+            if (path.Reference != null)
+                return path.Reference;
+
+            if (obj.GetType().Name == path.Name)
+                return obj;
+
+            if (path.IsProperty)
+            {
+                var pi = obj.GetType().GetProperty(path.Name);
+                return pi.GetValue(obj);
+            }
+
+            var collection = obj as IEnumerable;
+            if (collection != null)
+            {
+                var value = collection.Cast<object>()
+                                      .Skip(path.Position)
+                                      .First();
+
+                // check that the object type is the correct one
+                if (value.GetType().Name != path.Name)
+                    throw new Exception(String.Format("Class name mismatch: {0} vs {1}", value.GetType().Name, path.Name));
+
+                return value;
+            };
+
+            throw new Exception("Unkown retrieval method.");
+        }
+        /// <summary>
+        /// Finds bound attributes in the xml document representing the object.
+        /// </summary>
+        /// <param name="xmlDoc">An <see cref="XmlDocument"/>.</param>
+        /// <returns>A list of paths that have a data binding expression.</returns>
+        private IEnumerable<List<PathInfo>> FindBindingsInTree(XmlDocument xmlDoc)
+        {
+            foreach (var attr in xmlDoc.TraverseAllNodes().SelectMany(n => n.Attributes.Cast<XmlAttribute>()))
+            {
+                if (bindingRegex.IsMatch(attr.InnerText))
+                {
+                    var nodes = new List<PathInfo>();
+                    nodes.Add(new PathInfo { Name = attr.Name });
+
+                    for (XmlNode cur = attr.OwnerElement; cur != null; cur = cur.ParentNode)
+                    {
+                        var segment = CreatePathSegment(cur);
+                        nodes.Add(segment);
+                    }
+
+                    nodes.Reverse();
+                    nodes.RemoveAt(0); // remove #document
+
+                    yield return nodes;
+                }
+            }
+        }
+        /// <summary>
+        /// Finds bound attributes in the xml document representing the object.
+        /// </summary>
+        /// <param name="xmlDoc">An <see cref="XmlDocument"/>.</param>
+        /// <returns>A list of paths that have a data multi binding expression.</returns>
+        private IEnumerable<List<PathInfo>> FindMutiBindingsInTree(XmlDocument xmlDoc)
+        {
+            foreach (var node in xmlDoc.TraverseAllNodes())
+            {
+                if (node.Name.EndsWith("MultiBinding"))
+                {
+                    var nodes = new List<PathInfo>();
+
+                    for (XmlNode cur = node.ParentNode; cur != null; cur = cur.ParentNode)
+                    {
+                        var segment = CreatePathSegment(cur);
+                        nodes.Add(segment);
+                    }
+
+                    nodes.Reverse();
+                    nodes.RemoveAt(0); // remove #document
+
+                    yield return nodes;
+                }
+            }
+        }
+        /// <summary>
+        /// Converts the <paramref name="obj"/> into an xaml representation wrapped by an <see cref="XmlDocument"/>.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <returns>An <see cref="XmlDocument"/> holding the xaml representation of <paramref name="obj"/>.</returns>
+        private XmlDocument ObjectToXaml(object obj)
+        {
+            var outstr = new StringBuilder();
+
+            //this code need for right XML fomating
+            var settings = new XmlWriterSettings
+            {
+                Indent = true,
+                OmitXmlDeclaration = true
+            };
+
+            //http://www.codeproject.com/Articles/27158/XamlWriter-and-Bindings-Serialization
+            var dsm = new XamlDesignerSerializationManager(XmlWriter.Create(outstr, settings));
+            dsm.XamlWriterMode = XamlWriterMode.Expression;
+
+            XamlWriter.Save(Content, dsm);
+            var xaml = outstr.ToString();
+
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(xaml);
+
+            if (HasGeneratedContent)
+            {
+                var contentNode = xmlDoc.DocumentElement.ChildNodes.Cast<XmlNode>().Where(n => n.LocalName.EndsWith(".Content")).FirstOrDefault();
+
+                // reomve generated content except when it is a Binding/MultiBinding sub node
+                if (contentNode != null && (contentNode.ChildNodes.Count != 1 || !new[] { "Binding", "MultiBinding" }.Contains(contentNode.ChildNodes[0].LocalName)))
+                    contentNode.ParentNode.RemoveChild(contentNode);
+            }
+
+            return xmlDoc;
+        }
+        /// <summary>
+        /// Updates the binding on the property described by <paramref name="path"/> to use <paramref name="dataContext"/> as source.
+        /// </summary>
+        /// <param name="obj">The root object.</param>
+        /// <param name="dataContext">The object to use as source.</param>
+        /// <param name="path">A list of objects decribing the path through the object tree to the property.</param>
+        private bool UpdateBindingSource(object obj, object dataContext, ICollection<PathInfo> path)
+        {
+            object nestedObj = obj;
+            bool hasNewlyDiscoveredObjects = false;
+            var segmentsToTraverse = path.Take(path.Count - 1)
+                                         .SkipWhile(p => p.Reference != null)
+                                         .ToArray();
+
+            if (segmentsToTraverse.Length > 0)
+            {
+                // update object with last known reference
+                var index = path.Count - segmentsToTraverse.Length - 1 - 1;
+                if (index >= 0)
+                {
+                    nestedObj = path.ElementAt(index)
+                                    .Reference;
+                }
+
+                foreach (var pathSegment in segmentsToTraverse)
+                {
+                    nestedObj = GetValueOf(nestedObj, pathSegment);
+                    if (pathSegment.Reference == null)
+                    {
+                        pathSegment.Reference = nestedObj;
+                        hasNewlyDiscoveredObjects = true;
+                    }
+                }
+            }
+            else
+            {
+                // update object with last known reference
+                nestedObj = path.ElementAt(path.Count - 2)
+                                .Reference;
+
+            }
+
+            var type = nestedObj.GetType();
+
+            var visual = nestedObj as DependencyObject;
+            if (visual != null)
+            {
+                var secondLastSegment = path.ElementAt(path.Count - 2);
+                if (secondLastSegment.PublicDependencyProperties == null)
+                    secondLastSegment.PublicDependencyProperties = type.GetPublicStaticFields().ToArray();
+
+                foreach (var fi in secondLastSegment.PublicDependencyProperties)
                 {
                     var dp = fi.GetValue(null) as DependencyProperty;
-                    if (dp != null)
+                    if (dp != null && dp.Name == path.Last().Name)
                     {
-                        var binding = BindingOperations.GetBinding(this.Content, dp);
-                        if (binding != null)
+                        var binding = BindingOperations.GetBinding(visual, dp);
+                        if (binding != null && binding.Source == null)
                         {
-                            boundProperties.Add(dp.Name);
-                            BindingOperations.SetBinding(
-                                visual, dp, new Binding { Path = binding.Path, Source = source });
+                            BindingOperations.ClearBinding(visual, dp);
+
+                            var b = binding.Clone();
+                            b.Source = dataContext;
+
+                            BindingOperations.SetBinding(visual, dp, b);
+
+                            break;
+                        }
+
+                        var multiBinding = BindingOperations.GetMultiBinding(visual, dp);
+                        if (multiBinding != null)
+                        {
+                            var newMultiBinding = multiBinding.Clone();
+
+                            for (int a = 0; a < multiBinding.Bindings.Count; a++)
+                            {
+                                var innerBinding = multiBinding.Bindings[a] as Binding;
+                                if (innerBinding != null && innerBinding.Source == null)
+                                {
+                                    var newInnerBinding = innerBinding.Clone();
+                                    newInnerBinding.Source = dataContext;
+
+                                    newMultiBinding.Bindings.Add(newInnerBinding);
+                                }
+                                else
+                                {
+                                    newMultiBinding.Bindings.Add(multiBinding.Bindings[a]);
+                                }
+                            }
+
+                            BindingOperations.ClearBinding(visual, dp);
+                            BindingOperations.SetBinding(visual, dp, newMultiBinding);
                         }
                     }
                 }
             }
 
-            //foreach (var p in type.GetProperties())
-            //{
-            //    if (!p.CanWrite) continue;
-            //    if (boundProperties.Contains(p.Name)) 
-            //        continue;
-            //    var value = p.GetValue(this.Content);
-            //    p.SetValue(visual, value);
-            //}
+            return hasNewlyDiscoveredObjects;
+        }
+        /// <summary>
+        /// Shares the references of the <paramref name="currentlyUpdatedPath"/> with all <paramref name="otherPaths"/>.
+        /// </summary>
+        /// <param name="currentlyUpdatedPath">The source tree to take the reference from.</param>
+        /// <param name="otherPaths">The destination trees to update.</param>
+        private void UpdateKnownReferencesInTree(IList<PathInfo> currentlyUpdatedPath, LinkedList<List<PathInfo>> otherPaths)
+        {
+            foreach (var otherPath in otherPaths)
+            {
+                for (int a = 0; a < Math.Min(otherPath.Count, currentlyUpdatedPath.Count); a++)
+                {
+                    var curPathSeg = currentlyUpdatedPath[a];
+                    var othPathSeg = otherPath[a];
 
-            return visual;
+                    if (curPathSeg.Name == othPathSeg.Name && curPathSeg.IsProperty == othPathSeg.IsProperty && curPathSeg.Position == othPathSeg.Position)
+                    {
+                        if (othPathSeg.Reference == null)
+                            othPathSeg.Reference = curPathSeg.Reference;
+
+                        if (othPathSeg.PublicDependencyProperties == null)
+                            othPathSeg.PublicDependencyProperties = curPathSeg.PublicDependencyProperties;
+                    }
+                    else
+                    {
+                        // other tree path -> no further checks needed
+                        break;
+                    }
+                }
+            }
+        }
+
+        private class PathInfo
+        {
+            public bool IsProperty { get; set; }
+            public int Position { get; set; }
+            public string Name { get; set; }
+
+            public object Reference { get; set; }
+            public FieldInfo[] PublicDependencyProperties { get; set; }
         }
     }
 }

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/DataTemplateSelector3D.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/DataTemplateSelector3D.cs
@@ -1,0 +1,12 @@
+﻿namespace DataTemplateDemo
+{
+    using System.Windows;
+
+    public class DataTemplateSelector3D
+    {
+        public virtual DataTemplate3D SelectTemplate(object item, DependencyObject container)
+        {
+            return null;
+        }
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/DefaultDatTemplateSelctor3D.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/DefaultDatTemplateSelctor3D.cs
@@ -1,0 +1,19 @@
+﻿namespace DataTemplateDemo
+{
+    using System.Windows;
+
+    public class DefaultDatTemplateSelctor3D : DataTemplateSelector3D
+    {
+        public override DataTemplate3D SelectTemplate(object item, DependencyObject container)
+        {
+            var element = container as FrameworkElement;
+            if (element != null && item != null)
+            {
+                var key = item.GetType();
+                return element.FindResource(key) as DataTemplate3D;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/Extensions.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/Extensions.cs
@@ -1,0 +1,64 @@
+﻿namespace DataTemplateDemo
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Xml;
+
+    public static class Extensions
+    {
+        public static IEnumerable<Type> GetTypeAndBaseTypes(this Type type)
+        {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+
+            return GetTypeAndBaseTypesImpl(type);
+        }
+        private static IEnumerable<Type> GetTypeAndBaseTypesImpl(Type type)
+        {
+            yield return type;
+
+            var current = type;
+            while (current.BaseType != null)
+            {
+                yield return current.BaseType;
+                current = current.BaseType;
+            }
+        }
+
+        public static IEnumerable<FieldInfo> GetPublicStaticFields(this Type type)
+        {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+
+            return GetPublicStaticFieldsImpl(type);
+        }
+        private static IEnumerable<FieldInfo> GetPublicStaticFieldsImpl(Type type)
+        {
+            foreach (var t in GetTypeAndBaseTypes(type))
+            {
+                foreach (var fi in t.GetFields(BindingFlags.Public | BindingFlags.Static))
+                    yield return fi;
+            }
+        }
+
+        public static IEnumerable<XmlNode> TraverseAllNodes(this XmlDocument doc)
+        {
+            if (doc == null)
+                throw new ArgumentNullException(nameof(doc));
+
+            return TraverseNodesImpl(doc).Skip(1);
+        }
+        private static IEnumerable<XmlNode> TraverseNodesImpl(XmlNode node)
+        {
+            yield return node;
+
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
+                foreach (var node1 in TraverseNodesImpl(childNode))
+                    yield return node1;
+            }
+        }
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/ItemsVisual3D.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/ItemsVisual3D.cs
@@ -16,6 +16,8 @@ namespace DataTemplateDemo
     using System.Windows.Media.Media3D;
     using System.Collections.Specialized;
     using System.Collections.Generic;
+    using HelixToolkit.Wpf;
+    using System.Linq;
 
     /// <summary>
     ///     Represents a model that can be used to present a collection of items.supports generating child items by a
@@ -33,6 +35,12 @@ namespace DataTemplateDemo
         /// </summary>
         public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register(
             "ItemTemplate", typeof(DataTemplate3D), typeof(ItemsVisual3D), new PropertyMetadata(null));
+
+        /// <summary>
+        ///     The item template selector property
+        /// </summary>
+        public static readonly DependencyProperty ItemTemplateSelectorProperty = DependencyProperty.Register(
+            "ItemTemplateSelector", typeof(DataTemplateSelector3D), typeof(ItemsVisual3D), new PropertyMetadata(new DefaultDatTemplateSelctor3D()));
 
         /// <summary>
         ///     The items source property
@@ -63,6 +71,25 @@ namespace DataTemplateDemo
         }
 
         /// <summary>
+        ///     Gets or sets the <see cref="DataTemplateSelector3D" /> used to locate the <see cref="DataTemplate3D"/> to use.
+        /// </summary>
+        /// <value>
+        ///     The item template selector.
+        /// </value>
+        public DataTemplateSelector3D ItemTemplateSelector
+        {
+            get
+            {
+                return (DataTemplateSelector3D)this.GetValue(ItemTemplateSelectorProperty);
+            }
+
+            set
+            {
+                this.SetValue(ItemTemplateSelectorProperty, value);
+            }
+        }
+
+        /// <summary>
         ///     Gets or sets a collection used to generate the content of the <see cref="ItemsVisual3D" />.
         /// </summary>
         /// <value>
@@ -81,7 +108,6 @@ namespace DataTemplateDemo
             }
         }
 
-
         /// <summary>
         /// Keeps track of the visuals created for each item.
         /// </summary>
@@ -98,46 +124,57 @@ namespace DataTemplateDemo
         /// </exception>
         private void ItemsSourceChanged(DependencyPropertyChangedEventArgs e)
         {
-            var observableCollection = this.ItemsSource as INotifyCollectionChanged;
+            var oldObservableCollection = e.OldValue as INotifyCollectionChanged;
+            if (oldObservableCollection != null)
+            {
+                oldObservableCollection.CollectionChanged -= this.CollectionChanged;
+            }
+
+            var observableCollection = e.NewValue as INotifyCollectionChanged;
             if (observableCollection != null)
             {
-                // TODO: should also unsubscribe to avoid leaks.
                 observableCollection.CollectionChanged += this.CollectionChanged;
             }
 
             if (this.ItemsSource != null)
             {
-                foreach (var item in this.ItemsSource)
-                {
-                    this.AddItem(item);
-                }
+                AddItems(this.ItemsSource);
             }
         }
 
-        private void CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        private void AddItems(IEnumerable items)
+        {
+            if (items != null && items.Cast<object>().Any())
+            {
+                foreach (var item in items)
+                    AddItem(item);
+            }
+        }
+
+        private void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    foreach (var item in e.NewItems)
-                    {
-                        this.AddItem(item);
-                    }
-
+                    AddItems(e.NewItems);
                     break;
+
                 case NotifyCollectionChangedAction.Remove:
-                    foreach (var rem in e.OldItems)
-                    {
-                        if (this.visuals.ContainsKey(rem))
-                        {
-                            if (this.visuals[rem] != null)
-                            {
-                                this.Children.Remove(this.visuals[rem]);
-                            }
-                        }
-                    }
-
+                    RemoveItems(e.OldItems);
                     break;
+
+                case NotifyCollectionChangedAction.Replace:
+                    RemoveItems(e.OldItems);
+                    AddItems(e.NewItems);
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    this.Children.Clear();
+                    this.visuals.Clear();
+
+                    this.AddItems(ItemsSource);
+                    break;
+
                 default:
                     break;
             }
@@ -145,18 +182,9 @@ namespace DataTemplateDemo
 
         private void AddItem(object item)
         {
-            Visual3D visual;
-            if (this.ItemTemplate != null)
-            {
-                visual = this.ItemTemplate.CreateItem(item);
-            }
-            else
-                visual = item as Visual3D;
-
+            var visual = CreateVisualFromModel(item);
             if (visual != null)
             {
-
-                // todo: set up bindings?
                 // Cannot set DataContext, set bindings manually
                 // http://stackoverflow.com/questions/7725313/how-can-i-use-databinding-for-3d-elements-like-visual3d-or-uielement3d
                 this.Children.Add(visual);
@@ -166,6 +194,47 @@ namespace DataTemplateDemo
             else
             {
                 throw new InvalidOperationException("Cannot create a Model3D from ItemTemplate.");
+            }
+        }
+        private void RemoveItems(IEnumerable items)
+        {
+            if (items == null)
+                return;
+
+            foreach (var rem in items)
+            {
+                if (visuals.ContainsKey(rem))
+                {
+                    if (visuals[rem] != null)
+                    {
+                        Children.Remove(visuals[rem]);
+                    }
+                }
+            }
+        }
+
+        private Visual3D CreateVisualFromModel(object item)
+        {
+            if (this.ItemTemplate != null)
+            {
+                return this.ItemTemplate.CreateItem(item);
+            }
+            else if (ItemTemplateSelector != null)
+            {
+                var viewPort = Visual3DHelper.GetViewport3D(this);
+                var dataTemplate = ItemTemplateSelector.SelectTemplate(item, viewPort);
+                if (dataTemplate != null)
+                {
+                    return dataTemplate.CreateItem(item);
+                }
+                else
+                {
+                    return item as Visual3D;
+                }
+            }
+            else
+            {
+                return item as Visual3D;
             }
         }
     }

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MainWindow.xaml
@@ -8,8 +8,53 @@
         <local:DataTemplate3D x:Key="Template1">
             <h:SphereVisual3D Center="{Binding Position}" Material="{Binding Material}" Radius="{Binding Radius}"/>
         </local:DataTemplate3D>
-        <local:DataTemplate3D x:Key="Template2">
-            <h:CubeVisual3D Center="{Binding Position}" SideLength="{Binding Radius}" Fill="Blue"/>
+
+        <local:DataTemplate3D x:Key="{x:Type local:CubeElement}">
+            <h:CubeVisual3D Center="{Binding Position}" SideLength="0.6">
+                <h:CubeVisual3D.Material>
+                    <DiffuseMaterial Brush="Blue" />
+                </h:CubeVisual3D.Material>
+                <h:CubeVisual3D.Transform>
+                    <Transform3DGroup>
+                        <ScaleTransform3D CenterX="{Binding Position.X}" CenterY="{Binding Position.Y}" CenterZ="{Binding Position.Z}" ScaleX="3" />
+                        <RotateTransform3D CenterX="{Binding Position.X}" CenterY="{Binding Position.Y}" CenterZ="{Binding Position.Z}">
+                            <RotateTransform3D.Rotation>
+                                <AxisAngleRotation3D Angle="45" Axis="1,1,1" />
+                            </RotateTransform3D.Rotation>
+                        </RotateTransform3D>
+                    </Transform3DGroup>
+                </h:CubeVisual3D.Transform>
+            </h:CubeVisual3D>
+        </local:DataTemplate3D>
+        <local:DataTemplate3D x:Key="{x:Type local:SphereElement}">
+            <h:SphereVisual3D Center="{Binding Position}" Material="{Binding Material}" Radius="{Binding Radius}" />
+        </local:DataTemplate3D>
+
+        <local:DataTemplate3D x:Key="{x:Type local:ModelElement}">
+            <ModelVisual3D Content="{Binding Model}">
+                <ModelVisual3D.Transform>
+                    <TranslateTransform3D OffsetX="{Binding Position.X}" OffsetY="{Binding Position.Y}" OffsetZ="{Binding Position.Z}" />
+                </ModelVisual3D.Transform>
+            </ModelVisual3D>
+        </local:DataTemplate3D>
+        <local:DataTemplate3D x:Key="{x:Type local:ModelElement1}">
+            <ModelVisual3D>
+                <ModelVisual3D.Content>
+                    <MultiBinding Converter="{local:MultiConverterPassThrough}">
+                        <Binding Path="Model" />
+                    </MultiBinding>
+                </ModelVisual3D.Content>
+                <ModelVisual3D.Transform>
+                    <Transform3DGroup>
+                        <TranslateTransform3D OffsetX="{Binding Position.X}" OffsetY="{Binding Position.Y}" OffsetZ="{Binding Position.Z}" />
+                        <RotateTransform3D CenterX="{Binding Position.X}" CenterY="{Binding Position.Y}" CenterZ="{Binding Position.Z}">
+                            <RotateTransform3D.Rotation>
+                                <AxisAngleRotation3D Angle="90" Axis="0,0,1" />
+                            </RotateTransform3D.Rotation>
+                        </RotateTransform3D>
+                    </Transform3DGroup>
+                </ModelVisual3D.Transform>
+            </ModelVisual3D>
         </local:DataTemplate3D>
     </Window.Resources>
     <Grid>
@@ -20,11 +65,12 @@
         <StackPanel Orientation="Horizontal">
             <Button Command="{Binding AddElementCommand}">Add Element</Button>
             <Button Command="{Binding DeleteElementCommand}">Remove Element</Button>
+            <Button Command="{Binding AddElementsCommand}">Add 250 Elements</Button>
         </StackPanel>
         <h:HelixViewport3D Grid.Row="1" ZoomExtentsWhenLoaded="True">
             <h:SunLight/>
             <local:ItemsVisual3D ItemTemplate="{StaticResource Template1}" ItemsSource="{Binding FixedElements}"/>
-            <local:ItemsVisual3D ItemTemplate="{StaticResource Template2}" ItemsSource="{Binding ObservableElements}"/>
+            <local:ItemsVisual3D ItemsSource="{Binding ObservableElements}"/>
         </h:HelixViewport3D>
     </Grid>
 </Window>

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MainWindow.xaml.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MainWindow.xaml.cs
@@ -57,21 +57,57 @@ namespace DataTemplateDemo
             this.DataContext = this;
             this.AddElementCommand = new DelegateCommand(() =>
             {
-                this.ObservableElements.Add(new Element
+                if (this.ObservableElements.Count % 3 == 1)
                 {
-                    Position = new Point3D(0, -3, this.ObservableElements.Count),
-                    Material = Materials.Green,
-                    Radius = 0.4
-                });
+                    var modelBuilder = new MeshBuilder();
+                    modelBuilder.AddCylinder(new Point3D(0, 0, 0), new Point3D(0, 1, 0), 0.75, 15);
+
+                    var model = new ModelElement();
+                    if (this.ObservableElements.Count % 2 == 0)
+                        model = new ModelElement1();
+
+                    model.IsVisible = true;
+                    model.Model = new GeometryModel3D
+                    {
+                        Material = new DiffuseMaterial(System.Windows.Media.Brushes.Orange),
+                        BackMaterial = new DiffuseMaterial(System.Windows.Media.Brushes.Orange),
+                        Geometry = modelBuilder.ToMesh()
+                    };
+                    model.Position = new Point3D(0, -3, this.ObservableElements.Count);
+
+                    this.ObservableElements.Add(model);
+                }
+                else if (this.ObservableElements.Count % 2 == 0)
+                {
+                    this.ObservableElements.Add(new SphereElement
+                    {
+                        Position = new Point3D(-2, -3, this.ObservableElements.Count),
+                        Material = Materials.Green,
+                        Radius = 0.4
+                    });
+                }
+                else
+                {
+                    this.ObservableElements.Add(new CubeElement
+                    {
+                        Position = new Point3D(2, -3, this.ObservableElements.Count)
+                    });
+                }
             });
             this.DeleteElementCommand = new DelegateCommand(() =>
             {
                 this.ObservableElements.RemoveAt(this.ObservableElements.Count - 1);
             },
             () => this.ObservableElements.Count > 0);
+            this.AddElementsCommand = new DelegateCommand(() =>
+            {
+                for (int a = 0; a < 250; a++)
+                    AddElementCommand.Execute(null);
+            });
         }
 
         public DelegateCommand AddElementCommand { get; private set; }
+        public DelegateCommand AddElementsCommand { get; private set; }
 
         public DelegateCommand DeleteElementCommand { get; private set; }
 

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/ModelElement.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/ModelElement.cs
@@ -1,0 +1,31 @@
+﻿using System.ComponentModel;
+using System.Windows.Media.Media3D;
+
+namespace DataTemplateDemo
+{
+    public class ModelElement : Element, INotifyPropertyChanged
+    {
+        private bool isVisible = true;
+
+        public Model3D Model { get; set; }
+        public bool IsVisible
+        {
+            get { return isVisible; }
+            set
+            {
+                if (IsVisible != value)
+                {
+                    isVisible = value;
+                    OnPropertyChanged(nameof(IsVisible));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/ModelElement1.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/ModelElement1.cs
@@ -1,0 +1,6 @@
+﻿namespace DataTemplateDemo
+{
+    public class ModelElement1 : ModelElement
+    {
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MultiBindingConverter.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MultiBindingConverter.cs
@@ -1,0 +1,33 @@
+﻿namespace DataTemplateDemo
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Windows;
+    using System.Windows.Data;
+    using System.Windows.Markup;
+
+    public class MultiBindingConverter : ExpressionConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(MarkupExtension))
+                return true;
+            else
+                return false;
+        }
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(MarkupExtension))
+            {
+                var bindingExpression = value as MultiBindingExpression;
+                if (bindingExpression == null)
+                    throw new ArgumentNullException(nameof(bindingExpression));
+
+                return bindingExpression.ParentMultiBinding;
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MultiConverterPassThrough.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MultiConverterPassThrough.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace DataTemplateDemo
+{
+    public class MultiConverterPassThrough : MarkupExtension, IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return values.FirstOrDefault();
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            return new object[] { value };
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/SphereElement.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/SphereElement.cs
@@ -1,0 +1,6 @@
+﻿namespace DataTemplateDemo
+{
+    class SphereElement : Element
+    {
+    }
+}


### PR DESCRIPTION
I rewrote the whole DataTemplate3D logic a while ago, but didn't commit it somewhere. Now there is a ticket #407 and I remebered having that done before. So here it is.

The cloning now takes place at XAML level (serialising and deserialising), so all bindings and direct assignments will be set correctly. The bindings are then updated with the data context object as its source in the whole tree.

I also included a DataTemplateSelector3D to support dynamic templating based on the type of the data context. For this to work the DataTemplate3D's key must be set to the type of the target object.

The only downside is the performance. Inserting 250 objects at once takes abount 1 second.