### PR TITLE
Demonstrate and fix GroupModel3D duplicate render bug

### DIFF
--- a/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10044/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10044/MainWindow.xaml
@@ -68,7 +68,6 @@
             </hx:Viewport3DX.InputBindings>
             <hx:AmbientLight3D Color="0.1,0.1,0.1,1.0"/>
             <hx:DirectionalLight3D Color="{x:Static sdxm:Color4.White}" Direction="-2,-5,-2"/>
-            <hx:MeshGeometryModel3D Geometry="{StaticResource Model}" Transform="{StaticResource Model1Transform}" Material="{x:Static hx:PhongMaterials.Red}"/>
             <hx:GroupModel3D Transform="{StaticResource Model2Transform}">
                 <hx:MeshGeometryModel3D Geometry="{StaticResource Model}" Material="{x:Static hx:PhongMaterials.Green}"/>
             </hx:GroupModel3D>
@@ -80,6 +79,7 @@
                     <hx:LineGeometryModel3D Geometry="{StaticResource Lines}" Transform="{StaticResource Model1Transform}" Color="{x:Static sdxm:Color.Black}" Thickness="1.5"/>
                 </hx:CompositeModel3D>
             </hx:GroupModel3D>
+            <hx:MeshGeometryModel3D Geometry="{StaticResource Model}" Transform="{StaticResource Model1Transform}" Material="{x:Static hx:PhongMaterials.Red}"/>
         </hx:Viewport3DX>
 
         <StackPanel Grid.Row="1" Margin="0 24 0 0">

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
@@ -58,7 +58,6 @@ namespace HelixToolkit.Wpf.SharpDX
 
         protected override void OnRender(RenderContext renderContext)
         {
-            base.OnRender(renderContext);
             foreach (var c in this.Children)
             {
                 var model = c as ITransformable;


### PR DESCRIPTION
There is a bug in GroupModel3D.OnRender() that causes it's children to be rendered twice: with and without transform applied. This pull request is a fix and also demonstrates the issue via ExampleBrowser/Issue10044.