### PR TITLE
Avoid inverting ProjectionViewMatrix, use fast viewmatrix inversion

### DIFF
--- a/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
@@ -150,6 +150,8 @@ namespace BoneSkinDemo
 
         public IList<Matrix> Instances { get; private set; }
 
+        private const int numBonesInModel = 32;
+
         private readonly Matrix[] boneInternal = new Matrix[BoneMatricesStruct.NumberOfBones];
         private readonly List<BoneIds> boneParams = new List<BoneIds>();
         private DispatcherTimer timer = new DispatcherTimer();
@@ -195,7 +197,7 @@ namespace BoneSkinDemo
             {
                 DiffuseColor = Color.MistyRose
             };
-            for(int i=0; i<BoneMatricesStruct.NumberOfBones; ++i)
+            for(int i=0; i< numBonesInModel; ++i)
             {
                 boneInternal[i] = Matrix.Identity;
             }
@@ -205,15 +207,15 @@ namespace BoneSkinDemo
             };
 
             int boneId = 0;
-            numSegmentPerBone = (int)Math.Max(1, (double)Model.Positions.Count / Theta / (BoneMatricesStruct.NumberOfBones -1));
+            numSegmentPerBone = (int)Math.Max(1, (double)Model.Positions.Count / Theta / (numBonesInModel - 1));
             int count = 0;
             for(int i=0; i < Model.Positions.Count / Theta; ++i)
             {
                 boneParams.AddRange(Enumerable.Repeat(new BoneIds()
                 {
-                    Bone1 = Math.Min(BoneMatricesStruct.NumberOfBones -1, boneId),
-                    Bone2 = Math.Min(BoneMatricesStruct.NumberOfBones - 1, boneId-1),
-                    Bone3 = Math.Min(BoneMatricesStruct.NumberOfBones - 1, boneId+1),
+                    Bone1 = Math.Min(numBonesInModel - 1, boneId),
+                    Bone2 = Math.Min(numBonesInModel - 1, boneId-1),
+                    Bone3 = Math.Min(numBonesInModel - 1, boneId+1),
                     Weights = new Vector4(0.6f, 0.2f, 0.2f, 0)
                 }, Theta));
                 ++count;
@@ -255,7 +257,7 @@ namespace BoneSkinDemo
             var rotation = Matrix.RotationAxis(xAxis, 0);
             double angleEach = 0;
             int counter = 0;
-            for (int i=0; i< NumSegments && i < BoneMatricesStruct.NumberOfBones; ++i, counter+= numSegmentPerBone)
+            for (int i=0; i< NumSegments && i < numBonesInModel; ++i, counter+= numSegmentPerBone)
             {
                 if (i == 0)
                 {

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Controls/CanvasMock.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Controls/CanvasMock.cs
@@ -52,7 +52,7 @@ namespace HelixToolkit.Wpf.SharpDX.Tests.Controls
                 return light3DSceneShared;
             }
         }
-
+        public RenderContext RenderContext { get; }
         public bool EnableRenderFrustum
         {
             set;get;

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraExtensions.cs
@@ -490,16 +490,23 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public static Matrix InverseViewMatrix(ref Matrix viewMatrix)
         {
-            var v33Transpose = new Matrix3x3(
-                viewMatrix.M11, viewMatrix.M21, viewMatrix.M31,
-                viewMatrix.M12, viewMatrix.M22, viewMatrix.M32,
-                viewMatrix.M13, viewMatrix.M23, viewMatrix.M33);
-            var vpos = viewMatrix.Row4.ToVector3();
-            vpos = Vector3.Transform(vpos, v33Transpose) * -1;
-            var viewMatrixInv = new Matrix(v33Transpose.M11, v33Transpose.M12, v33Transpose.M13, 0,
-                v33Transpose.M21, v33Transpose.M22, v33Transpose.M23, 0,
-                v33Transpose.M31, v33Transpose.M32, v33Transpose.M33, 0, vpos.X, vpos.Y, vpos.Z, 1);
-            return viewMatrixInv;
+            //var v33Transpose = new Matrix3x3(
+            //    viewMatrix.M11, viewMatrix.M21, viewMatrix.M31,
+            //    viewMatrix.M12, viewMatrix.M22, viewMatrix.M32,
+            //    viewMatrix.M13, viewMatrix.M23, viewMatrix.M33);
+            
+            //var vpos = viewMatrix.Row4.ToVector3();
+
+            //     vpos = Vector3.Transform(vpos, v33Transpose) * -1;
+
+            var x = viewMatrix.M41 * viewMatrix.M11 + viewMatrix.M42 * viewMatrix.M12 + viewMatrix.M43 * viewMatrix.M13;
+            var y = viewMatrix.M41 * viewMatrix.M21 + viewMatrix.M42 * viewMatrix.M22 + viewMatrix.M43 * viewMatrix.M23;
+            var z = viewMatrix.M41 * viewMatrix.M31 + viewMatrix.M42 * viewMatrix.M32 + viewMatrix.M43 * viewMatrix.M33;
+      
+            return new Matrix(
+                viewMatrix.M11, viewMatrix.M21, viewMatrix.M31, 0,
+                viewMatrix.M12, viewMatrix.M22, viewMatrix.M32, 0,
+                viewMatrix.M13, viewMatrix.M23, viewMatrix.M33, 0, -x, -y, -z, 1);
         }
         /// <summary>
         /// Set the camera target point without changing the look direction.

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -80,6 +80,11 @@ namespace HelixToolkit.Wpf.SharpDX
             get { return renderCycles; }
         }
 
+        /// <summary>
+        /// Get RenderContext
+        /// </summary>
+        public RenderContext RenderContext { get { return renderContext; } }
+
         private readonly Light3DSceneShared light3DPerScene = new Light3DSceneShared();
         /// <summary>
         /// Light3D shared data per each secne

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvasThreading.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvasThreading.cs
@@ -176,6 +176,8 @@ namespace HelixToolkit.Wpf.SharpDX
             get { return renderCycles; }
         }
 
+        public RenderContext RenderContext { get { return renderContext; } }
+
         private readonly Light3DSceneShared light3DPerScene = new Light3DSceneShared();
         /// <summary>
         /// Light3D shared data per each secne

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/IRenderHost.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/IRenderHost.cs
@@ -42,6 +42,7 @@ namespace HelixToolkit.Wpf.SharpDX
 #endif
         IRenderer Renderable { get; set; }
 
+        RenderContext RenderContext { get; }
         /// <summary>
         /// Invalidates the current render and requests an update.
         /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/RenderContext.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/RenderContext.cs
@@ -34,7 +34,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public Matrix ViewMatrix { get { return this.viewMatrix; } }
 
-        public Matrix ProjectrionMatrix { get { return this.projectionMatrix; } }
+        public Matrix ProjectionMatrix { get { return this.projectionMatrix; } }
 
         public Matrix WorldMatrix { get { return worldMatrix; } }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -197,6 +197,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public event EventHandler<RelayExceptionEventArgs> RenderExceptionOccurred = delegate { };
 
+        public RenderContext RenderContext { get { return this.RenderHost?.RenderContext; } }
         /// <summary>
         /// Initializes static members of the <see cref="Viewport3DX" /> class.
         /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/ViewportExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/ViewportExtensions.cs
@@ -101,7 +101,8 @@ namespace HelixToolkit.Wpf.SharpDX
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Matrix GetViewProjectionMatrix(this Viewport3DX viewport)
         {
-            return viewport.Camera.GetViewProjectionMatrix(viewport.ActualWidth / viewport.ActualHeight);
+            return viewport.RenderContext != null ? viewport.RenderContext.ViewMatrix * viewport.RenderContext.ProjectionMatrix
+                : viewport.Camera.GetViewProjectionMatrix(viewport.ActualWidth / viewport.ActualHeight);
         }
 
         /// <summary>
@@ -354,7 +355,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 var px = (float)point2d.X;
                 var py = (float)point2d.Y;
 
-                var viewMatrix = camera.GetViewMatrix();
+                var viewMatrix = viewport.RenderContext != null ? viewport.RenderContext.ViewMatrix : camera.GetViewMatrix();
                 Vector3 v = new Vector3();
                 
                 var matrix = CameraExtensions.InverseViewMatrix(ref viewMatrix);
@@ -362,11 +363,11 @@ namespace HelixToolkit.Wpf.SharpDX
                 float h = (float)viewport.ActualHeight;
                 var aspectRatio = w / h;
 
-                var proj = camera.GetProjectionMatrix(aspectRatio);
+                var projMatrix = viewport.RenderContext != null ? viewport.RenderContext.ProjectionMatrix : camera.GetProjectionMatrix(aspectRatio);
                 Vector3 zn, zf;
-                v.X = (2 * px / w - 1) / proj.M11;
-                v.Y = -(2 * py / h - 1) / proj.M22;
-                v.Z = 1 / proj.M33;
+                v.X = (2 * px / w - 1) / projMatrix.M11;
+                v.Y = -(2 * py / h - 1) / projMatrix.M22;
+                v.Z = 1 / projMatrix.M33;
                 Vector3.TransformCoordinate(ref v, ref matrix, out zf);
 
                 if (camera is PerspectiveCamera)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
@@ -181,7 +181,7 @@ namespace HelixToolkit.Wpf.SharpDX
             renderContext.DeviceContext.OutputMerger.DepthStencilState = depthStencilState;
 
             // --- set constant paramerers 
-            var worldMatrix = Matrix.Translation(((PerspectiveCamera)renderContext.Camera).Position.ToVector3());
+            var worldMatrix = Matrix.Translation(renderContext.Camera.Position.ToVector3());
             this.effectTransforms.mWorld.SetMatrix(ref worldMatrix);
 
             // --- render the geometry


### PR DESCRIPTION
Avoid inverting ProjectionViewMatrix, use fast viewmatrix inversion.
Obtain ProjectionMatrix/ViewMatrix from render context directly. Avoid creating redundant matrices from camera.