### PR TITLE
Code improvement and cleanup

### DIFF
--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomGeometryModel3D.cs
@@ -45,7 +45,7 @@ namespace CustomShaderDemo
         protected Color4 selectionColor = new Color4(1.0f, 0.0f, 1.0f, 1.0f);
 
         public static readonly DependencyProperty RequiresPerVertexColorationProperty =
-            DependencyProperty.Register("RequiresPerVertexColoration", typeof(bool), typeof(GeometryModel3D), new UIPropertyMetadata(false));
+            DependencyProperty.Register("RequiresPerVertexColoration", typeof(bool), typeof(GeometryModel3D), new AffectsRenderPropertyMetadata(false));
 
         public bool RequiresPerVertexColoration
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ExposedArrayList.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ExposedArrayList.cs
@@ -27,7 +27,7 @@ namespace HelixToolkit.Wpf.SharpDX.Core
         {
         }
         /// <summary>
-        /// Using with caustious(Array Length >= List.Count). Avoid using as much as possible.
+        /// Using with caustious(Array Length >= List.Count).
         /// </summary>
         internal T[] Array
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ExposedArrayList.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ExposedArrayList.cs
@@ -26,7 +26,9 @@ namespace HelixToolkit.Wpf.SharpDX.Core
             : base(collection)
         {
         }
-
+        /// <summary>
+        /// Using with caustious(Array Length >= List.Count). Avoid using as much as possible.
+        /// </summary>
         internal T[] Array
         {
             get

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingBoxExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingBoxExtensions.cs
@@ -1,0 +1,58 @@
+﻿using SharpDX;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HelixToolkit.Wpf.SharpDX
+{
+    public static class BoundingBoxExtensions
+    {
+        /// <summary>
+        /// Constructs a <see cref="BoundingBox"/> that fully contains the given points.
+        /// </summary>
+        /// <param name="points">The points that will be contained by the box.</param>
+        /// <param name="result">When the method completes, contains the newly constructed bounding box.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="points"/> is <c>null</c>.</exception>
+        public static void FromPoints(IList<Vector3> points, out BoundingBox result)
+        {
+            if (points == null)
+                throw new ArgumentNullException("points");
+
+            Vector3 min = new Vector3(float.MaxValue);
+            Vector3 max = new Vector3(float.MinValue);
+
+            foreach (var p in points)
+            {
+                var point = p;
+                Vector3.Min(ref min, ref point, out min);
+                Vector3.Max(ref max, ref point, out max);
+            }
+
+            result = new BoundingBox(min, max);
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="BoundingBox"/> that fully contains the given points.
+        /// </summary>
+        /// <param name="points">The points that will be contained by the box.</param>
+        /// <returns>The newly constructed bounding box.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="points"/> is <c>null</c>.</exception>
+        public static BoundingBox FromPoints(IList<Vector3> points)
+        {
+            if (points == null)
+                throw new ArgumentNullException("points");
+
+            Vector3 min = new Vector3(float.MaxValue);
+            Vector3 max = new Vector3(float.MinValue);
+
+            foreach(var p in points)
+            {
+                var point = p;
+                Vector3.Min(ref min, ref point, out min);
+                Vector3.Max(ref max, ref point, out max);
+            }
+
+            return new BoundingBox(min, max);
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingSphereExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingSphereExtensions.cs
@@ -1,9 +1,104 @@
 ﻿using global::SharpDX;
+using System;
+using System.Collections.Generic;
 
 namespace HelixToolkit.Wpf.SharpDX
 {
     public static class BoundingSphereExtensions
     {
+        /// <summary>
+        /// Constructs a <see cref="BoundingSphere" /> that fully contains the given points.
+        /// </summary>
+        /// <param name="points">The points that will be contained by the sphere.</param>
+        /// <param name="start">The start index from points array to start compute the bounding sphere.</param>
+        /// <param name="count">The count of points to process to compute the bounding sphere.</param>
+        /// <param name="result">When the method completes, contains the newly constructed bounding sphere.</param>
+        /// <exception cref="System.ArgumentNullException">points</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// start
+        /// or
+        /// count
+        /// </exception>
+        public static void FromPoints(IList<Vector3> points, int start, int count, out global::SharpDX.BoundingSphere result)
+        {
+            if (points == null)
+            {
+                throw new ArgumentNullException("points");
+            }
+
+            // Check that start is in the correct range
+            if (start < 0 || start >= points.Count)
+            {
+                throw new ArgumentOutOfRangeException("start", start, string.Format("Must be in the range [0, {0}]", points.Count - 1));
+            }
+
+            // Check that count is in the correct range
+            if (count < 0 || (start + count) > points.Count)
+            {
+                throw new ArgumentOutOfRangeException("count", count, string.Format("Must be in the range <= {0}", points.Count));
+            }
+
+            var upperEnd = start + count;
+
+            //Find the center of all points.
+            Vector3 center = Vector3.Zero;
+            for (int i = start; i < upperEnd; ++i)
+            {
+                var p = points[i];
+                Vector3.Add(ref p, ref center, out center);
+            }
+
+            //This is the center of our sphere.
+            center /= (float)count;
+
+            //Find the radius of the sphere
+            float radius = 0f;
+            for (int i = start; i < upperEnd; ++i)
+            {
+                //We are doing a relative distance comparison to find the maximum distance
+                //from the center of our sphere.
+                float distance;
+                var p = points[i];
+                Vector3.DistanceSquared(ref center, ref p, out distance);
+
+                if (distance > radius)
+                    radius = distance;
+            }
+
+            //Find the real distance from the DistanceSquared.
+            radius = (float)Math.Sqrt(radius);
+
+            //Construct the sphere.
+            result.Center = center;
+            result.Radius = radius;
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="BoundingSphere"/> that fully contains the given points.
+        /// </summary>
+        /// <param name="points">The points that will be contained by the sphere.</param>
+        /// <param name="result">When the method completes, contains the newly constructed bounding sphere.</param>
+        public static void FromPoints(IList<Vector3> points, out global::SharpDX.BoundingSphere result)
+        {
+            if (points == null)
+            {
+                throw new ArgumentNullException("points");
+            }
+
+            FromPoints(points, 0, points.Count, out result);
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="BoundingSphere"/> that fully contains the given points.
+        /// </summary>
+        /// <param name="points">The points that will be contained by the sphere.</param>
+        /// <returns>The newly constructed bounding sphere.</returns>
+        public static global::SharpDX.BoundingSphere FromPoints(IList<Vector3> points)
+        {
+            global::SharpDX.BoundingSphere result;
+            FromPoints(points, out result);
+            return result;
+        }
 
         public static global::SharpDX.BoundingSphere TransformBoundingSphere(this global::SharpDX.BoundingSphere b, Matrix m)
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/CollectionExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/CollectionExtensions.cs
@@ -58,13 +58,13 @@ namespace HelixToolkit.Wpf.SharpDX.Extensions
 
         /// <summary>
         /// Gets the internal array of a <see cref="List{T}"/>.
+        /// <para>Warning: Internal array length >= List.Count. Use with cautious.</para>
         /// </summary>
         /// <typeparam name="T">The type of the elements.</typeparam>
         /// <param name="list">The respective list.</param>
         /// <returns>The internal array of the list.</returns>
         public static T[] GetInternalArray<T>(this List<T> list)
         {
-            list.TrimExcess(); //Trim capacity before exposing underlying array.
             return ArrayAccessor<T>.Getter(list);
         }
 #endif

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\Polygon3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Vector2Collection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Vector3Collection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\BoundingBoxExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\BoundingSphereExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CollectionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\Vector3DExtensions.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
@@ -38,11 +38,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             set
             {
-                if (indices != value)
+                if (Set(ref indices, value))
                 {
-                    indices = value;
-                    indicesArray = null;
-                    RaisePropertyChanged();
 #if !NETFX_CORE
                     Octree = null;
 #endif
@@ -50,21 +47,21 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        private int[] indicesArray = new int[0];
-        /// <summary>
-        /// Used to avoid excessive array copy
-        /// </summary>
-        public int[] IndicesArray
-        {
-            get
-            {
-                if (indicesArray == null)
-                {
-                    indicesArray = Indices != null ? Indices.ToArray() : new int[0];
-                }
-                return indicesArray;
-            }
-        }
+        //private int[] indicesArray = new int[0];
+        ///// <summary>
+        ///// Used to avoid excessive array copy
+        ///// </summary>
+        //public int[] IndicesArray
+        //{
+        //    get
+        //    {
+        //        if (indicesArray == null)
+        //        {
+        //            indicesArray = Indices != null ? Indices.ToArray() : new int[0];
+        //        }
+        //        return indicesArray;
+        //    }
+        //}
 
         private Vector3Collection position = null;
         public Vector3Collection Positions
@@ -75,11 +72,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             set
             {
-                if (position != value)
-                {
-                    position = value;
-                    positionArray = null;
-                    RaisePropertyChanged();                    
+                if (Set(ref position, value))
+                {                 
 #if !NETFX_CORE
                     Octree = null;
                     UpdateBounds();
@@ -88,21 +82,21 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        private Vector3[] positionArray = new Vector3[0];
-        /// <summary>
-        /// Used to avoid excessive array copy
-        /// </summary>
-        public Vector3[] PositionArray
-        {
-            get
-            {
-                if (positionArray == null)
-                {
-                    positionArray = Positions != null ? Positions.ToArray() : new Vector3[0];
-                }
-                return positionArray;
-            }
-        }
+        //private Vector3[] positionArray = new Vector3[0];
+        ///// <summary>
+        ///// Used to avoid excessive array copy
+        ///// </summary>
+        //public Vector3[] PositionArray
+        //{
+        //    get
+        //    {
+        //        if (positionArray == null)
+        //        {
+        //            positionArray = Positions != null ? Positions.ToArray() : new Vector3[0];
+        //        }
+        //        return positionArray;
+        //    }
+        //}
 
 #if !NETFX_CORE
         private BoundingBox bound;
@@ -241,8 +235,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             else
             {
-                Bound = BoundingBox.FromPoints(PositionArray);
-                BoundingSphere = BoundingSphere.FromPoints(PositionArray);
+                Bound = BoundingBoxExtensions.FromPoints(Positions);
+                BoundingSphere = BoundingSphereExtensions.FromPoints(Positions);
             }
         }
 #endif

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
@@ -38,12 +38,31 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             set
             {
-                if (Set<IntCollection>(ref indices, value))
+                if (indices != value)
                 {
+                    indices = value;
+                    indicesArray = null;
+                    RaisePropertyChanged();
 #if !NETFX_CORE
                     Octree = null;
 #endif
                 }
+            }
+        }
+
+        private int[] indicesArray = new int[0];
+        /// <summary>
+        /// Used to avoid excessive array copy
+        /// </summary>
+        public int[] IndicesArray
+        {
+            get
+            {
+                if (indicesArray == null)
+                {
+                    indicesArray = Indices != null ? Indices.ToArray() : new int[0];
+                }
+                return indicesArray;
             }
         }
 
@@ -56,13 +75,32 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             set
             {
-                if (Set(ref position, value))
+                if (position != value)
                 {
+                    position = value;
+                    positionArray = null;
+                    RaisePropertyChanged();                    
 #if !NETFX_CORE
                     Octree = null;
                     UpdateBounds();
 #endif
                 }
+            }
+        }
+
+        private Vector3[] positionArray = new Vector3[0];
+        /// <summary>
+        /// Used to avoid excessive array copy
+        /// </summary>
+        public Vector3[] PositionArray
+        {
+            get
+            {
+                if (positionArray == null)
+                {
+                    positionArray = Positions != null ? Positions.ToArray() : new Vector3[0];
+                }
+                return positionArray;
             }
         }
 
@@ -203,8 +241,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             else
             {
-                Bound = BoundingBox.FromPoints(position.Array);
-                BoundingSphere = BoundingSphere.FromPoints(position.Array);
+                Bound = BoundingBox.FromPoints(PositionArray);
+                BoundingSphere = BoundingSphere.FromPoints(PositionArray);
             }
         }
 #endif

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
@@ -132,7 +132,7 @@ namespace HelixToolkit.Wpf.SharpDX
 #if !NETFX_CORE
         protected override IOctree CreateOctree(OctreeBuildParameter parameter)
         {
-            return new MeshGeometryOctree(this.Positions, this.Indices, parameter);
+            return new MeshGeometryOctree(this.PositionArray, this.IndicesArray, parameter);
         }
 #endif
     }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
@@ -132,7 +132,7 @@ namespace HelixToolkit.Wpf.SharpDX
 #if !NETFX_CORE
         protected override IOctree CreateOctree(OctreeBuildParameter parameter)
         {
-            return new MeshGeometryOctree(this.PositionArray, this.IndicesArray, parameter);
+            return new MeshGeometryOctree(this.Positions, this.Indices, parameter);
         }
 #endif
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DeferredRenderer.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DeferredRenderer.cs
@@ -958,11 +958,11 @@ namespace HelixToolkit.Wpf.SharpDX
             MeshGeometry3D meshGeometry = mesh.ToMeshGeometry3D();
 
             var vertices = meshGeometry.Positions.Select(p => new Vector4(p, 1.0f)).ToArray();
-            var indices = meshGeometry.Indices;
+            var indices = meshGeometry.IndicesArray;
 
             this.screenSphere = new LightGeometryData()
             {
-                IndexBuffer = this.device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), indices.Array),
+                IndexBuffer = this.device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), indices),
                 VertexBuffer = this.device.CreateBuffer(BindFlags.VertexBuffer, Vector4.SizeInBytes, vertices),
                 IndexCount = meshGeometry.Indices.Count,
             };
@@ -980,11 +980,11 @@ namespace HelixToolkit.Wpf.SharpDX
             MeshGeometry3D meshGeometry = mesh.ToMeshGeometry3D();
             
             var vertices = meshGeometry.Positions.Select(p => new Vector4(p, 1.0f)).ToArray();
-            var indices = meshGeometry.Indices;
+            var indices = meshGeometry.IndicesArray;
 
             this.screenCone = new LightGeometryData()
             {
-                IndexBuffer = this.device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), indices.Array),
+                IndexBuffer = this.device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), indices),
                 VertexBuffer = this.device.CreateBuffer(BindFlags.VertexBuffer, Vector4.SizeInBytes, vertices),
                 IndexCount = meshGeometry.Indices.Count,
             };

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DeferredRenderer.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DeferredRenderer.cs
@@ -958,11 +958,10 @@ namespace HelixToolkit.Wpf.SharpDX
             MeshGeometry3D meshGeometry = mesh.ToMeshGeometry3D();
 
             var vertices = meshGeometry.Positions.Select(p => new Vector4(p, 1.0f)).ToArray();
-            var indices = meshGeometry.IndicesArray;
 
             this.screenSphere = new LightGeometryData()
             {
-                IndexBuffer = this.device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), indices),
+                IndexBuffer = this.device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), meshGeometry.Indices.Array, meshGeometry.Indices.Count),
                 VertexBuffer = this.device.CreateBuffer(BindFlags.VertexBuffer, Vector4.SizeInBytes, vertices),
                 IndexCount = meshGeometry.Indices.Count,
             };
@@ -980,11 +979,10 @@ namespace HelixToolkit.Wpf.SharpDX
             MeshGeometry3D meshGeometry = mesh.ToMeshGeometry3D();
             
             var vertices = meshGeometry.Positions.Select(p => new Vector4(p, 1.0f)).ToArray();
-            var indices = meshGeometry.IndicesArray;
 
             this.screenCone = new LightGeometryData()
             {
-                IndexBuffer = this.device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), indices),
+                IndexBuffer = this.device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), meshGeometry.Indices.Array, meshGeometry.Indices.Count),
                 VertexBuffer = this.device.CreateBuffer(BindFlags.VertexBuffer, Vector4.SizeInBytes, vertices),
                 IndexCount = meshGeometry.Indices.Count,
             };

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -203,6 +203,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Utilities\AffectsRenderPropertyMetadata.cs" />
     <Compile Include="Utilities\IOctreeManager.cs" />
     <Compile Include="Utilities\Octree.cs" />
     <Compile Include="Utilities\OctreeHelper.cs" />

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -227,18 +227,27 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="e">The event data that describes the property that changed, as well as old and new values.</param>
         protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
         {
-            // Possible improvement: Only invalidate if the property metadata has the flag "AffectsRender".
-            // => Need to change all relevant DP's metadata to FrameworkPropertyMetadata or to a new "AffectsRenderPropertyMetadata".
-            PropertyMetadata fmetadata = null;
-            if (e.Property.Name.Equals(nameof(Visibility))
-                || ((fmetadata = e.Property.GetMetadata(this)) != null
-                && (fmetadata is IAffectsRender
-                || (fmetadata is FrameworkPropertyMetadata && (fmetadata as FrameworkPropertyMetadata).AffectsRender)
-                )))
+            if (CheckAffectsRender(e))
             {
                 this.InvalidateRender();
             }
             base.OnPropertyChanged(e);
+        }
+        /// <summary>
+        /// Check if dependency property changed event affects render
+        /// </summary>
+        /// <param name="e"></param>
+        /// <returns></returns>
+        protected virtual bool CheckAffectsRender(DependencyPropertyChangedEventArgs e)
+        {            
+            // Possible improvement: Only invalidate if the property metadata has the flag "AffectsRender".
+            // => Need to change all relevant DP's metadata to FrameworkPropertyMetadata or to a new "AffectsRenderPropertyMetadata".
+            PropertyMetadata fmetadata = null;
+            return (e.Property.Name.Equals(nameof(Visibility))
+                || ((fmetadata = e.Property.GetMetadata(this)) != null
+                && (fmetadata is IAffectsRender
+                || (fmetadata is FrameworkPropertyMetadata && (fmetadata as FrameworkPropertyMetadata).AffectsRender)
+                )));
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -229,10 +229,14 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             // Possible improvement: Only invalidate if the property metadata has the flag "AffectsRender".
             // => Need to change all relevant DP's metadata to FrameworkPropertyMetadata or to a new "AffectsRenderPropertyMetadata".
-            var fmetadata = e.Property.GetMetadata(this);
-            if (fmetadata != null && (fmetadata is IAffectsRender || (fmetadata is FrameworkPropertyMetadata && (fmetadata as FrameworkPropertyMetadata).AffectsRender)))
+            PropertyMetadata fmetadata = null;
+            if (e.Property.Name.Equals(nameof(Visibility))
+                || ((fmetadata = e.Property.GetMetadata(this)) != null
+                && (fmetadata is IAffectsRender
+                || (fmetadata is FrameworkPropertyMetadata && (fmetadata as FrameworkPropertyMetadata).AffectsRender)
+                )))
             {
-                this.InvalidateRender();                
+                this.InvalidateRender();
             }
             base.OnPropertyChanged(e);
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -9,7 +9,9 @@
 
 namespace HelixToolkit.Wpf.SharpDX
 {
+    using SharpDX;
     using System;
+    using System.Diagnostics;
     using System.Windows;
     using System.Windows.Media;
 
@@ -178,7 +180,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// default is true
         /// </summary>
         public static readonly DependencyProperty IsRenderingProperty =
-            DependencyProperty.Register("IsRendering", typeof(bool), typeof(Element3D), new UIPropertyMetadata(true));
+            DependencyProperty.Register("IsRendering", typeof(bool), typeof(Element3D), new AffectsRenderPropertyMetadata(true));
 
         /// <summary>
         /// Indicates, if this element should be rendered.
@@ -225,15 +227,14 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="e">The event data that describes the property that changed, as well as old and new values.</param>
         protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
         {
-            base.OnPropertyChanged(e);
-
             // Possible improvement: Only invalidate if the property metadata has the flag "AffectsRender".
-            // => Need to change all relevant DP's metadata to FrameworkPropertyMetadata or to a new "Element3DPropertyMetadata".
-            //var fmetadata = e.Property.GetMetadata(this) as FrameworkPropertyMetadata;
-            //if (fmetadata != null && fmetadata.AffectsRender)
+            // => Need to change all relevant DP's metadata to FrameworkPropertyMetadata or to a new "AffectsRenderPropertyMetadata".
+            var fmetadata = e.Property.GetMetadata(this);
+            if (fmetadata != null && (fmetadata is IAffectsRender || (fmetadata is FrameworkPropertyMetadata && (fmetadata as FrameworkPropertyMetadata).AffectsRender)))
             {
-                this.InvalidateRender();
+                this.InvalidateRender();                
             }
+            base.OnPropertyChanged(e);
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -80,13 +80,14 @@ namespace HelixToolkit.Wpf.SharpDX
                 (e.NewValue as INotifyPropertyChanged).PropertyChanged -= model.OnGeometryPropertyChangedPrivate;
                 (e.NewValue as INotifyPropertyChanged).PropertyChanged += model.OnGeometryPropertyChangedPrivate;
             }
+            model.geometryInternal = e.NewValue == null ? null : e.NewValue as Geometry3D;
             model.OnGeometryChanged(e);
         }
 
         protected virtual void OnGeometryChanged(DependencyPropertyChangedEventArgs e)
         {
-            if (this.Geometry != null && this.Geometry.Positions != null && renderHost != null)
-            {
+            if (this.geometryInternal != null && this.geometryInternal.Positions != null && renderHost != null)
+            {               
                 var host = this.renderHost;
                 this.Detach();
                 this.Attach(host);
@@ -99,11 +100,11 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 if (e.PropertyName.Equals(nameof(Geometry3D.Bound)))
                 {
-                    this.Bounds = this.Geometry != null ? this.Geometry.Bound : new BoundingBox();
+                    this.Bounds = this.geometryInternal != null ? this.geometryInternal.Bound : new BoundingBox();
                 }
                 else if (e.PropertyName.Equals(nameof(Geometry3D.BoundingSphere)))
                 {
-                    this.BoundsSphere = this.Geometry != null ? this.Geometry.BoundingSphere : new BoundingSphere();
+                    this.BoundsSphere = this.geometryInternal != null ? this.geometryInternal.BoundingSphere : new BoundingSphere();
                 }
                 OnGeometryPropertyChanged(sender, e);
             }
@@ -117,7 +118,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override void OnTransformChanged(DependencyPropertyChangedEventArgs e)
         {
             base.OnTransformChanged(e);
-            if (this.Geometry != null)
+            if (this.geometryInternal != null)
             {
                 BoundsWithTransform
                     = BoundingBox.FromPoints(Bounds.GetCorners()
@@ -130,6 +131,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 BoundsSphereWithTransform = BoundsSphere;
             }
         }
+
+        protected Geometry3D geometryInternal = null;
 
         private BoundingBox bounds;
         public BoundingBox Bounds
@@ -311,14 +314,14 @@ namespace HelixToolkit.Wpf.SharpDX
 
         /// <summary>
         /// <para>Check geometry validity.</para>
-        /// Return false if (this.Geometry == null || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0 || this.Geometry.Indices == null || this.Geometry.Indices.Count == 0)
+        /// Return false if (this.geometryInternal == null || this.geometryInternal.Positions == null || this.geometryInternal.Positions.Count == 0 || this.geometryInternal.Indices == null || this.geometryInternal.Indices.Count == 0)
         /// </summary>
         /// <returns>
         /// </returns>
         protected virtual bool CheckGeometry()
         {
-            if (this.Geometry == null || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0
-                || this.Geometry.Indices == null || this.Geometry.Indices.Count == 0)
+            if (this.geometryInternal == null || this.geometryInternal.Positions == null || this.geometryInternal.Positions.Count == 0
+                || this.geometryInternal.Indices == null || this.geometryInternal.Indices.Count == 0)
             {
                 return false;
             }
@@ -350,8 +353,8 @@ namespace HelixToolkit.Wpf.SharpDX
             base.OnAttached();
             if (Geometry != null)
             {
-                this.Bounds = this.Geometry.Bound;
-                this.BoundsSphere = this.Geometry.BoundingSphere;
+                this.Bounds = this.geometryInternal.Bound;
+                this.BoundsSphere = this.geometryInternal.BoundingSphere;
             }
             OnRasterStateChanged();
         }
@@ -367,8 +370,8 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             if (Geometry != null)
             {
-                Geometry.PropertyChanged -= OnGeometryPropertyChangedPrivate;
-                Geometry.PropertyChanged += OnGeometryPropertyChangedPrivate;
+                geometryInternal.PropertyChanged -= OnGeometryPropertyChangedPrivate;
+                geometryInternal.PropertyChanged += OnGeometryPropertyChangedPrivate;
             }
         }
 
@@ -376,7 +379,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             if (Geometry != null)
             {
-                Geometry.PropertyChanged -= OnGeometryPropertyChangedPrivate;
+                geometryInternal.PropertyChanged -= OnGeometryPropertyChangedPrivate;
             }
         }
 
@@ -457,12 +460,12 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 return false;
             }
-            if (this.IsHitTestVisible == false || this.Geometry == null)
+            if (this.IsHitTestVisible == false || this.geometryInternal == null)
             {
                 return false;
             }
 
-            var g = this.Geometry as MeshGeometry3D;
+            var g = this.geometryInternal as MeshGeometry3D;
             bool isHit = false;
 
             if (g.Octree != null)
@@ -533,7 +536,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
             var result = new HitTestResult();
             result.Distance = double.MaxValue;
-            var g = this.Geometry as MeshGeometry3D;
+            var g = this.geometryInternal as MeshGeometry3D;
             var h = false;
 
             if (g != null)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -66,7 +66,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty GeometryProperty =
-            DependencyProperty.Register("Geometry", typeof(Geometry3D), typeof(GeometryModel3D), new UIPropertyMetadata(GeometryChanged));
+            DependencyProperty.Register("Geometry", typeof(Geometry3D), typeof(GeometryModel3D), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, GeometryChanged));
 
         protected static void GeometryChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -209,7 +209,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty DepthBiasProperty =
-            DependencyProperty.Register("DepthBias", typeof(int), typeof(GeometryModel3D), new UIPropertyMetadata(0, RasterStateChanged));
+            DependencyProperty.Register("DepthBias", typeof(int), typeof(GeometryModel3D), new FrameworkPropertyMetadata(0, FrameworkPropertyMetadataOptions.AffectsRender, RasterStateChanged));
 
         protected static void RasterStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -243,16 +243,16 @@ namespace HelixToolkit.Wpf.SharpDX
         public event BoundSphereChangedEventHandler OnTransformBoundSphereChanged;
 
         public static readonly DependencyProperty IsSelectedProperty =
-            DependencyProperty.Register("IsSelected", typeof(bool), typeof(DraggableGeometryModel3D), new UIPropertyMetadata(false));
+            DependencyProperty.Register("IsSelected", typeof(bool), typeof(DraggableGeometryModel3D), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.AffectsRender));
 
         public static readonly DependencyProperty IsMultisampleEnabledProperty =
-            DependencyProperty.Register("IsMultisampleEnabled", typeof(bool), typeof(GeometryModel3D), new UIPropertyMetadata(true, RasterStateChanged));
+            DependencyProperty.Register("IsMultisampleEnabled", typeof(bool), typeof(GeometryModel3D), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsRender, RasterStateChanged));
 
         public static readonly DependencyProperty FillModeProperty = DependencyProperty.Register("FillMode", typeof(FillMode), typeof(GeometryModel3D),
-            new PropertyMetadata(FillMode.Solid, RasterStateChanged));
+            new FrameworkPropertyMetadata(FillMode.Solid, FrameworkPropertyMetadataOptions.AffectsRender, RasterStateChanged));
 
         public static readonly DependencyProperty IsScissorEnabledProperty =
-            DependencyProperty.Register("IsScissorEnabled", typeof(bool), typeof(GeometryModel3D), new UIPropertyMetadata(true, RasterStateChanged));
+            DependencyProperty.Register("IsScissorEnabled", typeof(bool), typeof(GeometryModel3D), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsRender, RasterStateChanged));
 
         /// <summary>
         /// Provide CLR accessors for the event 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -20,7 +20,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty ChildrenProperty =
-            DependencyProperty.Register("Children", typeof(Element3DCollection), typeof(GroupElement3D), new UIPropertyMetadata(new Element3DCollection()));
+            DependencyProperty.Register("Children", typeof(Element3DCollection), typeof(GroupElement3D), new FrameworkPropertyMetadata(new Element3DCollection(), FrameworkPropertyMetadataOptions.AffectsRender));
 
         public GroupElement3D()
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
@@ -243,7 +243,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     var b = this.Bounds;
                     this.PushMatrix(modelMatrix);
-                    this.Bounds = BoundingBox.FromPoints(this.Geometry.Positions.Select(x => Vector3.TransformCoordinate(x, this.modelMatrix)).ToArray());
+                    this.Bounds = BoundingBox.FromPoints(this.geometryInternal.Positions.Select(x => Vector3.TransformCoordinate(x, this.modelMatrix)).ToArray());
                     if (base.HitTest(context, rayWS, ref hits))
                     {
                         hit = true;
@@ -325,7 +325,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     // --- has bumpmap
                     if (material.NormalMap != null && model.RenderNormalMap)
                     {
-                        var geometry = model.Geometry as MeshGeometry3D;
+                        var geometry = model.geometryInternal as MeshGeometry3D;
                         if (geometry != null)
                         {
                             if (geometry.Tangents == null)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
@@ -50,7 +50,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty RenderDiffuseMapProperty =
-            DependencyProperty.Register("RenderDiffuseMap", typeof(bool), typeof(MaterialGeometryModel3D), new UIPropertyMetadata(true));
+            DependencyProperty.Register("RenderDiffuseMap", typeof(bool), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         /// 
@@ -65,7 +65,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty RenderAlphaDiffuseMapProperty =
-            DependencyProperty.Register("RenderAlphaDiffuseMap", typeof(bool), typeof(MaterialGeometryModel3D), new UIPropertyMetadata(true));
+            DependencyProperty.Register("RenderAlphaDiffuseMap", typeof(bool), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         /// 
@@ -79,7 +79,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty RenderNormalMapProperty =
-            DependencyProperty.Register("RenderNormalMap", typeof(bool), typeof(MaterialGeometryModel3D), new UIPropertyMetadata(true));
+            DependencyProperty.Register("RenderNormalMap", typeof(bool), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         /// 
@@ -94,7 +94,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty RenderDisplacementMapProperty =
-            DependencyProperty.Register("RenderDisplacementMap", typeof(bool), typeof(MaterialGeometryModel3D), new UIPropertyMetadata(true));
+            DependencyProperty.Register("RenderDisplacementMap", typeof(bool), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         /// 
@@ -109,7 +109,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty MaterialProperty =
-            DependencyProperty.Register("Material", typeof(Material), typeof(MaterialGeometryModel3D), new UIPropertyMetadata(MaterialChanged));
+            DependencyProperty.Register("Material", typeof(Material), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, MaterialChanged));
 
         /// <summary>
         /// 
@@ -141,7 +141,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// List of instance matrix.
         /// </summary>
         public static readonly DependencyProperty InstancesProperty =
-            DependencyProperty.Register("Instances", typeof(IList<Matrix>), typeof(MaterialGeometryModel3D), new UIPropertyMetadata(null, InstancesChanged));
+            DependencyProperty.Register("Instances", typeof(IList<Matrix>), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, InstancesChanged));
 
         /// <summary>
         /// 
@@ -157,7 +157,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty TextureCoodScaleProperty =
-            DependencyProperty.Register("TextureCoodScale", typeof(Vector2), typeof(MaterialGeometryModel3D), new UIPropertyMetadata(new Vector2(1, 1)));
+            DependencyProperty.Register("TextureCoodScale", typeof(Vector2), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(new Vector2(1, 1), FrameworkPropertyMetadataOptions.AffectsRender));
 
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Model3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Model3D.cs
@@ -62,7 +62,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty TransformProperty =
-            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(Model3D), new FrameworkPropertyMetadata(Transform3D.Identity, TransformPropertyChanged));
+            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(Model3D), new FrameworkPropertyMetadata(Transform3D.Identity, FrameworkPropertyMetadataOptions.AffectsRender, TransformPropertyChanged));
 
         protected static void TransformPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -430,7 +430,7 @@ namespace HelixToolkit.Wpf.SharpDX
             billboardType = billboardGeometry.Type;
             billboardGeometry.DrawTexture();
 
-            var position = billboardGeometry.Positions.Array;
+            var position = billboardGeometry.Positions;
             var vertexCount = billboardGeometry.Positions.Count;
             if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
                 vertexArrayBuffer = new BillboardVertex[vertexCount];

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -30,7 +30,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <para>When FixedSize = false, the billboard render size will be actual size in 3D world space</para>
         /// </summary>
         public static readonly DependencyProperty FixedSizeProperty = DependencyProperty.Register("FixedSize", typeof(bool), typeof(BillboardTextModel3D),
-            new PropertyMetadata(true, (d, e) => { (d as Element3D).InvalidateRender(); }));
+            new AffectsRenderPropertyMetadata(true));
 
         /// <summary>
         /// Fixed sized billboard. Default = true. 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -74,7 +74,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 return false;
             }
 
-            var g = this.Geometry as IBillboardText;
+            var g = this.geometryInternal as IBillboardText;
             var h = false;
             var result = new HitTestResult();
             result.Distance = double.MaxValue;
@@ -239,7 +239,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         protected override bool CheckGeometry()
         {
-            return Geometry is IBillboardText;
+            return geometryInternal is IBillboardText;
         }
 
         protected override void OnRasterStateChanged()
@@ -288,7 +288,7 @@ namespace HelixToolkit.Wpf.SharpDX
             vViewport = effect.GetVariableByName("vViewport").AsVector();
             bFixedSizeVariable = effect.GetVariableByName("bBillboardFixedSize").AsScalar();
             // --- get geometry
-            var geometry = Geometry as IBillboardText;
+            var geometry = geometryInternal as IBillboardText;
             if (geometry == null)
             {
                 throw new System.Exception("Geometry must implement IBillboardText");
@@ -337,7 +337,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override void OnRender(RenderContext renderContext)
         {
             // --- check to render the model
-            var geometry = Geometry as IBillboardText;
+            var geometry = geometryInternal as IBillboardText;
             if (geometry == null)
             {
                 throw new System.Exception("Geometry must implement IBillboardText");
@@ -381,7 +381,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 billboardAlphaTextureVariable.SetResource(billboardAlphaTextureView);
             }
 
-            var vertexCount = Geometry.Positions.Count;
+            var vertexCount = geometryInternal.Positions.Count;
             switch (billboardType)
             {
                 case BillboardType.MultipleText:

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
@@ -128,7 +128,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             if (this.hasBoneParameter)
             {
-                if (isBoneParamChanged && this.VertexBoneIds.Count >= Geometry.Positions.Count)
+                if (isBoneParamChanged && this.VertexBoneIds.Count >= geometryInternal.Positions.Count)
                 {
                     if (vertexBoneParamsBuffer == null || this.vertexBoneParamsBuffer.Description.SizeInBytes < BoneIds.SizeInBytes * this.VertexBoneIds.Count)
                     {
@@ -175,7 +175,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 // --- render the geometry
                 this.effectTechnique.GetPassByIndex(0).Apply(renderContext.DeviceContext);
                 // --- draw              
-                renderContext.DeviceContext.DrawIndexedInstanced(this.Geometry.Indices.Count, this.Instances.Count, 0, 0, 0);
+                renderContext.DeviceContext.DrawIndexedInstanced(this.geometryInternal.Indices.Count, this.Instances.Count, 0, 0, 0);
                 this.bHasInstances.Set(false);
             }
             else
@@ -187,7 +187,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 var pass = this.effectTechnique.GetPassByIndex(0);
                 pass.Apply(renderContext.DeviceContext);
                 // --- draw
-                renderContext.DeviceContext.DrawIndexed(this.Geometry.Indices.Count, 0, 0);
+                renderContext.DeviceContext.DrawIndexed(this.geometryInternal.Indices.Count, 0, 0);
             }
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
@@ -14,7 +14,7 @@ namespace HelixToolkit.Wpf.SharpDX
     public class BoneSkinMeshGeometryModel3D : MeshGeometryModel3D
     {
         public static DependencyProperty VertexBoneIdsProperty = DependencyProperty.Register("VertexBoneIds", typeof(IList<BoneIds>), typeof(BoneSkinMeshGeometryModel3D), 
-            new PropertyMetadata(null, (d,e)=>
+            new AffectsRenderPropertyMetadata(null, (d,e)=>
             {
                 (d as BoneSkinMeshGeometryModel3D).OnBoneParameterChanged();
             }));
@@ -32,10 +32,11 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static DependencyProperty BoneMatricesProperty = DependencyProperty.Register("BoneMatrices", typeof(BoneMatricesStruct), typeof(BoneSkinMeshGeometryModel3D),
-            new PropertyMetadata(new BoneMatricesStruct() { Bones = new Matrix[BoneMatricesStruct.NumberOfBones] }, (d, e) =>
-            {
-                (d as BoneSkinMeshGeometryModel3D).OnBoneMatricesChanged();
-            }));
+            new AffectsRenderPropertyMetadata(new BoneMatricesStruct() { Bones = new Matrix[BoneMatricesStruct.NumberOfBones] }, 
+                (d, e) =>
+                {
+                    (d as BoneSkinMeshGeometryModel3D).OnBoneMatricesChanged();
+                }));
 
         public BoneMatricesStruct BoneMatrices
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/DraggableGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/DraggableGeometryModel3D.cs
@@ -26,13 +26,13 @@ namespace HelixToolkit.Wpf.SharpDX
         private MatrixTransform3D dragTransform;
 
         public static readonly DependencyProperty DragXProperty =
-            DependencyProperty.Register("DragX", typeof(bool), typeof(DraggableGeometryModel3D), new UIPropertyMetadata(true));
+            DependencyProperty.Register("DragX", typeof(bool), typeof(DraggableGeometryModel3D), new AffectsRenderPropertyMetadata(true));
 
         public static readonly DependencyProperty DragYProperty =
-            DependencyProperty.Register("DragY", typeof(bool), typeof(DraggableGeometryModel3D), new UIPropertyMetadata(true));
+            DependencyProperty.Register("DragY", typeof(bool), typeof(DraggableGeometryModel3D), new AffectsRenderPropertyMetadata(true));
 
         public static readonly DependencyProperty DragZProperty =
-            DependencyProperty.Register("DragZ", typeof(bool), typeof(DraggableGeometryModel3D), new UIPropertyMetadata(true));
+            DependencyProperty.Register("DragZ", typeof(bool), typeof(DraggableGeometryModel3D), new AffectsRenderPropertyMetadata(true));
 
 
         public bool DragX

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
@@ -114,7 +114,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, CubeVertex.SizeInBytes, this.geometry.Positions.Select((x, ii) => new CubeVertex() { Position = new Vector4(x, 1f) }).ToArray());
 
                 // --- set up index buffer
-                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.Indices.Array);
+                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.IndicesArray);
 
                 // --- set up rasterizer states
                 var rasterStateDesc = new RasterizerStateDescription()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
@@ -114,7 +114,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, CubeVertex.SizeInBytes, this.geometry.Positions.Select((x, ii) => new CubeVertex() { Position = new Vector4(x, 1f) }).ToArray());
 
                 // --- set up index buffer
-                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.IndicesArray);
+                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.Indices.Array, geometry.Indices.Count);
 
                 // --- set up rasterizer states
                 var rasterStateDesc = new RasterizerStateDescription()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMapModel3D.cs
@@ -43,7 +43,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty FilenameProperty =
-            DependencyProperty.Register("Filename", typeof(string), typeof(EnvironmentMap3D), new UIPropertyMetadata(null));
+            DependencyProperty.Register("Filename", typeof(string), typeof(EnvironmentMap3D), new AffectsRenderPropertyMetadata(null));
 
         /// <summary>
         /// Gets or sets the current environment map texture image
@@ -61,7 +61,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// default is true.
         /// </summary>
         public static readonly DependencyProperty IsActiveProperty =
-            DependencyProperty.Register("IsActive", typeof(bool), typeof(Element3D), new UIPropertyMetadata(true, IsActiveChanged));
+            DependencyProperty.Register("IsActive", typeof(bool), typeof(Element3D), new AffectsRenderPropertyMetadata(true, IsActiveChanged));
 
         /// <summary>
         /// Indicates, if this element is active, if not, the model will be not 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
@@ -42,7 +42,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty TransformProperty =
-            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(GroupModel3D), new UIPropertyMetadata(Transform3D.Identity, TransformPropertyChanged));
+            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(GroupModel3D), new FrameworkPropertyMetadata(Transform3D.Identity, FrameworkPropertyMetadataOptions.AffectsRender, TransformPropertyChanged));
 
         private static void TransformPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
@@ -353,7 +353,7 @@ namespace HelixToolkit.Wpf.SharpDX
             billboardType = billboardGeometry.Type;
             billboardGeometry.DrawTexture();
 
-            var position = billboardGeometry.Positions.Array;
+            var position = billboardGeometry.Positions;
             var vertexCount = billboardGeometry.Positions.Count;
             if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
                 vertexArrayBuffer = new BillboardVertex[vertexCount];

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
@@ -36,7 +36,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// List of instance parameter. 
         /// </summary>
         public static readonly DependencyProperty InstanceAdvArrayProperty =
-            DependencyProperty.Register("InstanceParamArray", typeof(IList<BillboardInstanceParameter>), typeof(InstancingBillboardModel3D), new UIPropertyMetadata(null, InstancesParamChanged));
+            DependencyProperty.Register("InstanceParamArray", typeof(IList<BillboardInstanceParameter>), typeof(InstancingBillboardModel3D), 
+                new AffectsRenderPropertyMetadata(null, InstancesParamChanged));
         /// <summary>
         /// List of instance parameters. 
         /// </summary>
@@ -64,7 +65,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <para>When FixedSize = false, the billboard render size will be actual size in 3D world space</para>
         /// </summary>
         public static readonly DependencyProperty FixedSizeProperty = DependencyProperty.Register("FixedSize", typeof(bool), typeof(InstancingBillboardModel3D),
-            new PropertyMetadata(true, (d, e) => { (d as Element3D).InvalidateRender(); }));
+            new AffectsRenderPropertyMetadata(true));
 
         /// <summary>
         /// Fixed sized billboard. Default = true. 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
@@ -111,7 +111,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         protected override bool CheckGeometry()
         {
-            return Geometry is IBillboardText;
+            return geometryInternal is IBillboardText;
         }
 
         protected override void OnRasterStateChanged()
@@ -161,7 +161,7 @@ namespace HelixToolkit.Wpf.SharpDX
             vViewport = effect.GetVariableByName("vViewport").AsVector();
 
             // --- get geometry
-            var geometry = Geometry as IBillboardText;
+            var geometry = geometryInternal as IBillboardText;
             if (geometry == null)
             {
                 throw new System.Exception("Geometry must implement IBillboardText");
@@ -226,7 +226,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override void OnRender(RenderContext renderContext)
         {
             // --- check to render the model
-            var geometry = Geometry as IBillboardText;
+            var geometry = geometryInternal as IBillboardText;
             if (geometry == null)
             {
                 throw new System.Exception("Geometry must implement IBillboardText");
@@ -262,7 +262,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 billboardAlphaTextureVariable.SetResource(billboardAlphaTextureView);
             }
-            var vertexCount = Geometry.Positions.Count;
+            var vertexCount = geometryInternal.Positions.Count;
             if (this.hasInstances)
             {
                 if (this.isInstanceChanged)
@@ -346,7 +346,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private BillboardVertex[] CreateBillboardVertexArray()
         {
-            var billboardGeometry = Geometry as IBillboardText;
+            var billboardGeometry = geometryInternal as IBillboardText;
 
             // Gather all of the textInfo offsets.
             // These should be equal in number to the positions.

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
@@ -182,7 +182,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 // --- render the geometry
                 this.effectTechnique.GetPassByIndex(0).Apply(renderContext.DeviceContext);
                 // --- draw
-                renderContext.DeviceContext.DrawIndexedInstanced(this.Geometry.Indices.Count, this.Instances.Count, 0, 0, 0);
+                renderContext.DeviceContext.DrawIndexedInstanced(this.geometryInternal.Indices.Count, this.Instances.Count, 0, 0, 0);
             }
             this.bHasInstances.Set(false);
             this.hasInstanceParamVar.Set(false);
@@ -233,7 +233,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 isHit = OctreeManager.Octree.HitTest(context, this, ModelMatrix, rayWS, ref boundHits);
                 if (isHit)
                 {
-                    var g = this.Geometry as MeshGeometry3D;
+                    var g = this.geometryInternal as MeshGeometry3D;
                     isHit = false;
                     Matrix instanceMatrix;
                     if (g.Octree != null)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
@@ -78,7 +78,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// List of instance parameter. 
         /// </summary>
         public static readonly DependencyProperty InstanceAdvArrayProperty =
-            DependencyProperty.Register("InstanceParamArray", typeof(IList<InstanceParameter>), typeof(InstancingMeshGeometryModel3D), new UIPropertyMetadata(null, InstancesParamChanged));
+            DependencyProperty.Register("InstanceParamArray", typeof(IList<InstanceParameter>), typeof(InstancingMeshGeometryModel3D), 
+                new AffectsRenderPropertyMetadata(null, InstancesParamChanged));
 
 
         private static void InstancesParamChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
@@ -37,7 +37,7 @@ namespace HelixToolkit.Wpf.SharpDX
         ///     The item template property
         /// </summary>
         public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register(
-            "ItemTemplate", typeof(DataTemplate), typeof(ItemsModel3D), new PropertyMetadata(null));
+            "ItemTemplate", typeof(DataTemplate), typeof(ItemsModel3D), new AffectsRenderPropertyMetadata(null));
 
         /// <summary>
         ///     The items source property
@@ -46,7 +46,7 @@ namespace HelixToolkit.Wpf.SharpDX
             "ItemsSource",
             typeof(IEnumerable),
             typeof(ItemsModel3D),
-            new PropertyMetadata(null, (s, e) => ((ItemsModel3D)s).ItemsSourceChanged(e)));
+            new AffectsRenderPropertyMetadata(null, (s, e) => ((ItemsModel3D)s).ItemsSourceChanged(e)));
 
         /// <summary>
         /// Add octree manager to use octree hit test.

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -209,7 +209,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 else if (e.PropertyName.Equals(nameof(LineGeometry3D.Indices)) || e.PropertyName.Equals(Geometry3D.TriangleBuffer))
                 {
                     Disposer.RemoveAndDispose(ref this.indexBuffer);
-                    this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.IndicesArray);
+                    this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array, Geometry.Indices.Count);
                     InvalidateRender();
                 }
                 else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
@@ -274,7 +274,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 // --- set up buffers            
                 CreateVertexBuffer();
                 // --- set up indexbuffer
-                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.IndicesArray);
+                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.Indices.Array, geometry.Indices.Count);
             }
             else
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -63,7 +63,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty ColorProperty =
-            DependencyProperty.Register("Color", typeof(Color), typeof(LineGeometryModel3D), new UIPropertyMetadata(Color.Black, (o, e) => ((LineGeometryModel3D)o).OnColorChanged()));
+            DependencyProperty.Register("Color", typeof(Color), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(Color.Black, (o, e) => ((LineGeometryModel3D)o).OnColorChanged()));
 
         public double Thickness
         {
@@ -72,7 +72,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty ThicknessProperty =
-            DependencyProperty.Register("Thickness", typeof(double), typeof(LineGeometryModel3D), new UIPropertyMetadata(1.0));
+            DependencyProperty.Register("Thickness", typeof(double), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(1.0));
 
         public double Smoothness
         {
@@ -81,7 +81,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty SmoothnessProperty =
-            DependencyProperty.Register("Smoothness", typeof(double), typeof(LineGeometryModel3D), new UIPropertyMetadata(0.0));
+            DependencyProperty.Register("Smoothness", typeof(double), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(0.0));
 
         public IList<Matrix> Instances
         {
@@ -90,7 +90,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty InstancesProperty =
-            DependencyProperty.Register("Instances", typeof(IList<Matrix>), typeof(LineGeometryModel3D), new UIPropertyMetadata(null, InstancesChanged));
+            DependencyProperty.Register("Instances", typeof(IList<Matrix>), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(null, InstancesChanged));
 
         public double HitTestThickness
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -209,7 +209,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 else if (e.PropertyName.Equals(nameof(LineGeometry3D.Indices)) || e.PropertyName.Equals(Geometry3D.TriangleBuffer))
                 {
                     Disposer.RemoveAndDispose(ref this.indexBuffer);
-                    this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array);
+                    this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.IndicesArray);
                     InvalidateRender();
                 }
                 else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
@@ -274,7 +274,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 // --- set up buffers            
                 CreateVertexBuffer();
                 // --- set up indexbuffer
-                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.Indices.Array);
+                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.IndicesArray);
             }
             else
             {
@@ -447,7 +447,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         private LinesVertex[] CreateLinesVertexArray()
         {
-            var positions = this.Geometry.Positions.Array;
+            var positions = this.Geometry.Positions;
             var vertexCount = this.Geometry.Positions.Count;
             var color = this.Color;
             if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -115,7 +115,7 @@ namespace HelixToolkit.Wpf.SharpDX
             if (this.Visibility == Visibility.Collapsed ||
                 this.IsHitTestVisible == false ||
                 context == null ||
-                (lineGeometry3D = this.Geometry as LineGeometry3D) == null)
+                (lineGeometry3D = this.geometryInternal as LineGeometry3D) == null)
             {
                 return false;
             }
@@ -209,7 +209,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 else if (e.PropertyName.Equals(nameof(LineGeometry3D.Indices)) || e.PropertyName.Equals(Geometry3D.TriangleBuffer))
                 {
                     Disposer.RemoveAndDispose(ref this.indexBuffer);
-                    this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array, Geometry.Indices.Count);
+                    this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.geometryInternal.Indices.Array, geometryInternal.Indices.Count);
                     InvalidateRender();
                 }
                 else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
@@ -229,7 +229,7 @@ namespace HelixToolkit.Wpf.SharpDX
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CreateVertexBuffer()
         {
-            var geometry = Geometry as LineGeometry3D;
+            var geometry = geometryInternal as LineGeometry3D;
             if (geometry != null && geometry.Positions != null)
             {
                 Disposer.RemoveAndDispose(ref vertexBuffer);
@@ -266,7 +266,7 @@ namespace HelixToolkit.Wpf.SharpDX
             effectTransforms = new EffectTransformVariables(effect);
             
             // --- get geometry
-            var geometry = Geometry as LineGeometry3D;
+            var geometry = geometryInternal as LineGeometry3D;
 
             // -- set geometry if given
             if (geometry != null)
@@ -419,7 +419,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 for (int i = 0; i < this.effectTechnique.Description.PassCount; i++)
                 {
                     this.effectTechnique.GetPassByIndex(i).Apply(renderContext.DeviceContext);
-                    renderContext.DeviceContext.DrawIndexedInstanced(this.Geometry.Indices.Count, this.Instances.Count, 0, 0, 0);
+                    renderContext.DeviceContext.DrawIndexedInstanced(this.geometryInternal.Indices.Count, this.Instances.Count, 0, 0, 0);
                 }
                 this.bHasInstances.Set(false);
             }
@@ -430,7 +430,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 // --- render the geometry
                 this.effectTechnique.GetPassByIndex(0).Apply(renderContext.DeviceContext);
-                renderContext.DeviceContext.DrawIndexed(this.Geometry.Indices.Count, 0, 0);
+                renderContext.DeviceContext.DrawIndexed(this.geometryInternal.Indices.Count, 0, 0);
             }
         }
 
@@ -447,15 +447,15 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         private LinesVertex[] CreateLinesVertexArray()
         {
-            var positions = this.Geometry.Positions;
-            var vertexCount = this.Geometry.Positions.Count;
+            var positions = this.geometryInternal.Positions;
+            var vertexCount = this.geometryInternal.Positions.Count;
             var color = this.Color;
             if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
                 vertexArrayBuffer = new LinesVertex[vertexCount];
 
-            if (this.Geometry.Colors != null && this.Geometry.Colors.Any())
+            if (this.geometryInternal.Colors != null && this.geometryInternal.Colors.Any())
             {
-                var colors = this.Geometry.Colors;
+                var colors = this.geometryInternal.Colors;
 
                 for (var i = 0; i < vertexCount; i++)
                 {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -135,7 +135,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 else if (e.PropertyName.Equals(nameof(MeshGeometry3D.Indices)) || e.PropertyName.Equals(Geometry3D.TriangleBuffer))
                 {
                     Disposer.RemoveAndDispose(ref this.indexBuffer);
-                    this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array);
+                    if (this.Geometry.IndicesArray != null && this.Geometry.IndicesArray.Length > 0)
+                    { this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.IndicesArray); }
                     InvalidateRender();
                 }
                 else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
@@ -182,7 +183,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 CreateVertexBuffer(CreateDefaultVertexArray);
                 Disposer.RemoveAndDispose(ref this.indexBuffer);
                 // --- init index buffer
-                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array);
+                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.IndicesArray);
             }
             else
             {
@@ -329,13 +330,13 @@ namespace HelixToolkit.Wpf.SharpDX
         private DefaultVertex[] CreateDefaultVertexArray()
         {
             var geometry = (MeshGeometry3D)this.Geometry;
-            var colors = geometry.Colors != null ? geometry.Colors.Array : null;
-            var textureCoordinates = geometry.TextureCoordinates != null ? geometry.TextureCoordinates.Array : null;
+            var colors = geometry.Colors != null ? geometry.Colors : null;
+            var textureCoordinates = geometry.TextureCoordinates != null ? geometry.TextureCoordinates : null;
             var texScale = this.TextureCoodScale;
-            var normals = geometry.Normals != null ? geometry.Normals.Array : null;
-            var tangents = geometry.Tangents != null ? geometry.Tangents.Array : null;
-            var bitangents = geometry.BiTangents != null ? geometry.BiTangents.Array : null;
-            var positions = geometry.Positions.Array;
+            var normals = geometry.Normals != null ? geometry.Normals : null;
+            var tangents = geometry.Tangents != null ? geometry.Tangents : null;
+            var bitangents = geometry.BiTangents != null ? geometry.BiTangents : null;
+            var positions = geometry.Positions;
             var vertexCount = geometry.Positions.Count;
             if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
                 vertexArrayBuffer = new DefaultVertex[vertexCount];
@@ -384,10 +385,10 @@ namespace HelixToolkit.Wpf.SharpDX
             var vertexCount = geometry.Positions.Count;
             if (vertexArrayBuffer != null && vertexArrayBuffer.Length >= vertexCount)
             {
-                var positions = geometry.Positions.Array;
-                var normals = geometry.Normals != null ? geometry.Normals.Array : null;
-                var tangents = geometry.Tangents != null ? geometry.Tangents.Array : null;
-                var bitangents = geometry.BiTangents != null ? geometry.BiTangents.Array : null;
+                var positions = geometry.Positions;
+                var normals = geometry.Normals != null ? geometry.Normals : null;
+                var tangents = geometry.Tangents != null ? geometry.Tangents : null;
+                var bitangents = geometry.BiTangents != null ? geometry.BiTangents : null;
                 for (int i = 0; i < vertexCount; ++i)
                 {
                     vertexArrayBuffer[i].Position = new Vector4(positions[i], 1f);

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -135,8 +135,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 else if (e.PropertyName.Equals(nameof(MeshGeometry3D.Indices)) || e.PropertyName.Equals(Geometry3D.TriangleBuffer))
                 {
                     Disposer.RemoveAndDispose(ref this.indexBuffer);
-                    if (this.Geometry.IndicesArray != null && this.Geometry.IndicesArray.Length > 0)
-                    { this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.IndicesArray); }
+                    if (this.Geometry.Indices != null && this.Geometry.Indices.Count > 0)
+                    { this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array, this.Geometry.Indices.Count); }
                     InvalidateRender();
                 }
                 else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
@@ -183,7 +183,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 CreateVertexBuffer(CreateDefaultVertexArray);
                 Disposer.RemoveAndDispose(ref this.indexBuffer);
                 // --- init index buffer
-                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.IndicesArray);
+                this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometry.Indices.Array, geometry.Indices.Count);
             }
             else
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -135,8 +135,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 else if (e.PropertyName.Equals(nameof(MeshGeometry3D.Indices)) || e.PropertyName.Equals(Geometry3D.TriangleBuffer))
                 {
                     Disposer.RemoveAndDispose(ref this.indexBuffer);
-                    if (this.Geometry.Indices != null && this.Geometry.Indices.Count > 0)
-                    { this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.Geometry.Indices.Array, this.Geometry.Indices.Count); }
+                    if (this.geometryInternal.Indices != null && this.geometryInternal.Indices.Count > 0)
+                    { this.indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), this.geometryInternal.Indices.Array, this.geometryInternal.Indices.Count); }
                     InvalidateRender();
                 }
                 else if (e.PropertyName.Equals(Geometry3D.VertexBuffer))
@@ -172,7 +172,7 @@ namespace HelixToolkit.Wpf.SharpDX
             var texScale = TextureCoodScale;
 
             // --- get geometry
-            var geometry = this.Geometry as MeshGeometry3D;
+            var geometry = this.geometryInternal as MeshGeometry3D;
 
             // -- set geometry if given
             if (geometry != null)
@@ -208,7 +208,7 @@ namespace HelixToolkit.Wpf.SharpDX
         private void CreateVertexBuffer(Func<DefaultVertex[]> updateFunction)
         {
             // --- get geometry
-            var geometry = this.Geometry as MeshGeometry3D;
+            var geometry = this.geometryInternal as MeshGeometry3D;
 
             // -- set geometry if given
             if (geometry != null && geometry.Positions != null)
@@ -300,7 +300,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 // --- render the geometry
                 this.effectTechnique.GetPassByIndex(0).Apply(renderContext.DeviceContext);
                 // --- draw
-                renderContext.DeviceContext.DrawIndexedInstanced(this.Geometry.Indices.Count, this.Instances.Count, 0, 0, 0);
+                renderContext.DeviceContext.DrawIndexedInstanced(this.geometryInternal.Indices.Count, this.Instances.Count, 0, 0, 0);
                 this.bHasInstances.Set(false);
             }
             else
@@ -312,7 +312,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 var pass = this.effectTechnique.GetPassByIndex(0);
                 pass.Apply(renderContext.DeviceContext);
                 // --- draw
-                renderContext.DeviceContext.DrawIndexed(this.Geometry.Indices.Count, 0, 0);
+                renderContext.DeviceContext.DrawIndexed(this.geometryInternal.Indices.Count, 0, 0);
             }
         }
 
@@ -329,7 +329,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         private DefaultVertex[] CreateDefaultVertexArray()
         {
-            var geometry = (MeshGeometry3D)this.Geometry;
+            var geometry = (MeshGeometry3D)this.geometryInternal;
             var colors = geometry.Colors != null ? geometry.Colors : null;
             var textureCoordinates = geometry.TextureCoordinates != null ? geometry.TextureCoordinates : null;
             var texScale = this.TextureCoodScale;
@@ -356,7 +356,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private DefaultVertex[] UpdateTextureOnly()
         {
-            var geometry = (MeshGeometry3D)this.Geometry;
+            var geometry = (MeshGeometry3D)this.geometryInternal;
             var vertexCount = geometry.Positions.Count;
             if (vertexArrayBuffer != null && geometry.TextureCoordinates != null && vertexArrayBuffer.Length >= vertexCount)
             {
@@ -381,7 +381,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private DefaultVertex[] UpdatePositionOnly()
         {
-            var geometry = (MeshGeometry3D)this.Geometry;
+            var geometry = (MeshGeometry3D)this.geometryInternal;
             var vertexCount = geometry.Positions.Count;
             if (vertexArrayBuffer != null && vertexArrayBuffer.Length >= vertexCount)
             {
@@ -402,15 +402,14 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private DefaultVertex[] UpdateColorsOnly()
         {
-            var geometry = (MeshGeometry3D)this.Geometry;
-            var vertexCount = geometry.Positions.Count;
-            if (vertexArrayBuffer != null && geometry.Colors != null && vertexArrayBuffer.Length >= vertexCount)
+            var vertexCount = geometryInternal.Positions.Count;
+            if (vertexArrayBuffer != null && geometryInternal.Colors != null && vertexArrayBuffer.Length >= vertexCount)
             {
-                if (geometry.Colors != null && geometry.Colors.Count == vertexCount)
+                if (geometryInternal.Colors != null && geometryInternal.Colors.Count == vertexCount)
                 {
                     for (int i = 0; i < vertexCount; ++i)
                     {
-                        vertexArrayBuffer[i].Color = geometry.Colors[i];
+                        vertexArrayBuffer[i].Color = geometryInternal.Colors[i];
                     }
                 }
                 else

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -30,7 +30,8 @@ namespace HelixToolkit.Wpf.SharpDX
 
     public class MeshGeometryModel3D : MaterialGeometryModel3D
     {
-        public static readonly DependencyProperty FrontCounterClockwiseProperty = DependencyProperty.Register("FrontCounterClockwise", typeof(bool), typeof(MeshGeometryModel3D), new PropertyMetadata(true, RasterStateChanged));
+        public static readonly DependencyProperty FrontCounterClockwiseProperty = DependencyProperty.Register("FrontCounterClockwise", typeof(bool), typeof(MeshGeometryModel3D),
+            new AffectsRenderPropertyMetadata(true, RasterStateChanged));
 
         public bool FrontCounterClockwise
         {
@@ -44,7 +45,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public static readonly DependencyProperty CullModeProperty = DependencyProperty.Register("CullMode", typeof(CullMode), typeof(MeshGeometryModel3D), new PropertyMetadata(CullMode.None, RasterStateChanged));
+        public static readonly DependencyProperty CullModeProperty = DependencyProperty.Register("CullMode", typeof(CullMode), typeof(MeshGeometryModel3D), 
+            new AffectsRenderPropertyMetadata(CullMode.None, RasterStateChanged));
 
         public CullMode CullMode
         {
@@ -58,7 +60,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public static readonly DependencyProperty IsDepthClipEnabledProperty = DependencyProperty.Register("IsDepthClipEnabled", typeof(bool), typeof(MeshGeometryModel3D), new PropertyMetadata(true, RasterStateChanged));
+        public static readonly DependencyProperty IsDepthClipEnabledProperty = DependencyProperty.Register("IsDepthClipEnabled", typeof(bool), typeof(MeshGeometryModel3D),
+            new AffectsRenderPropertyMetadata(true, RasterStateChanged));
 
         public bool IsDepthClipEnabled
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -231,7 +231,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, DefaultVertex.SizeInBytes, CreateDefaultVertexArray(), geometry.Positions.Count);
 
                 // --- init index buffer
-                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), Geometry.IndicesArray);
+                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), Geometry.Indices.Array, Geometry.Indices.Count);
             }
             else
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -59,7 +59,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty ShadingProperty =
-            DependencyProperty.Register("Shading", typeof(string), typeof(PatchGeometryModel3D), new UIPropertyMetadata("Solid", ShadingChanged));
+            DependencyProperty.Register("Shading", typeof(string), typeof(PatchGeometryModel3D), new AffectsRenderPropertyMetadata("Solid", ShadingChanged));
 
         /// <summary>
         /// 
@@ -101,7 +101,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty TessellationFactorProperty =
-            DependencyProperty.Register("TessellationFactor", typeof(double), typeof(PatchGeometryModel3D), new UIPropertyMetadata(1.0, TessellationFactorChanged));
+            DependencyProperty.Register("TessellationFactor", typeof(double), typeof(PatchGeometryModel3D), 
+                new AffectsRenderPropertyMetadata(1.0, TessellationFactorChanged));
 
         /// <summary>
         /// 
@@ -115,7 +116,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public static readonly DependencyProperty FrontCounterClockwiseProperty = DependencyProperty.Register("FrontCounterClockwise", typeof(bool), typeof(PatchGeometryModel3D), new PropertyMetadata(true, RasterStateChanged));
+        public static readonly DependencyProperty FrontCounterClockwiseProperty = DependencyProperty.Register("FrontCounterClockwise", typeof(bool), typeof(PatchGeometryModel3D),
+            new AffectsRenderPropertyMetadata(true, RasterStateChanged));
 
         public bool FrontCounterClockwise
         {
@@ -129,7 +131,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public static readonly DependencyProperty CullModeProperty = DependencyProperty.Register("CullMode", typeof(CullMode), typeof(PatchGeometryModel3D), new PropertyMetadata(CullMode.None, RasterStateChanged));
+        public static readonly DependencyProperty CullModeProperty = DependencyProperty.Register("CullMode", typeof(CullMode), typeof(PatchGeometryModel3D), 
+            new AffectsRenderPropertyMetadata(CullMode.None, RasterStateChanged));
 
         public CullMode CullMode
         {
@@ -143,7 +146,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public static readonly DependencyProperty IsDepthClipEnabledProperty = DependencyProperty.Register("IsDepthClipEnabled", typeof(bool), typeof(PatchGeometryModel3D), new PropertyMetadata(true, RasterStateChanged));
+        public static readonly DependencyProperty IsDepthClipEnabledProperty = DependencyProperty.Register("IsDepthClipEnabled", typeof(bool), typeof(PatchGeometryModel3D),
+            new AffectsRenderPropertyMetadata(true, RasterStateChanged));
 
         public bool IsDepthClipEnabled
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -220,7 +220,7 @@ namespace HelixToolkit.Wpf.SharpDX
             AttachMaterial();
 
             // -- get geometry
-            var geometry = Geometry as MeshGeometry3D;
+            var geometry = geometryInternal as MeshGeometry3D;
 
             // -- get geometry
             if (geometry != null)
@@ -231,7 +231,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, DefaultVertex.SizeInBytes, CreateDefaultVertexArray(), geometry.Positions.Count);
 
                 // --- init index buffer
-                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), Geometry.Indices.Array, Geometry.Indices.Count);
+                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), geometryInternal.Indices.Array, geometryInternal.Indices.Count);
             }
             else
             {
@@ -309,7 +309,7 @@ namespace HelixToolkit.Wpf.SharpDX
             shaderPass.Apply(renderContext.DeviceContext);
 
             // --- render the geometry
-            renderContext.DeviceContext.DrawIndexed(Geometry.Indices.Count, 0, 0);
+            renderContext.DeviceContext.DrawIndexed(geometryInternal.Indices.Count, 0, 0);
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         private DefaultVertex[] CreateDefaultVertexArray()
         {
-            var geometry = (MeshGeometry3D)this.Geometry;
+            var geometry = (MeshGeometry3D)this.geometryInternal;
             var colors = geometry.Colors != null ? geometry.Colors : null;
             var textureCoordinates = geometry.TextureCoordinates != null ? geometry.TextureCoordinates : null;
             var texScale = this.TextureCoodScale;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -231,7 +231,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 vertexBuffer = Device.CreateBuffer(BindFlags.VertexBuffer, DefaultVertex.SizeInBytes, CreateDefaultVertexArray(), geometry.Positions.Count);
 
                 // --- init index buffer
-                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), Geometry.Indices.Array);
+                indexBuffer = Device.CreateBuffer(BindFlags.IndexBuffer, sizeof(int), Geometry.IndicesArray);
             }
             else
             {
@@ -343,13 +343,13 @@ namespace HelixToolkit.Wpf.SharpDX
         private DefaultVertex[] CreateDefaultVertexArray()
         {
             var geometry = (MeshGeometry3D)this.Geometry;
-            var colors = geometry.Colors != null ? geometry.Colors.Array : null;
-            var textureCoordinates = geometry.TextureCoordinates != null ? geometry.TextureCoordinates.Array : null;
+            var colors = geometry.Colors != null ? geometry.Colors : null;
+            var textureCoordinates = geometry.TextureCoordinates != null ? geometry.TextureCoordinates : null;
             var texScale = this.TextureCoodScale;
-            var normals = geometry.Normals != null ? geometry.Normals.Array : null;
-            var tangents = geometry.Tangents != null ? geometry.Tangents.Array : null;
-            var bitangents = geometry.BiTangents != null ? geometry.BiTangents.Array : null;
-            var positions = geometry.Positions.Array;
+            var normals = geometry.Normals != null ? geometry.Normals : null;
+            var tangents = geometry.Tangents != null ? geometry.Tangents : null;
+            var bitangents = geometry.BiTangents != null ? geometry.BiTangents : null;
+            var positions = geometry.Positions;
             var vertexCount = geometry.Positions.Count;
             if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
                 vertexArrayBuffer = new DefaultVertex[vertexCount];

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -366,7 +366,7 @@
         /// </summary>
         private Geometry3D.PointsVertex[] CreateVertexArray()
         {
-            var positions = this.Geometry.Positions.Array;
+            var positions = this.Geometry.Positions;
             var vertexCount = this.Geometry.Positions.Count;
             var color = this.Color;
             if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -101,20 +101,20 @@
             {
                 return false;
             }
-            if (this.IsHitTestVisible == false || this.Geometry == null)
+            if (this.IsHitTestVisible == false || this.geometryInternal == null)
             {
                 return false;
             }
-            if (Geometry.Octree != null)
+            if (geometryInternal.Octree != null)
             {
-                return Geometry.Octree.HitTest(context, this, ModelMatrix, rayWS, ref hits);
+                return geometryInternal.Octree.HitTest(context, this, ModelMatrix, rayWS, ref hits);
             }
             else
             {
                 PointGeometry3D pointGeometry3D;
 
                 if (context == null ||
-                    (pointGeometry3D = this.Geometry as PointGeometry3D) == null)
+                    (pointGeometry3D = this.geometryInternal as PointGeometry3D) == null)
                 {
                     return false;
                 }
@@ -204,7 +204,7 @@
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CreateVertexBuffer()
         {
-            var geometry = Geometry as PointGeometry3D;
+            var geometry = geometryInternal as PointGeometry3D;
             if (geometry != null && geometry.Positions != null)
             {
                 Disposer.RemoveAndDispose(ref vertexBuffer);
@@ -250,7 +250,7 @@
 
         protected override bool CheckGeometry()
         {
-            if (this.Geometry == null || this.Geometry.Positions == null || this.Geometry.Positions.Count == 0)
+            if (this.geometryInternal == null || this.geometryInternal.Positions == null || this.geometryInternal.Positions.Count == 0)
             {
                 return false;
             }
@@ -350,7 +350,7 @@
             // --- render the geometry
             this.effectTechnique.GetPassByIndex(0).Apply(renderContext.DeviceContext);
 
-            renderContext.DeviceContext.Draw(this.Geometry.Positions.Count, 0);
+            renderContext.DeviceContext.Draw(this.geometryInternal.Positions.Count, 0);
         }
 
         /// <summary>
@@ -366,15 +366,15 @@
         /// </summary>
         private Geometry3D.PointsVertex[] CreateVertexArray()
         {
-            var positions = this.Geometry.Positions;
-            var vertexCount = this.Geometry.Positions.Count;
+            var positions = this.geometryInternal.Positions;
+            var vertexCount = this.geometryInternal.Positions.Count;
             var color = this.Color;
             if (!ReuseVertexArrayBuffer || vertexArrayBuffer == null || vertexArrayBuffer.Length < vertexCount)
                 vertexArrayBuffer = new Geometry3D.PointsVertex[vertexCount];
 
-            if (this.Geometry.Colors != null && this.Geometry.Colors.Any())
+            if (this.geometryInternal.Colors != null && this.geometryInternal.Colors.Any())
             {
-                var colors = this.Geometry.Colors;
+                var colors = this.geometryInternal.Colors;
                 for (var i = 0; i < vertexCount; i++)
                 {
                     vertexArrayBuffer[i].Position = new Vector4(positions[i], 1f);

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -37,7 +37,7 @@
 
         public static readonly DependencyProperty ColorProperty =
             DependencyProperty.Register("Color", typeof(Color), typeof(PointGeometryModel3D),
-                new UIPropertyMetadata(Color.Black, (o, e) => ((PointGeometryModel3D)o).OnColorChanged()));
+                new AffectsRenderPropertyMetadata(Color.Black, (o, e) => ((PointGeometryModel3D)o).OnColorChanged()));
 
         public Size Size
         {
@@ -46,7 +46,7 @@
         }
 
         public static readonly DependencyProperty SizeProperty =
-            DependencyProperty.Register("Size", typeof(Size), typeof(PointGeometryModel3D), new UIPropertyMetadata(new Size(1.0, 1.0)));
+            DependencyProperty.Register("Size", typeof(Size), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(new Size(1.0, 1.0)));
 
         public PointFigure Figure
         {
@@ -55,7 +55,7 @@
         }
 
         public static readonly DependencyProperty FigureProperty =
-            DependencyProperty.Register("Figure", typeof(PointFigure), typeof(PointGeometryModel3D), new UIPropertyMetadata(PointFigure.Rect));
+            DependencyProperty.Register("Figure", typeof(PointFigure), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(PointFigure.Rect));
 
         public double FigureRatio
         {
@@ -64,7 +64,7 @@
         }
 
         public static readonly DependencyProperty FigureRatioProperty =
-            DependencyProperty.Register("FigureRatio", typeof(double), typeof(PointGeometryModel3D), new UIPropertyMetadata(0.25));
+            DependencyProperty.Register("FigureRatio", typeof(double), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(0.25));
 
         public double HitTestThickness
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/TransformableItems3DControl.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/TransformableItems3DControl.cs
@@ -45,7 +45,8 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty TransformProperty =
-            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(TransformableItems3DControl), new UIPropertyMetadata(Transform3D.Identity, TransformPropertyChanged));
+            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(TransformableItems3DControl),
+                new AffectsRenderPropertyMetadata(Transform3D.Identity, TransformPropertyChanged));
 
         private static void TransformPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UICompositeManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UICompositeManipulator3D.cs
@@ -51,7 +51,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The can translate y property.
         /// </summary>
         public static readonly DependencyProperty CanTranslateYProperty = DependencyProperty.Register(
-            "CanTranslateY", typeof(bool), typeof(UICompositeManipulator3D), new UIPropertyMetadata(true, ChildrenChanged));
+            "CanTranslateY", typeof(bool), typeof(UICompositeManipulator3D), new UIPropertyMetadata(true,  ChildrenChanged));
 
         /// <summary>
         /// The can translate z property.
@@ -63,13 +63,14 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The diameter property.
         /// </summary>
         public static readonly DependencyProperty DiameterProperty = DependencyProperty.Register(
-            "Diameter", typeof(double), typeof(UICompositeManipulator3D), new UIPropertyMetadata(2.0, ChildrenChanged));
+            "Diameter", typeof(double), typeof(UICompositeManipulator3D), new AffectsRenderPropertyMetadata(2.0, ChildrenChanged));
 
         /// <summary>
         ///   The target transform property.
         /// </summary>
         public static readonly DependencyProperty TargetTransformProperty = DependencyProperty.Register(
-            "TargetTransform", typeof(Transform3D), typeof(UICompositeManipulator3D), new FrameworkPropertyMetadata(Transform3D.Identity, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+            "TargetTransform", typeof(Transform3D), typeof(UICompositeManipulator3D), 
+            new AffectsRenderFrameworkPropertyMetadata(Transform3D.Identity, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         ///   Gets or sets TargetTransform.

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIManipulator3D.cs
@@ -33,19 +33,19 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   Bind the Tranform of the Target to this Property
         /// </summary>
         public static readonly DependencyProperty TargetTransformProperty = DependencyProperty.Register(
-            "TargetTransform", typeof(Transform3D), typeof(UIManipulator3D), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+            "TargetTransform", typeof(Transform3D), typeof(UIManipulator3D), new AffectsRenderFrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         ///   The offset property.
         /// </summary>
         public static readonly DependencyProperty OffsetProperty = DependencyProperty.Register(
-            "Offset", typeof(Vector3), typeof(UIManipulator3D), new UIPropertyMetadata(new Vector3(0, 0, 0), ModelChanged));
+            "Offset", typeof(Vector3), typeof(UIManipulator3D), new AffectsRenderPropertyMetadata(new Vector3(0, 0, 0), ModelChanged));
 
         /// <summary>
         ///   The value property.
         /// </summary>
         public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
-            "Value", typeof(double), typeof(UIManipulator3D), new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, ValueChanged));
+            "Value", typeof(double), typeof(UIManipulator3D), new AffectsRenderFrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.AffectsRender, ValueChanged));
 
 
         //public static readonly DependencyProperty PositionProperty =

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIRotateManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIRotateManipulator3D.cs
@@ -26,31 +26,31 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The axis property.
         /// </summary>
         public static readonly DependencyProperty AxisProperty = DependencyProperty.Register(
-            "Axis", typeof(Vector3), typeof(UIRotateManipulator3D), new UIPropertyMetadata(new Vector3(0, 0, 1), ModelChanged));
+            "Axis", typeof(Vector3), typeof(UIRotateManipulator3D), new AffectsRenderPropertyMetadata(new Vector3(0, 0, 1), ModelChanged));
 
         /// <summary>
         /// The diameter property.
         /// </summary>
         public static readonly DependencyProperty OuterDiameterProperty = DependencyProperty.Register(
-            "OuterDiameter", typeof(double), typeof(UIRotateManipulator3D), new UIPropertyMetadata(1.5, ModelChanged));
+            "OuterDiameter", typeof(double), typeof(UIRotateManipulator3D), new AffectsRenderPropertyMetadata(1.5, ModelChanged));
 
         /// <summary>
         /// The inner diameter property.
         /// </summary>
         public static readonly DependencyProperty InnerDiameterProperty = DependencyProperty.Register(
-            "InnerDiameter", typeof(double), typeof(UIRotateManipulator3D), new UIPropertyMetadata(1.0, ModelChanged));
+            "InnerDiameter", typeof(double), typeof(UIRotateManipulator3D), new AffectsRenderPropertyMetadata(1.0, ModelChanged));
 
         /// <summary>
         /// The length property.
         /// </summary>
         public static readonly DependencyProperty LengthProperty = DependencyProperty.Register(
-            "Length", typeof(double), typeof(UIRotateManipulator3D), new UIPropertyMetadata(0.1, ModelChanged));
+            "Length", typeof(double), typeof(UIRotateManipulator3D), new AffectsRenderPropertyMetadata(0.1, ModelChanged));
 
         /// <summary>
         /// The pivot point property.
         /// </summary>
         public static readonly DependencyProperty PivotProperty = DependencyProperty.Register(
-            "Pivot", typeof(Vector3), typeof(UIRotateManipulator3D), new PropertyMetadata(new Vector3(0, 0, 0)));
+            "Pivot", typeof(Vector3), typeof(UIRotateManipulator3D), new AffectsRenderPropertyMetadata(new Vector3(0, 0, 0)));
 
         /// <summary>
         /// Gets or sets the rotation axis.

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UITranslateManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UITranslateManipulator3D.cs
@@ -27,19 +27,19 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The diameter property.
         /// </summary>
         public static readonly DependencyProperty DiameterProperty =
-            DependencyProperty.Register("Diameter", typeof(double), typeof(UITranslateManipulator3D), new UIPropertyMetadata(0.2, ModelChanged));
+            DependencyProperty.Register("Diameter", typeof(double), typeof(UITranslateManipulator3D), new AffectsRenderPropertyMetadata(0.2, ModelChanged));
 
         /// <summary>
         /// The direction property.
         /// </summary>
         public static readonly DependencyProperty DirectionProperty =
-            DependencyProperty.Register("Direction", typeof(Vector3), typeof(UITranslateManipulator3D), new UIPropertyMetadata(new Vector3(0, 0, 1), ModelChanged));
+            DependencyProperty.Register("Direction", typeof(Vector3), typeof(UITranslateManipulator3D), new AffectsRenderPropertyMetadata(new Vector3(0, 0, 1), ModelChanged));
 
         /// <summary>
         /// The length property.
         /// </summary>
         public static readonly DependencyProperty LengthProperty =
-            DependencyProperty.Register("Length", typeof(double), typeof(UITranslateManipulator3D), new UIPropertyMetadata(1.0, ModelChanged));
+            DependencyProperty.Register("Length", typeof(double), typeof(UITranslateManipulator3D), new AffectsRenderPropertyMetadata(1.0, ModelChanged));
 
         /// <summary>
         /// Gets or sets the diameter of the manipulator arrow.

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Geometry/PointGeometry3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Geometry/PointGeometry3D.cs
@@ -19,7 +19,7 @@
 
         protected override IOctree CreateOctree(OctreeBuildParameter parameter)
         {
-            return new PointGeometryOctree(PositionArray, parameter);
+            return new PointGeometryOctree(Positions, parameter);
         }
 
         protected override bool CanCreateOctree()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Geometry/PointGeometry3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Geometry/PointGeometry3D.cs
@@ -19,7 +19,7 @@
 
         protected override IOctree CreateOctree(OctreeBuildParameter parameter)
         {
-            return new PointGeometryOctree(Positions, parameter);
+            return new PointGeometryOctree(PositionArray, parameter);
         }
 
         protected override bool CanCreateOctree()

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
@@ -39,13 +39,13 @@ namespace HelixToolkit.Wpf.SharpDX
     {
         public Light3DSceneShared Light3DSceneShared { private set; get; }
         public static readonly DependencyProperty DirectionProperty =
-            DependencyProperty.Register("Direction", typeof(Vector3), typeof(Light3D), new UIPropertyMetadata(new Vector3()));
+            DependencyProperty.Register("Direction", typeof(Vector3), typeof(Light3D), new AffectsRenderPropertyMetadata(new Vector3()));
 
         public static readonly DependencyProperty DirectionTransformProperty =
-            DependencyProperty.Register("DirectionTransform", typeof(Transform3D), typeof(Light3D), new UIPropertyMetadata(Transform3D.Identity, DirectionTransformPropertyChanged));
+            DependencyProperty.Register("DirectionTransform", typeof(Transform3D), typeof(Light3D), new AffectsRenderPropertyMetadata(Transform3D.Identity, DirectionTransformPropertyChanged));
 
         public static readonly DependencyProperty ColorProperty =
-            DependencyProperty.Register("Color", typeof(Color4), typeof(Light3D), new UIPropertyMetadata(new Color4(0.2f, 0.2f, 0.2f, 1.0f), ColorChanged));
+            DependencyProperty.Register("Color", typeof(Color4), typeof(Light3D), new AffectsRenderPropertyMetadata(new Color4(0.2f, 0.2f, 0.2f, 1.0f), ColorChanged));
 
 
         public LightType LightType { get; protected set; }
@@ -202,10 +202,10 @@ namespace HelixToolkit.Wpf.SharpDX
     public abstract class PointLightBase3D : Light3D
     {
         public static readonly DependencyProperty AttenuationProperty =
-            DependencyProperty.Register("Attenuation", typeof(Vector3), typeof(PointLightBase3D), new UIPropertyMetadata(new Vector3(1.0f, 0.0f, 0.0f)));
+            DependencyProperty.Register("Attenuation", typeof(Vector3), typeof(PointLightBase3D), new AffectsRenderPropertyMetadata(new Vector3(1.0f, 0.0f, 0.0f)));
 
         public static readonly DependencyProperty RangeProperty =
-            DependencyProperty.Register("Range", typeof(double), typeof(PointLightBase3D), new UIPropertyMetadata(1000.0));
+            DependencyProperty.Register("Range", typeof(double), typeof(PointLightBase3D), new AffectsRenderPropertyMetadata(1000.0));
 
         /// <summary>
         /// The position of the model in world space.
@@ -217,7 +217,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         private static readonly DependencyPropertyKey PositionPropertyKey =
-            DependencyProperty.RegisterReadOnly("Position", typeof(Point3D), typeof(PointLightBase3D), new UIPropertyMetadata(new Point3D()));
+            DependencyProperty.RegisterReadOnly("Position", typeof(Point3D), typeof(PointLightBase3D), new AffectsRenderPropertyMetadata(new Point3D()));
 
         public static readonly DependencyProperty PositionProperty = PositionPropertyKey.DependencyProperty;
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ShadowMap3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ShadowMap3D.cs
@@ -36,7 +36,7 @@ namespace HelixToolkit.Wpf.SharpDX
         private int width = 1024, height = 1024;
 
         public static readonly DependencyProperty ResolutionProperty =
-            DependencyProperty.Register("Resolution", typeof(Vector2), typeof(ShadowMap3D), new UIPropertyMetadata(new Vector2(1024, 1024), ResolutionChanged));
+            DependencyProperty.Register("Resolution", typeof(Vector2), typeof(ShadowMap3D), new AffectsRenderPropertyMetadata(new Vector2(1024, 1024), ResolutionChanged));
 
         private static void ResolutionChanged(DependencyObject d, DependencyPropertyChangedEventArgs args)
         {            
@@ -49,13 +49,13 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty FactorPCFProperty =
-                DependencyProperty.Register("FactorPCF", typeof(double), typeof(ShadowMap3D), new UIPropertyMetadata(1.5));
+                DependencyProperty.Register("FactorPCF", typeof(double), typeof(ShadowMap3D), new AffectsRenderPropertyMetadata(1.5));
 
         public static readonly DependencyProperty BiasProperty =
-                DependencyProperty.Register("Bias", typeof(double), typeof(ShadowMap3D), new UIPropertyMetadata(0.0015));
+                DependencyProperty.Register("Bias", typeof(double), typeof(ShadowMap3D), new AffectsRenderPropertyMetadata(0.0015));
 
         public static readonly DependencyProperty IntensityProperty =
-                DependencyProperty.Register("Intensity", typeof(double), typeof(ShadowMap3D), new UIPropertyMetadata(0.5));
+                DependencyProperty.Register("Intensity", typeof(double), typeof(ShadowMap3D), new AffectsRenderPropertyMetadata(0.5));
 
 
         [TypeConverter(typeof(Vector2Converter))]

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
@@ -22,13 +22,13 @@ namespace HelixToolkit.Wpf.SharpDX
     public sealed class SpotLight3D : PointLightBase3D
     {
         public static readonly DependencyProperty FalloffProperty =
-            DependencyProperty.Register("Falloff", typeof(double), typeof(SpotLight3D), new UIPropertyMetadata(1.0));
+            DependencyProperty.Register("Falloff", typeof(double), typeof(SpotLight3D), new AffectsRenderPropertyMetadata(1.0));
 
         public static readonly DependencyProperty InnerAngleProperty =
-            DependencyProperty.Register("InnerAngle", typeof(double), typeof(SpotLight3D), new UIPropertyMetadata(5.0));
+            DependencyProperty.Register("InnerAngle", typeof(double), typeof(SpotLight3D), new AffectsRenderPropertyMetadata(5.0));
 
         public static readonly DependencyProperty OuterAngleProperty =
-            DependencyProperty.Register("OuterAngle", typeof(double), typeof(SpotLight3D), new UIPropertyMetadata(45.0));
+            DependencyProperty.Register("OuterAngle", typeof(double), typeof(SpotLight3D), new AffectsRenderPropertyMetadata(45.0));
 
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/AffectsRenderPropertyMetadata.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/AffectsRenderPropertyMetadata.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace HelixToolkit.Wpf.SharpDX
+{
+    public interface IAffectsRender
+    {
+        bool AffectsRender { get; }
+    }
+    public class AffectsRenderPropertyMetadata : PropertyMetadata, IAffectsRender
+    {
+        public AffectsRenderPropertyMetadata()
+        {
+        }
+
+        public AffectsRenderPropertyMetadata(PropertyChangedCallback propertyChangedCallback) : base(propertyChangedCallback)
+        {
+        }
+
+        public AffectsRenderPropertyMetadata(object defaultValue) : base(defaultValue)
+        {
+        }
+
+        public AffectsRenderPropertyMetadata(object defaultValue, PropertyChangedCallback propertyChangedCallback) : base(defaultValue, propertyChangedCallback)
+        {
+        }
+
+        public AffectsRenderPropertyMetadata(object defaultValue, PropertyChangedCallback propertyChangedCallback, CoerceValueCallback coerceValueCallback) : base(defaultValue, propertyChangedCallback, coerceValueCallback)
+        {
+        }
+
+        public bool AffectsRender { set; get; } = true;       
+    }
+
+    public class AffectsRenderFrameworkPropertyMetadata : FrameworkPropertyMetadata, IAffectsRender
+    {
+        public AffectsRenderFrameworkPropertyMetadata()
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(PropertyChangedCallback propertyChangedCallback) 
+            : base(FrameworkPropertyMetadataOptions.AffectsRender, propertyChangedCallback)
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(object defaultValue, FrameworkPropertyMetadataOptions flags = FrameworkPropertyMetadataOptions.AffectsRender) 
+            : base(defaultValue, flags)
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(object defaultValue, PropertyChangedCallback propertyChangedCallback)
+            : base(defaultValue, FrameworkPropertyMetadataOptions.AffectsRender, propertyChangedCallback)
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(PropertyChangedCallback propertyChangedCallback, CoerceValueCallback coerceValueCallback) 
+            : base(propertyChangedCallback, coerceValueCallback)
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(object defaultValue, FrameworkPropertyMetadataOptions flags, PropertyChangedCallback propertyChangedCallback) 
+            : base(defaultValue, flags, propertyChangedCallback)
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(object defaultValue, PropertyChangedCallback propertyChangedCallback, CoerceValueCallback coerceValueCallback) 
+            : base(defaultValue, FrameworkPropertyMetadataOptions.AffectsRender, propertyChangedCallback, coerceValueCallback)
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(object defaultValue, FrameworkPropertyMetadataOptions flags, PropertyChangedCallback propertyChangedCallback, CoerceValueCallback coerceValueCallback)
+            : base(defaultValue, flags, propertyChangedCallback, coerceValueCallback)
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(object defaultValue, FrameworkPropertyMetadataOptions flags, PropertyChangedCallback propertyChangedCallback, CoerceValueCallback coerceValueCallback, bool isAnimationProhibited)
+            : base(defaultValue, flags, propertyChangedCallback, coerceValueCallback, isAnimationProhibited)
+        {
+        }
+
+        public AffectsRenderFrameworkPropertyMetadata(object defaultValue, FrameworkPropertyMetadataOptions flags, PropertyChangedCallback propertyChangedCallback, CoerceValueCallback coerceValueCallback, bool isAnimationProhibited, UpdateSourceTrigger defaultUpdateSourceTrigger) 
+            : base(defaultValue, flags, propertyChangedCallback, coerceValueCallback, isAnimationProhibited, defaultUpdateSourceTrigger)
+        {
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/LineBuilder.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/LineBuilder.cs
@@ -252,7 +252,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <returns></returns>
         public static LineGeometry3D GenerateBoundingBox(Geometry3D mesh)
         {
-            var bb = global::SharpDX.BoundingBox.FromPoints(mesh.PositionArray);
+            var bb = BoundingBoxExtensions.FromPoints(mesh.Positions);
             return GenerateBoundingBox(bb);
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/LineBuilder.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/LineBuilder.cs
@@ -252,7 +252,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <returns></returns>
         public static LineGeometry3D GenerateBoundingBox(Geometry3D mesh)
         {
-            var bb = global::SharpDX.BoundingBox.FromPoints(mesh.Positions.Array);
+            var bb = global::SharpDX.BoundingBox.FromPoints(mesh.PositionArray);
             return GenerateBoundingBox(bb);
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
@@ -860,7 +860,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     switch (keyword.ToLower())
                     {
                         case "newmtl":
-                            if (value != null)
+                            if (value != null && !Materials.ContainsKey(value))
                             {
                                 currentMaterial = new MaterialDefinition();
                                 this.Materials.Add(value, currentMaterial);

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
@@ -1116,17 +1116,17 @@ namespace HelixToolkit.Wpf.SharpDX
     {
         public IList<Vector3> Positions { private set; get; }
         public IList<int> Indices { private set; get; }
-        public MeshGeometryOctree(Vector3Collection positions, IList<int> indices, Queue<IOctree> queueCache = null)
+        public MeshGeometryOctree(Vector3[] positions, IList<int> indices, Queue<IOctree> queueCache = null)
             : this(positions, indices, null, queueCache)
         {
         }
-        public MeshGeometryOctree(Vector3Collection positions, IList<int> indices,
+        public MeshGeometryOctree(Vector3[] positions, IList<int> indices,
             OctreeBuildParameter parameter, Queue<IOctree> queueCache = null)
             : base(null, parameter, queueCache)
         {
             Positions = positions;
             Indices = indices;
-            Bound = BoundingBox.FromPoints(positions.Array);
+            Bound = BoundingBox.FromPoints(positions);
             Objects = new List<Tuple<int, BoundingBox>>(indices.Count / 3);
             // Construct triangle index and its bounding box tuple
             foreach (var i in Enumerable.Range(0, indices.Count / 3))
@@ -1320,22 +1320,22 @@ namespace HelixToolkit.Wpf.SharpDX
 
     public class PointGeometryOctree : OctreeBase<int>
     {
-        private Vector3Collection Positions;
+        private Vector3[] Positions;
         private static readonly Vector3 BoundOffset = new Vector3(0.0001f);
-        public PointGeometryOctree(Vector3Collection positions, Queue<IOctree> queueCache = null)
+        public PointGeometryOctree(Vector3[] positions, Queue<IOctree> queueCache = null)
             : this(positions, null, queueCache)
         {
         }
-        public PointGeometryOctree(Vector3Collection positions,
+        public PointGeometryOctree(Vector3[] positions,
             OctreeBuildParameter parameter, Queue<IOctree> queueCache = null)
                : base(null, parameter, queueCache)
         {
             Positions = positions;
-            Bound = BoundingBox.FromPoints(positions.Array);
-            Objects = Enumerable.Range(0, Positions.Count).ToList();
+            Bound = BoundingBox.FromPoints(positions);
+            Objects = Enumerable.Range(0, Positions.Length).ToList();
         }
 
-        protected PointGeometryOctree(BoundingBox bound, Vector3Collection positions, List<int> list, IOctree parent, OctreeBuildParameter paramter,
+        protected PointGeometryOctree(BoundingBox bound, Vector3[] positions, List<int> list, IOctree parent, OctreeBuildParameter paramter,
             Queue<IOctree> queueCache)
             : base(ref bound, list, parent, paramter, queueCache)
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
@@ -1116,17 +1116,17 @@ namespace HelixToolkit.Wpf.SharpDX
     {
         public IList<Vector3> Positions { private set; get; }
         public IList<int> Indices { private set; get; }
-        public MeshGeometryOctree(Vector3[] positions, IList<int> indices, Queue<IOctree> queueCache = null)
+        public MeshGeometryOctree(IList<Vector3> positions, IList<int> indices, Queue<IOctree> queueCache = null)
             : this(positions, indices, null, queueCache)
         {
         }
-        public MeshGeometryOctree(Vector3[] positions, IList<int> indices,
+        public MeshGeometryOctree(IList<Vector3>  positions, IList<int> indices,
             OctreeBuildParameter parameter, Queue<IOctree> queueCache = null)
             : base(null, parameter, queueCache)
         {
             Positions = positions;
             Indices = indices;
-            Bound = BoundingBox.FromPoints(positions);
+            Bound = BoundingBoxExtensions.FromPoints(positions);
             Objects = new List<Tuple<int, BoundingBox>>(indices.Count / 3);
             // Construct triangle index and its bounding box tuple
             foreach (var i in Enumerable.Range(0, indices.Count / 3))
@@ -1320,22 +1320,22 @@ namespace HelixToolkit.Wpf.SharpDX
 
     public class PointGeometryOctree : OctreeBase<int>
     {
-        private Vector3[] Positions;
+        private IList<Vector3> Positions;
         private static readonly Vector3 BoundOffset = new Vector3(0.0001f);
-        public PointGeometryOctree(Vector3[] positions, Queue<IOctree> queueCache = null)
+        public PointGeometryOctree(IList<Vector3> positions, Queue<IOctree> queueCache = null)
             : this(positions, null, queueCache)
         {
         }
-        public PointGeometryOctree(Vector3[] positions,
+        public PointGeometryOctree(IList<Vector3> positions,
             OctreeBuildParameter parameter, Queue<IOctree> queueCache = null)
                : base(null, parameter, queueCache)
         {
             Positions = positions;
-            Bound = BoundingBox.FromPoints(positions);
-            Objects = Enumerable.Range(0, Positions.Length).ToList();
+            Bound = BoundingBoxExtensions.FromPoints(positions);
+            Objects = Enumerable.Range(0, Positions.Count).ToList();
         }
 
-        protected PointGeometryOctree(BoundingBox bound, Vector3[] positions, List<int> list, IOctree parent, OctreeBuildParameter paramter,
+        protected PointGeometryOctree(BoundingBox bound, IList<Vector3> positions, List<int> list, IOctree parent, OctreeBuildParameter paramter,
             Queue<IOctree> queueCache)
             : base(ref bound, list, parent, paramter, queueCache)
         {


### PR DESCRIPTION
1. Code cleanup. Remove TrimExcess before getting internal array, since it does not guarantee to be trimmed.
2. Support to create boundingbox and boundingsphere from IList<Vector3> directly. 
3. Unify dependency property metadata to custom AffectsRenderPropertyMetaData.
4. Add FindNearestPointFromPoint in Octree.