### PR TITLE
Bug fixes and improvements

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingSphereExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingSphereExtensions.cs
@@ -15,5 +15,16 @@ namespace HelixToolkit.Wpf.SharpDX
 
             return new global::SharpDX.BoundingSphere(worldCenter.ToXYZ(), (worldEdge - worldCenter).Length());
         }
+
+        public static void TransformBoundingSphere(this global::SharpDX.BoundingSphere b, ref Matrix m, out global::SharpDX.BoundingSphere boundSphere)
+        {
+            var center = b.Center;
+            var edge = b.Center + Vector3.Right * b.Radius;
+
+            var worldCenter = Vector3.Transform(center, m);
+            var worldEdge = Vector3.Transform(edge, m);
+
+            boundSphere = new global::SharpDX.BoundingSphere(worldCenter.ToXYZ(), (worldEdge - worldCenter).Length());
+        }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
@@ -56,9 +56,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             set
             {
-                if(position != value)
+                if (Set(ref position, value))
                 {
-                    position = value;
 #if !NETFX_CORE
                     Octree = null;
                     if (position == null || position.Count == 0)
@@ -72,20 +71,35 @@ namespace HelixToolkit.Wpf.SharpDX
                         BoundingSphere = BoundingSphere.FromPoints(position.Array);
                     }
 #endif
-                    RaisePropertyChanged();
                 }
             }
         }
 
 #if !NETFX_CORE
+        private BoundingBox bound;
         public BoundingBox Bound
         {
-            set;get;
+            set
+            {
+                Set(ref bound, value);
+            }
+            get
+            {
+                return bound;
+            }
         }
 
+        private BoundingSphere boundingSphere;
         public BoundingSphere BoundingSphere
         {
-            set;get;
+            set
+            {
+                Set(ref boundingSphere, value);
+            }
+            get
+            {
+                return boundingSphere;
+            }
         }
 #endif
         private Color4Collection colors = null;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
@@ -56,15 +56,38 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             set
             {
-                if (Set<Vector3Collection>(ref position, value))
+                if(position != value)
                 {
+                    position = value;
 #if !NETFX_CORE
                     Octree = null;
+                    if (position == null || position.Count == 0)
+                    {
+                        Bound = new BoundingBox();
+                        BoundingSphere = new BoundingSphere();
+                    }
+                    else
+                    {
+                        Bound = BoundingBox.FromPoints(position.Array);
+                        BoundingSphere = BoundingSphere.FromPoints(position.Array);
+                    }
 #endif
+                    RaisePropertyChanged();
                 }
             }
         }
 
+#if !NETFX_CORE
+        public BoundingBox Bound
+        {
+            set;get;
+        }
+
+        public BoundingSphere BoundingSphere
+        {
+            set;get;
+        }
+#endif
         private Color4Collection colors = null;
         public Color4Collection Colors
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -34,7 +34,7 @@ namespace HelixToolkit.Wpf.SharpDX
     [DefaultProperty("Children")]
     [ContentProperty("Items")]
     [TemplatePart(Name = "PART_CameraController", Type = typeof(CameraController))]
-    [TemplatePart(Name = "PART_Canvas", Type = typeof(IRenderHost))]
+    [TemplatePart(Name = "PART_Canvas", Type = typeof(ContentPresenter))]
     [TemplatePart(Name = "PART_AdornerLayer", Type = typeof(AdornerDecorator))]
     [TemplatePart(Name = "PART_CoordinateView", Type = typeof(Viewport3D))]
     [TemplatePart(Name = "PART_ViewCubeViewport", Type = typeof(Viewport3D))]

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/ViewportExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/ViewportExtensions.cs
@@ -361,7 +361,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 var px = (float)point2d.X;
                 var py = (float)point2d.Y;
 
-                var viewMatrix = viewport.RenderContext != null ? viewport.RenderContext.ViewMatrix : camera.GetViewMatrix();
+                var viewMatrix = camera.GetViewMatrix();
                 Vector3 v = new Vector3();
                 
                 var matrix = CameraExtensions.InverseViewMatrix(ref viewMatrix);
@@ -369,7 +369,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 float h = (float)viewport.ActualHeight;
                 var aspectRatio = w / h;
 
-                var projMatrix = viewport.RenderContext != null ? viewport.RenderContext.ProjectionMatrix : camera.GetProjectionMatrix(aspectRatio);
+                var projMatrix = camera.GetProjectionMatrix(aspectRatio);
                 Vector3 zn, zf;
                 v.X = (2 * px / w - 1) / projMatrix.M11;
                 v.Y = -(2 * py / h - 1) / projMatrix.M22;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -92,16 +92,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             else
             {
-                if (this.Geometry.Positions.Count != 0)
-                {
-                    this.Bounds = BoundingBox.FromPoints(this.Geometry.Positions.Array);
-                    this.BoundsSphere = BoundingSphere.FromPoints(this.Geometry.Positions.Array);
-                }
-                else
-                {
-                    this.Bounds = new BoundingBox();
-                    this.BoundsSphere = new BoundingSphere();
-                }
+                this.Bounds = this.Geometry.Bound;
+                this.BoundsSphere = this.Geometry.BoundingSphere;
                 if (renderHost != null)
                 {
                     var host = this.renderHost;
@@ -117,15 +109,15 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 if (e.PropertyName.Equals(nameof(Geometry3D.Positions)) || e.PropertyName.Equals(Geometry3D.VertexBuffer))
                 {
-                    if (this.Geometry == null || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0)
+                    if (this.Geometry == null)
                     {
                         this.Bounds = new BoundingBox();
                         this.BoundsSphere = new BoundingSphere();
                     }
                     else
                     {
-                        this.Bounds = BoundingBox.FromPoints(this.Geometry.Positions.Array);
-                        this.BoundsSphere = BoundingSphere.FromPoints(this.Geometry.Positions.Array);
+                        this.Bounds = this.Geometry.Bound;
+                        this.BoundsSphere = this.Geometry.BoundingSphere;
                     }
                 }
                 OnGeometryPropertyChanged(sender, e);

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -107,18 +107,13 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             if (this.IsAttached)
             {
-                if (e.PropertyName.Equals(nameof(Geometry3D.Positions)) || e.PropertyName.Equals(Geometry3D.VertexBuffer))
+                if (e.PropertyName.Equals(nameof(Geometry3D.Bound)))
                 {
-                    if (this.Geometry == null)
-                    {
-                        this.Bounds = new BoundingBox();
-                        this.BoundsSphere = new BoundingSphere();
-                    }
-                    else
-                    {
-                        this.Bounds = this.Geometry.Bound;
-                        this.BoundsSphere = this.Geometry.BoundingSphere;
-                    }
+                    this.Bounds = this.Geometry != null ? this.Geometry.Bound : new BoundingBox();
+                }
+                else if (e.PropertyName.Equals(nameof(Geometry3D.BoundingSphere)))
+                {
+                    this.BoundsSphere = this.Geometry != null ? this.Geometry.BoundingSphere : new BoundingSphere();
                 }
                 OnGeometryPropertyChanged(sender, e);
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
@@ -1198,9 +1198,12 @@ namespace HelixToolkit.Wpf.SharpDX
                 foreach (var t in this.Objects)
                 {
                     var idx = t.Item1 * 3;
-                    var v0 = Positions[Indices[idx]];
-                    var v1 = Positions[Indices[idx + 1]];
-                    var v2 = Positions[Indices[idx + 2]];
+                    var t1 = Indices[idx];
+                    var t2 = Indices[idx + 1];
+                    var t3 = Indices[idx + 2];
+                    var v0 = Positions[t1];
+                    var v1 = Positions[t2];
+                    var v2 = Positions[t3];
                     float d;
                     var p0 = Vector3.TransformCoordinate(v0, modelMatrix);
                     var p1 = Vector3.TransformCoordinate(v1, modelMatrix);
@@ -1220,8 +1223,8 @@ namespace HelixToolkit.Wpf.SharpDX
                             n.Normalize();
                             // transform hit-info to world space now:
                             result.NormalAtHit = n.ToVector3D();// Vector3.TransformNormal(n, m).ToVector3D();
-                            result.TriangleIndices = new System.Tuple<int, int, int>(Indices[idx], Indices[idx + 1], Indices[idx + 2]);
-                            result.Tag = idx / 3;
+                            result.TriangleIndices = new System.Tuple<int, int, int>(t1, t2, t3);
+                            result.Tag = t.Item1;
                             isHit = true;
                         }
                     }
@@ -1266,9 +1269,12 @@ namespace HelixToolkit.Wpf.SharpDX
                         Vector3 cloestPoint;
 
                         var idx = t.Item1 * 3;
-                        var v0 = Positions[Indices[idx]];
-                        var v1 = Positions[Indices[idx + 1]];
-                        var v2 = Positions[Indices[idx + 2]];
+                        var t1 = Indices[idx];
+                        var t2 = Indices[idx + 1];
+                        var t3 = Indices[idx + 2];
+                        var v0 = Positions[t1];
+                        var v1 = Positions[t2];
+                        var v2 = Positions[t3];
                         Collision.ClosestPointPointTriangle(ref sphere.Center, ref v0, ref v1, ref v2, out cloestPoint);
                         var d = (cloestPoint - sphere.Center).Length();
                         if (tempResult.Distance > d)
@@ -1276,7 +1282,8 @@ namespace HelixToolkit.Wpf.SharpDX
                             tempResult.Distance = d;
                             tempResult.IsValid = true;
                             tempResult.PointHit = cloestPoint.ToPoint3D();
-                            tempResult.TriangleIndices = new Tuple<int, int, int>(Indices[idx], Indices[idx + 1], Indices[idx + 2]);
+                            tempResult.TriangleIndices = new Tuple<int, int, int>(t1, t2, t3);
+                            tempResult.Tag = t.Item1;
                             isHit = true;
                         }
                     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
@@ -1186,11 +1186,15 @@ namespace HelixToolkit.Wpf.SharpDX
             result.Distance = double.MaxValue;
             var bound = BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
             bool checkBoundSphere = false;
-            var boundSphere = new global::SharpDX.BoundingSphere();
+            global::SharpDX.BoundingSphere boundSphere;
             if (model != null)
             {
                 checkBoundSphere = true;
-                boundSphere = model.BoundsSphere.TransformBoundingSphere(modelMatrix);
+                model.BoundsSphere.TransformBoundingSphere(ref modelMatrix, out boundSphere);
+            }
+            else
+            {
+                boundSphere = new global::SharpDX.BoundingSphere();
             }
             if (rayWS.Intersects(ref bound) && (!checkBoundSphere || rayWS.Intersects(ref boundSphere)))
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
@@ -96,7 +96,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="radius"></param>
         /// <param name="points"></param>
         /// <returns></returns>
-        bool FindNearestPointByPointAndSearchRadius(ref Vector3 point, int radius, ref List<HitTestResult> points);
+        bool FindNearestPointByPointAndSearchRadius(ref Vector3 point, float radius, ref List<HitTestResult> points);
         /// <summary>
         /// Build the whole tree from top to bottom iteratively.
         /// </summary>
@@ -1077,7 +1077,7 @@ namespace HelixToolkit.Wpf.SharpDX
             return node;
         }
 
-        public bool FindNearestPointByPointAndSearchRadius(ref Vector3 point, int radius, ref List<HitTestResult> result)
+        public bool FindNearestPointByPointAndSearchRadius(ref Vector3 point, float radius, ref List<HitTestResult> result)
         {
             var sphere = new global::SharpDX.BoundingSphere(point, radius);
             return FindNearestPointBySphere(ref sphere, ref result);
@@ -1276,7 +1276,7 @@ namespace HelixToolkit.Wpf.SharpDX
                             tempResult.Distance = d;
                             tempResult.IsValid = true;
                             tempResult.PointHit = cloestPoint.ToPoint3D();
-                            tempResult.TriangleIndices = new Tuple<int, int, int>(idx, idx + 1, idx + 2);
+                            tempResult.TriangleIndices = new Tuple<int, int, int>(Indices[idx], Indices[idx + 1], Indices[idx + 2]);
                             isHit = true;
                         }
                     }

--- a/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
@@ -28,13 +28,19 @@ namespace HelixToolkit.Wpf
         /// Identifies the <see cref="BackText"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty BackTextProperty = DependencyProperty.Register(
-            "BackText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("B", VisualModelChanged));
+            "BackText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("B", (d,e)=> 
+            {
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(1, Brushes.Red, e.NewValue == null ? "" : (string)e.NewValue);
+            }));
 
         /// <summary>
         /// Identifies the <see cref="BottomText"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty BottomTextProperty = DependencyProperty.Register(
-            "BottomText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("D", VisualModelChanged));
+            "BottomText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("D", (d, e) =>
+            {
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(5, Brushes.Blue, e.NewValue == null ? "" : (string)e.NewValue);
+            }));
 
         /// <summary>
         /// Identifies the <see cref="Center"/> dependency property.
@@ -46,13 +52,19 @@ namespace HelixToolkit.Wpf
         /// Identifies the <see cref="FrontText"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty FrontTextProperty = DependencyProperty.Register(
-            "FrontText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("F", VisualModelChanged));
+            "FrontText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("F", (d, e) =>
+            {
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(0, Brushes.Red, e.NewValue == null ? "" : (string)e.NewValue);
+            }));
 
         /// <summary>
         /// Identifies the <see cref="LeftText"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty LeftTextProperty = DependencyProperty.Register(
-            "LeftText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("L", VisualModelChanged));
+            "LeftText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("L", (d, e) =>
+            {
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(2, Brushes.Green, e.NewValue == null ? "" : (string)e.NewValue);
+            }));
 
         /// <summary>
         /// Identifies the <see cref="LeftText"/> dependency property.
@@ -74,7 +86,10 @@ namespace HelixToolkit.Wpf
         /// Identifies the <see cref="RightText"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty RightTextProperty = DependencyProperty.Register(
-            "RightText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("R", VisualModelChanged));
+            "RightText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("R", (d, e) =>
+            {
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(3, Brushes.Green, e.NewValue == null ? "" : (string)e.NewValue);
+            }));
 
         /// <summary>
         /// Identifies the <see cref="Size"/> dependency property.
@@ -86,7 +101,10 @@ namespace HelixToolkit.Wpf
         /// Identifies the <see cref="TopText"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty TopTextProperty = DependencyProperty.Register(
-            "TopText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("U", VisualModelChanged));
+            "TopText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("U", (d, e) =>
+            {
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(4, Brushes.Blue, e.NewValue == null ? "" : (string)e.NewValue);
+            }));
 
         /// <summary>
         /// Identifies the <see cref="Viewport"/> dependency property.
@@ -107,7 +125,10 @@ namespace HelixToolkit.Wpf
         /// Identifies the <see cref="EnableEdgeClicks"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty EnableEdgeClicksProperty =
-            DependencyProperty.Register("EnableEdgeClicks", typeof(bool), typeof(ViewCubeVisual3D), new PropertyMetadata(false, VisualModelChanged));
+            DependencyProperty.Register("EnableEdgeClicks", typeof(bool), typeof(ViewCubeVisual3D), new PropertyMetadata(false, (d,e)=>
+            {
+                (d as ViewCubeVisual3D).EnableDisableEdgeClicks();
+            }));
 
         /// <summary>
         /// The normal vectors.
@@ -347,12 +368,18 @@ namespace HelixToolkit.Wpf
             ((ViewCubeVisual3D)d).UpdateVisuals();
         }
 
+        private IList<GeometryModel3D> CubeFaceModels = new List<GeometryModel3D>(6);
+        private IList<ModelUIElement3D> EdgeCornerModels = new List<ModelUIElement3D>();
         /// <summary>
         /// Updates the visuals.
         /// </summary>
         private void UpdateVisuals()
         {
             this.Children.Clear();
+            faceNormals.Clear();
+            faceUpVectors.Clear();
+            CubeFaceModels.Clear();
+            EdgeCornerModels.Clear();
             var frontColor = Brushes.Red;
             var leftColor = Brushes.Green;
             var upColor = Brushes.Blue;
@@ -369,12 +396,12 @@ namespace HelixToolkit.Wpf
 
             var vecFront = Vector3D.CrossProduct(vecLeft, vecUp);
 
-            this.AddCubeFace(vecFront, vecUp, frontColor, this.FrontText);
-            this.AddCubeFace(-vecFront, vecUp, frontColor, this.BackText);
-            this.AddCubeFace(vecLeft, vecUp, leftColor, this.LeftText);
-            this.AddCubeFace(-vecLeft, vecUp, leftColor, this.RightText);
-            this.AddCubeFace(vecUp, vecLeft, upColor, this.TopText);
-            this.AddCubeFace(-vecUp, -vecLeft, upColor, this.BottomText);
+            CubeFaceModels.Add(this.AddCubeFace(vecFront, vecUp, frontColor, this.FrontText));
+            CubeFaceModels.Add(this.AddCubeFace(-vecFront, vecUp, frontColor, this.BackText));
+            CubeFaceModels.Add(this.AddCubeFace(vecLeft, vecUp, leftColor, this.LeftText));
+            CubeFaceModels.Add(this.AddCubeFace(-vecLeft, vecUp, leftColor, this.RightText));
+            CubeFaceModels.Add(this.AddCubeFace(vecUp, vecLeft, upColor, this.TopText));
+            CubeFaceModels.Add(this.AddCubeFace(-vecUp, -vecLeft, upColor, this.BottomText));
 
             var circle = new PieSliceVisual3D();
             circle.BeginEdit();
@@ -389,10 +416,28 @@ namespace HelixToolkit.Wpf
             circle.EndEdit();
             this.Children.Add(circle);
 
-            if (EnableEdgeClicks)
+            AddCorners();
+            AddEdges();
+            EnableDisableEdgeClicks();
+        }
+
+        private void EnableDisableEdgeClicks()
+        {
+            foreach(var item in EdgeCornerModels)
             {
-                AddCorners();
-                AddEdges();
+                item.Visibility = EnableEdgeClicks ? Visibility.Visible : Visibility.Collapsed;
+            }
+        }
+
+        private void UpdateCubefaceMaterial(int index, Brush b, string text)
+        {
+            if(CubeFaceModels.Count > 0 && index < CubeFaceModels.Count)
+            {
+                CubeFaceModels[index].Material = CreateTextMaterial(b, text);
+            }
+            else
+            {
+                UpdateVisuals();
             }
         }
 
@@ -443,6 +488,7 @@ namespace HelixToolkit.Wpf
             element.MouseLeave += EdgesMouseLeaves;
 
             Children.Add(element);
+            EdgeCornerModels.Add(element);
         }
 
         private void AddCorners()
@@ -474,6 +520,7 @@ namespace HelixToolkit.Wpf
                 element.MouseLeave += CornersMouseLeave;
 
                 Children.Add(element);
+                EdgeCornerModels.Add(element);
             }
         }
 
@@ -516,24 +563,9 @@ namespace HelixToolkit.Wpf
         /// <param name="text">
         /// The text.
         /// </param>
-        private void AddCubeFace(Vector3D normal, Vector3D up, Brush b, string text)
+        private GeometryModel3D AddCubeFace(Vector3D normal, Vector3D up, Brush b, string text)
         {
-            var grid = new Grid { Width = 20, Height = 20, Background = b };
-            grid.Children.Add(
-                new TextBlock
-                {
-                    Text = text,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    HorizontalAlignment = HorizontalAlignment.Center,
-                    FontSize = 15,
-                    Foreground = Brushes.White
-                });
-            grid.Arrange(new Rect(new Point(0, 0), new Size(20, 20)));
-
-            var bmp = new RenderTargetBitmap((int)grid.Width, (int)grid.Height, 96, 96, PixelFormats.Default);
-            bmp.Render(grid);
-
-            var material = MaterialHelper.CreateMaterial(new ImageBrush(bmp));
+            var material = CreateTextMaterial(b, text);
 
             double a = this.Size;
 
@@ -550,6 +582,27 @@ namespace HelixToolkit.Wpf
             this.faceUpVectors.Add(element, up);
 
             this.Children.Add(element);
+            return model;
+        }
+
+        private Material CreateTextMaterial(Brush b, string text)
+        {
+            var grid = new Grid { Width = 20, Height = 20, Background = b };
+            grid.Children.Add(
+                new TextBlock
+                {
+                    Text = text,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    FontSize = 15,
+                    Foreground = Brushes.White
+                });
+            grid.Arrange(new Rect(new Point(0, 0), new Size(20, 20)));
+
+            var bmp = new RenderTargetBitmap((int)grid.Width, (int)grid.Height, 96, 96, PixelFormats.Default);
+            bmp.Render(grid);
+
+            return MaterialHelper.CreateMaterial(new ImageBrush(bmp));
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
@@ -30,6 +30,7 @@ namespace HelixToolkit.Wpf
         public static readonly DependencyProperty BackTextProperty = DependencyProperty.Register(
             "BackText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("B", (d,e)=> 
             {
+                var b = (d as ViewCubeVisual3D).GetCubefaceColor(1);
                 (d as ViewCubeVisual3D).UpdateCubefaceMaterial(1, Brushes.Red, e.NewValue == null ? "" : (string)e.NewValue);
             }));
 
@@ -39,7 +40,8 @@ namespace HelixToolkit.Wpf
         public static readonly DependencyProperty BottomTextProperty = DependencyProperty.Register(
             "BottomText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("D", (d, e) =>
             {
-                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(5, Brushes.Blue, e.NewValue == null ? "" : (string)e.NewValue);
+                var b = (d as ViewCubeVisual3D).GetCubefaceColor(5);
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(5, b, e.NewValue == null ? "" : (string)e.NewValue);
             }));
 
         /// <summary>
@@ -54,7 +56,8 @@ namespace HelixToolkit.Wpf
         public static readonly DependencyProperty FrontTextProperty = DependencyProperty.Register(
             "FrontText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("F", (d, e) =>
             {
-                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(0, Brushes.Red, e.NewValue == null ? "" : (string)e.NewValue);
+                var b = (d as ViewCubeVisual3D).GetCubefaceColor(0);
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(0, b, e.NewValue == null ? "" : (string)e.NewValue);
             }));
 
         /// <summary>
@@ -63,7 +66,8 @@ namespace HelixToolkit.Wpf
         public static readonly DependencyProperty LeftTextProperty = DependencyProperty.Register(
             "LeftText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("L", (d, e) =>
             {
-                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(2, Brushes.Green, e.NewValue == null ? "" : (string)e.NewValue);
+                var b = (d as ViewCubeVisual3D).GetCubefaceColor(2);
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(2, b, e.NewValue == null ? "" : (string)e.NewValue);
             }));
 
         /// <summary>
@@ -88,7 +92,8 @@ namespace HelixToolkit.Wpf
         public static readonly DependencyProperty RightTextProperty = DependencyProperty.Register(
             "RightText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("R", (d, e) =>
             {
-                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(3, Brushes.Green, e.NewValue == null ? "" : (string)e.NewValue);
+                var b = (d as ViewCubeVisual3D).GetCubefaceColor(3);
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(3, b, e.NewValue == null ? "" : (string)e.NewValue);
             }));
 
         /// <summary>
@@ -103,7 +108,8 @@ namespace HelixToolkit.Wpf
         public static readonly DependencyProperty TopTextProperty = DependencyProperty.Register(
             "TopText", typeof(string), typeof(ViewCubeVisual3D), new UIPropertyMetadata("U", (d, e) =>
             {
-                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(4, Brushes.Blue, e.NewValue == null ? "" : (string)e.NewValue);
+                var b = (d as ViewCubeVisual3D).GetCubefaceColor(4);
+                (d as ViewCubeVisual3D).UpdateCubefaceMaterial(4, b, e.NewValue == null ? "" : (string)e.NewValue);
             }));
 
         /// <summary>
@@ -380,28 +386,19 @@ namespace HelixToolkit.Wpf
             faceUpVectors.Clear();
             CubeFaceModels.Clear();
             EdgeCornerModels.Clear();
-            var frontColor = Brushes.Red;
-            var leftColor = Brushes.Green;
-            var upColor = Brushes.Blue;
+
             var vecUp = this.ModelUpDirection;
             // create left vector 90° from up
             var vecLeft = new Vector3D(vecUp.Y, vecUp.Z, vecUp.X);
 
-            // change the colors if not a positive Z vector is used for up
-            if (vecUp.Z < 1)
-            {
-                leftColor = Brushes.Blue;
-                upColor = Brushes.Green;
-            }
-
             var vecFront = Vector3D.CrossProduct(vecLeft, vecUp);
 
-            CubeFaceModels.Add(this.AddCubeFace(vecFront, vecUp, frontColor, this.FrontText));
-            CubeFaceModels.Add(this.AddCubeFace(-vecFront, vecUp, frontColor, this.BackText));
-            CubeFaceModels.Add(this.AddCubeFace(vecLeft, vecUp, leftColor, this.LeftText));
-            CubeFaceModels.Add(this.AddCubeFace(-vecLeft, vecUp, leftColor, this.RightText));
-            CubeFaceModels.Add(this.AddCubeFace(vecUp, vecLeft, upColor, this.TopText));
-            CubeFaceModels.Add(this.AddCubeFace(-vecUp, -vecLeft, upColor, this.BottomText));
+            CubeFaceModels.Add(this.AddCubeFace(vecFront, vecUp, GetCubefaceColor(0), this.FrontText));
+            CubeFaceModels.Add(this.AddCubeFace(-vecFront, vecUp, GetCubefaceColor(1), this.BackText));
+            CubeFaceModels.Add(this.AddCubeFace(vecLeft, vecUp, GetCubefaceColor(2), this.LeftText));
+            CubeFaceModels.Add(this.AddCubeFace(-vecLeft, vecUp, GetCubefaceColor(3), this.RightText));
+            CubeFaceModels.Add(this.AddCubeFace(vecUp, vecLeft, GetCubefaceColor(4), this.TopText));
+            CubeFaceModels.Add(this.AddCubeFace(-vecUp, -vecLeft, GetCubefaceColor(5), this.BottomText));
 
             var circle = new PieSliceVisual3D();
             circle.BeginEdit();
@@ -419,6 +416,38 @@ namespace HelixToolkit.Wpf
             AddCorners();
             AddEdges();
             EnableDisableEdgeClicks();
+        }
+
+        private Brush GetCubefaceColor(int index)
+        {
+            switch (index)
+            {
+                case 0:
+                case 1:
+                    return Brushes.Red;
+                case 2:
+                case 3:
+                    if (ModelUpDirection.Z < 1)
+                    {
+                        return Brushes.Blue;
+                    }
+                    else
+                    {
+                        return Brushes.Green;
+                    }
+                case 4:
+                case 5:
+                    if (ModelUpDirection.Z < 1)
+                    {
+                        return Brushes.Green;
+                    }
+                    else
+                    {
+                        return Brushes.Blue;
+                    }
+                default:
+                    return Brushes.White;
+            }
         }
 
         private void EnableDisableEdgeClicks()


### PR DESCRIPTION
1. Fix octree FindNearestPointBySphereExcludeChild triangleIndices in hitResult.
2. Move create bounding box/bounding sphere into Geometry3D.
3. Avoid calling update visuals when text changed. Only needs to rebuild visuals on ModelUpDirection changed.
4. Unproject bug fix, cannot use render context view matrix. Causes panning issue