### PR TITLE
Cleanup and optimize

### DIFF
--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/AttachedProperties.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/AttachedProperties.cs
@@ -12,12 +12,12 @@ namespace CustomShaderDemo
             typeof(GeometryModel3D),
             new PropertyMetadata(false, ShowSelectedPropertyChanged));
 
-        public static void SetShowSelected(UIElement element, bool value)
+        public static void SetShowSelected(DependencyObject element, bool value)
         {
             element.SetValue(ShowSelectedProperty, value);
         }
 
-        public static bool GetShowSelected(UIElement element)
+        public static bool GetShowSelected(DependencyObject element)
         {
             return (bool)element.GetValue(ShowSelectedProperty);
         }

--- a/Source/Examples/WPF.SharpDX/InstancingDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/InstancingDemo/MainViewModel.cs
@@ -19,6 +19,7 @@ namespace InstancingDemo
     using System;
     using System.IO;
     using System.Windows.Threading;
+    using System.Diagnostics;
 
     public class MainViewModel : BaseViewModel
     {
@@ -203,6 +204,7 @@ namespace InstancingDemo
             if (hitTests.Count > 0)
             {
                 var index = (int)hitTests[0].Tag;
+                Debug.WriteLine("Hit instance idx = " + index);
                 InstanceParam[index].EmissiveColor = InstanceParam[index].EmissiveColor == Color.Transparent? Color.Yellow : Color.Transparent;
                 InstanceParam = (InstanceParameter[])InstanceParam.Clone();
             }

--- a/Source/Examples/WPF.SharpDX/InstancingDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/InstancingDemo/MainViewModel.cs
@@ -20,6 +20,7 @@ namespace InstancingDemo
     using System.IO;
     using System.Windows.Threading;
     using System.Diagnostics;
+    using System.Linq;
 
     public class MainViewModel : BaseViewModel
     {
@@ -27,6 +28,8 @@ namespace InstancingDemo
         public LineGeometry3D Lines { get; private set; }
         public LineGeometry3D Grid { get; private set; }
         public Matrix[] ModelInstances { get; private set; }
+
+        public Matrix[] SelectedLineInstances { private set; get; }
 
         public InstanceParameter[] InstanceParam { get; private set; }
 
@@ -72,9 +75,9 @@ namespace InstancingDemo
                 Model.TextureCoordinates[i] = new Vector2(tex.X * 0.5f, tex.Y * 0.5f);
             }
             var l1 = new LineBuilder();
-            l1.AddBox(new Vector3(0, 0, 0), 0.8, 0.8, 0.5);
+            l1.AddBox(new Vector3(0, 0, 0), 1.1, 1.1, 1.1);
             Lines = l1.ToLineGeometry3D();
-
+            Lines.Colors = new HelixToolkit.Wpf.SharpDX.Core.Color4Collection(Enumerable.Repeat(Color.White.ToColor4(), Lines.Positions.Count));
             // model trafo
             ModelTransform = Media3D.Transform3D.Identity;// new Media3D.RotateTransform3D(new Media3D.AxisAngleRotation3D(new Vector3D(0, 0, 1), 45));
 
@@ -101,6 +104,7 @@ namespace InstancingDemo
 
         const int num = 40;
         List<Matrix> instances = new List<Matrix>(num * 2);
+        List<Matrix> selectedLineInstances = new List<Matrix>();
         List<InstanceParameter> parameters = new List<InstanceParameter>(num * 2);
 
         List<Matrix> billboardinstances = new List<Matrix>(num * 2);
@@ -204,9 +208,16 @@ namespace InstancingDemo
             if (hitTests.Count > 0)
             {
                 var index = (int)hitTests[0].Tag;
-                Debug.WriteLine("Hit instance idx = " + index);
-                InstanceParam[index].EmissiveColor = InstanceParam[index].EmissiveColor == Color.Transparent? Color.Yellow : Color.Transparent;
-                InstanceParam = (InstanceParameter[])InstanceParam.Clone();
+                if (hitTests[0].ModelHit is InstancingMeshGeometryModel3D)
+                {
+                    
+                    InstanceParam[index].EmissiveColor = InstanceParam[index].EmissiveColor == Color.Transparent? Color.Yellow : Color.Transparent;
+                    InstanceParam = (InstanceParameter[])InstanceParam.Clone();
+                }
+                else if(hitTests[0].ModelHit is LineGeometryModel3D)
+                {
+                    SelectedLineInstances = new Matrix[] { ModelInstances[index] };
+                }
             }
         }
     }

--- a/Source/Examples/WPF.SharpDX/InstancingDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/InstancingDemo/MainWindow.xaml
@@ -7,6 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
     xmlns:ie="http://schemas.microsoft.com/expression/2010/interactions"
+    xmlns:dx="clr-namespace:SharpDX;assembly=SharpDX.Mathematics"
     Title="{Binding Title}"
     Width="800"
     Height="500"
@@ -56,9 +57,13 @@
             <hx:OctreeLineGeometryModel3D x:Name="octreelines" Octree="{Binding Octree, ElementName=manager}" />
             <hx:LineGeometryModel3D
                 x:Name="lines"
-                Geometry="{Binding Lines}"
+                Geometry="{Binding Lines}" Thickness="0.4"
                 Instances="{Binding ModelInstances}"
-                Transform="{Binding ModelTransform}" />
+                Transform="{Binding ModelTransform}" Color="{x:Static dx:Color.White}"/>
+            <hx:LineGeometryModel3D
+                Geometry="{Binding Lines}"
+                Instances="{Binding SelectedLineInstances}"
+                Color="{x:Static dx:Color.Orange}"/>
             <hx:InstancingBillboardModel3D x:Name="billboardModel3D" Geometry="{Binding BillboardModel}" Instances="{Binding BillboardInstances}" InstanceParamArray="{Binding BillboardInstanceParams}"/>
         </hx:Viewport3DX>
 

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -184,6 +184,7 @@
     <Compile Include="Controls\ViewportCommands.cs" />
     <Compile Include="Extensions\BitmapExtension.cs" />
     <Compile Include="Extensions\Matrix3DExtensions.cs" />
+    <Compile Include="Model\Elements3D\AbstractElements3D\InstanceGeometryModel3D.cs" />
     <Compile Include="Model\Elements3D\BillboardTextModel3D.cs" />
     <Compile Include="Model\Elements3D\BoneSkinMeshGeometryModel3D.cs" />
     <Compile Include="Model\Elements3D\InstancingBillboardModel3D.cs" />

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -18,8 +18,73 @@ namespace HelixToolkit.Wpf.SharpDX
     /// <summary>
     /// Base class for renderable elements.
     /// </summary>    
-    public abstract class Element3D : FrameworkElement, IDisposable, IRenderable, IGUID
+    public abstract class Element3D : FrameworkContentElement, IDisposable, IRenderable, IGUID
     {
+        /// <summary>
+        /// Indicates, if this element should be rendered,
+        /// default is true
+        /// </summary>
+        public static readonly DependencyProperty IsRenderingProperty =
+            DependencyProperty.Register("IsRendering", typeof(bool), typeof(Element3D), new AffectsRenderPropertyMetadata(true,
+                (d, e) =>
+                {
+                    (d as Element3D).isRenderingInternal = (bool)e.NewValue;
+                }));
+
+        /// <summary>
+        /// Indicates, if this element should be rendered.
+        /// Use this also to make the model visible/unvisible
+        /// default is true
+        /// </summary>
+        public bool IsRendering
+        {
+            get { return (bool)GetValue(IsRenderingProperty); }
+            set { SetValue(IsRenderingProperty, value); }
+        }
+
+        public static readonly DependencyProperty IsHitTestVisibleProperty =
+            DependencyProperty.Register("IsHitTestVisible", typeof(bool), typeof(Element3D), new PropertyMetadata(true, (d, e) =>
+            {
+                (d as Element3D).IsHitTestVisibleInternal = (bool)e.NewValue;
+            }));
+
+        public bool IsHitTestVisible
+        {
+            set
+            {
+                SetValue(IsHitTestVisibleProperty, value);
+            }
+            get
+            {
+                return (bool)GetValue(IsHitTestVisibleProperty);
+            }
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public static readonly DependencyProperty VisibilityProperty =
+            DependencyProperty.Register("Visibility", typeof(Visibility), typeof(Element3D), new AffectsRenderPropertyMetadata(Visibility.Visible, (d, e) =>
+            {
+                (d as Element3D).visibleInternal = (Visibility)e.NewValue == Visibility.Visible;
+            }));
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public Visibility Visibility
+        {
+            set
+            {
+                SetValue(VisibilityProperty, value);
+            }
+            get
+            {
+                return (Visibility)GetValue(VisibilityProperty);
+            }
+        }
+
         protected global::SharpDX.Direct3D11.Effect effect;
 
         protected RenderTechnique renderTechnique;
@@ -35,6 +100,11 @@ namespace HelixToolkit.Wpf.SharpDX
         protected bool isRenderingInternal { private set; get; } = true;
 
         protected bool visibleInternal { private set; get; } = true;
+
+        public bool IsHitTestVisibleInternal
+        {
+            private set; get;
+        } = true;
         /// <summary>
         /// If this has been attached onto renderhost. 
         /// </summary>
@@ -181,29 +251,6 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// Indicates, if this element should be rendered,
-        /// default is true
-        /// </summary>
-        public static readonly DependencyProperty IsRenderingProperty =
-            DependencyProperty.Register("IsRendering", typeof(bool), typeof(Element3D), new AffectsRenderPropertyMetadata(true, 
-                (d,e)=> 
-                {
-                    (d as Element3D).isRenderingInternal = (bool)e.NewValue;
-                }));
-
-        /// <summary>
-        /// Indicates, if this element should be rendered.
-        /// Use this also to make the model visible/unvisible
-        /// default is true
-        /// </summary>
-        public bool IsRendering
-        {
-            get { return (bool)GetValue(IsRenderingProperty); }
-            set { SetValue(IsRenderingProperty, value); }
-        }
-
-
-        /// <summary>
         /// Looks for the first visual ancestor of type <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The type of visual ancestor.</typeparam>
@@ -237,10 +284,6 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="e">The event data that describes the property that changed, as well as old and new values.</param>
         protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
         {
-            if (e.Property.Name.Equals(nameof(Visibility)))
-            {
-                visibleInternal = (Visibility)e.NewValue == Visibility.Visible;
-            }
             if (CheckAffectsRender(e))
             {
                 this.InvalidateRender();
@@ -257,11 +300,10 @@ namespace HelixToolkit.Wpf.SharpDX
             // Possible improvement: Only invalidate if the property metadata has the flag "AffectsRender".
             // => Need to change all relevant DP's metadata to FrameworkPropertyMetadata or to a new "AffectsRenderPropertyMetadata".
             PropertyMetadata fmetadata = null;
-            return (e.Property.Name.Equals(nameof(Visibility))
-                || ((fmetadata = e.Property.GetMetadata(this)) != null
+            return ((fmetadata = e.Property.GetMetadata(this)) != null
                 && (fmetadata is IAffectsRender
                 || (fmetadata is FrameworkPropertyMetadata && (fmetadata as FrameworkPropertyMetadata).AffectsRender)
-                )));
+                ));
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -453,138 +453,22 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <returns>True if the ray hits one or more times.</returns>
         public virtual bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
         {
-            if (this.Visibility == Visibility.Collapsed)
+            if (CanHitTest(context))
             {
-                return false;
-            }
-            if (this.IsHitTestVisibleInternal == false || this.geometryInternal == null)
-            {
-                return false;
-            }
-
-            var g = this.geometryInternal as MeshGeometry3D;
-            bool isHit = false;
-
-            if (g.Octree != null)
-            {
-                isHit = g.Octree.HitTest(context, this, ModelMatrix, rayWS, ref hits);
+                return OnHitTest(context, rayWS, ref hits);
             }
             else
             {
-                var result = new HitTestResult();
-                result.Distance = double.MaxValue;
-                if (g != null)
-                {
-                    var m = this.modelMatrix;
-
-                    // put bounds to world space
-                    var b = BoundingBox.FromPoints(this.Bounds.GetCorners().Select(x => Vector3.TransformCoordinate(x, m)).ToArray());
-
-                    //var b = this.Bounds;
-
-                    // this all happens now in world space now:
-                    if (rayWS.Intersects(ref b))
-                    {
-                        int index = 0;
-                        foreach (var t in g.Triangles)
-                        {
-                            float d;
-                            var p0 = Vector3.TransformCoordinate(t.P0, m);
-                            var p1 = Vector3.TransformCoordinate(t.P1, m);
-                            var p2 = Vector3.TransformCoordinate(t.P2, m);
-                            if (Collision.RayIntersectsTriangle(ref rayWS, ref p0, ref p1, ref p2, out d))
-                            {
-                                if (d > 0 && d < result.Distance) // If d is NaN, the condition is false.
-                                {
-                                    result.IsValid = true;
-                                    result.ModelHit = this;
-                                    // transform hit-info to world space now:
-                                    result.PointHit = (rayWS.Position + (rayWS.Direction * d)).ToPoint3D();
-                                    result.Distance = d;
-
-                                    var n = Vector3.Cross(p1 - p0, p2 - p0);
-                                    n.Normalize();
-                                    // transform hit-info to world space now:
-                                    result.NormalAtHit = n.ToVector3D();// Vector3.TransformNormal(n, m).ToVector3D();
-                                    result.TriangleIndices = new System.Tuple<int, int, int>(g.Indices[index], g.Indices[index + 1], g.Indices[index + 2]);
-                                    result.Tag = index / 3;
-                                    isHit = true;
-                                }
-                            }
-                            index += 3;
-                        }
-                    }
-                }
-                if (isHit)
-                {
-                    hits.Add(result);
-                }
-            }
-            return isHit;
-        }
-
-        /*
-        public virtual bool HitTestMS(Ray rayWS, ref List<HitTestResult> hits)
-        {
-            if (this.Visibility == Visibility.Collapsed)
-            {
                 return false;
             }
-
-            var result = new HitTestResult();
-            result.Distance = double.MaxValue;
-            var g = this.geometryInternal as MeshGeometry3D;
-            var h = false;
-
-            if (g != null)
-            {
-                var m = this.modelMatrix;
-                var mi = Matrix.Invert(m);
-
-                // put the ray to model space
-                var rayMS = new Ray(Vector3.TransformNormal(rayWS.Direction, mi), Vector3.TransformCoordinate(rayWS.Position, mi));
-
-                // bounds are in model space
-                var b = this.Bounds;
-
-                // this all happens now in model space now:
-                if (rayMS.Intersects(ref b))
-                {
-                    foreach (var t in g.Triangles)
-                    {
-                        float d;
-                        var p0 = t.P0;
-                        var p1 = t.P1;
-                        var p2 = t.P2;
-                        if (Collision.RayIntersectsTriangle(ref rayMS, ref p0, ref p1, ref p2, out d))
-                        {
-                            if (d < result.Distance)
-                            {
-                                result.IsValid = true;
-                                result.ModelHit = this;
-                                // transform hit-info to world space now:
-                                result.PointHit = Vector3.TransformCoordinate((rayMS.Position + (rayMS.Direction * d)), m).ToPoint3D();
-                                result.Distance = d;
-
-                                var n = Vector3.Cross(p1 - p0, p2 - p0);
-                                n.Normalize();
-                                // transform hit-info to world space now:
-                                result.NormalAtHit = Vector3.TransformNormal(n, m).ToVector3D();
-                            }
-                            h = true;
-                        }
-                    }
-                }
-            }
-
-            if (h)
-            {
-                result.IsValid = h;
-                hits.Add(result);
-            }
-            return h;
         }
-        */
+
+        protected abstract bool OnHitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits);
+
+        protected virtual bool CanHitTest(IRenderMatrices context)
+        {
+            return visibleInternal && isRenderingInternal && IsHitTestVisibleInternal;
+        }
 
         public bool IsThrowingShadow
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -457,7 +457,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 return false;
             }
-            if (this.IsHitTestVisible == false || this.geometryInternal == null)
+            if (this.IsHitTestVisibleInternal == false || this.geometryInternal == null)
             {
                 return false;
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/InstanceGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/InstanceGeometryModel3D.cs
@@ -1,0 +1,141 @@
+﻿using SharpDX;
+using SharpDX.Direct3D11;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace HelixToolkit.Wpf.SharpDX
+{
+    public abstract class InstanceGeometryModel3D : GeometryModel3D
+    {
+        /// <summary>
+        /// List of instance matrix. 
+        /// </summary>
+        public IList<Matrix> Instances
+        {
+            get { return (IList<Matrix>)this.GetValue(InstancesProperty); }
+            set { this.SetValue(InstancesProperty, value); }
+        }
+
+        /// <summary>
+        /// List of instance matrix.
+        /// </summary>
+        public static readonly DependencyProperty InstancesProperty =
+            DependencyProperty.Register("Instances", typeof(IList<Matrix>), typeof(InstanceGeometryModel3D), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, InstancesChanged));
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private static void InstancesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var model = (InstanceGeometryModel3D)d;
+            model.InstancesChanged();
+        }
+
+        protected bool isInstanceChanged = true;
+        protected bool hasInstances = false;
+        public bool HasInstancing { get { return hasInstances; } }
+        protected EffectScalarVariable bHasInstances;
+
+
+        protected BoundingBox instancesBound;
+        public BoundingBox InstancesBound
+        {
+            protected set
+            {
+                instancesBound = value;
+            }
+            get
+            {
+                return instancesBound;
+            }
+        }
+
+        protected virtual void InstancesChanged()
+        {
+            this.hasInstances = (this.Instances != null) && (this.Instances.Any());
+            UpdateInstancesBounds();
+            isInstanceChanged = true;
+        }
+
+        protected virtual void UpdateInstancesBounds()
+        {
+            if (!hasInstances)
+            {
+                InstancesBound = this.BoundsWithTransform;
+            }
+            else
+            {
+                var bound = BoundingBox.FromPoints(this.BoundsWithTransform.GetCorners().Select(x => Vector3.TransformCoordinate(x, Instances[0])).ToArray());
+                foreach (var instance in Instances)
+                {
+                    var b = BoundingBox.FromPoints(this.BoundsWithTransform.GetCorners().Select(x => Vector3.TransformCoordinate(x, instance)).ToArray());
+                    BoundingBox.Merge(ref bound, ref b, out bound);
+                }
+                InstancesBound = bound;
+            }
+        }
+
+        protected override bool CanHitTest(IRenderMatrices context)
+        {
+            return base.CanHitTest(context) && geometryInternal != null && geometryInternal.Positions != null && geometryInternal.Positions.Count > 0;
+        }
+        /// <summary>
+        /// 
+        /// </summary>        
+        public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+        {
+            if (CanHitTest(context))
+            {
+                if ((this.Instances != null) && (this.Instances.Any()))
+                {
+                    bool hit = false;
+                    int idx = 0;
+                    foreach (var modelMatrix in Instances)
+                    {
+                        var b = this.Bounds;
+                        this.PushMatrix(modelMatrix);
+                        if (OnHitTest(context, rayWS, ref hits))
+                        {
+                            hit = true;
+                            var lastHit = hits[hits.Count - 1];
+                            lastHit.Tag = idx;
+                            hits[hits.Count - 1] = lastHit;
+                        }
+                        this.PopMatrix();
+                        ++idx;
+                    }
+
+                    return hit;
+                }
+                else
+                {
+                    return OnHitTest(context, rayWS, ref hits);
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        protected override bool CheckBoundingFrustum(ref BoundingFrustum boundingFrustum)
+        {
+            return !hasInstances && base.CheckBoundingFrustum(ref boundingFrustum) || boundingFrustum.Intersects(ref instancesBound);
+        }
+
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            // --- init instances buffer            
+            bHasInstances = this.effect.GetVariableByName("bHasInstances").AsScalar();
+            InstancesChanged();
+        }
+
+        protected override void OnDetach()
+        {
+            Disposer.RemoveAndDispose(ref this.bHasInstances);
+            base.OnDetach();
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
@@ -19,7 +19,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
     using HelixToolkit.Wpf.SharpDX.Utilities;
 
-    public abstract class MaterialGeometryModel3D : GeometryModel3D
+    public abstract class MaterialGeometryModel3D : InstanceGeometryModel3D
     {
         protected InputLayout vertexLayout;
         protected Buffer vertexBuffer;
@@ -28,11 +28,8 @@ namespace HelixToolkit.Wpf.SharpDX
         protected EffectTechnique effectTechnique;
         protected EffectTransformVariables effectTransforms;
         protected EffectMaterialVariables effectMaterial;
-        protected EffectScalarVariable bHasInstances;
-        protected bool isInstanceChanged = true;
-        protected bool hasInstances = false;
+       
         protected bool hasShadowMap = false;
-        public bool HasInstancing { get { return hasInstances; } }
         public MaterialGeometryModel3D()
         {
         }
@@ -127,22 +124,6 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
             }
         }
-
-        /// <summary>
-        /// List of instance matrix. 
-        /// </summary>
-        public IList<Matrix> Instances
-        {
-            get { return (IList<Matrix>)this.GetValue(InstancesProperty); }
-            set { this.SetValue(InstancesProperty, value); }
-        }
-
-        /// <summary>
-        /// List of instance matrix.
-        /// </summary>
-        public static readonly DependencyProperty InstancesProperty =
-            DependencyProperty.Register("Instances", typeof(IList<Matrix>), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, InstancesChanged));
-
         /// <summary>
         /// 
         /// </summary>
@@ -159,59 +140,6 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty TextureCoodScaleProperty =
             DependencyProperty.Register("TextureCoodScale", typeof(Vector2), typeof(MaterialGeometryModel3D), new FrameworkPropertyMetadata(new Vector2(1, 1), FrameworkPropertyMetadataOptions.AffectsRender));
 
-
-        /// <summary>
-        /// 
-        /// </summary>
-        private static void InstancesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var model = (MaterialGeometryModel3D)d;
-            model.InstancesChanged();
-        }
-
-        protected virtual void InstancesChanged()
-        {
-            this.hasInstances = (this.Instances != null) && (this.Instances.Any());
-            UpdateInstancesBounds();
-            isInstanceChanged = true;
-        }
-
-        protected BoundingBox instancesBound;
-        public BoundingBox InstancesBound
-        {
-            protected set
-            {
-                instancesBound = value;
-            }
-            get
-            {
-                return instancesBound;
-            }
-        }
-
-        protected virtual void UpdateInstancesBounds()
-        {
-            if(!hasInstances)
-            {
-                InstancesBound = this.BoundsWithTransform;
-            }
-            else
-            {
-                var bound = BoundingBox.FromPoints(this.BoundsWithTransform.GetCorners().Select(x => Vector3.TransformCoordinate(x, Instances[0])).ToArray());
-                foreach(var instance in Instances)
-                {
-                    var b = BoundingBox.FromPoints(this.BoundsWithTransform.GetCorners().Select(x => Vector3.TransformCoordinate(x, instance)).ToArray());
-                    BoundingBox.Merge(ref bound, ref b, out bound);
-                }
-                InstancesBound = bound;
-            }
-        }
-
-        protected override bool CheckBoundingFrustum(ref BoundingFrustum boundingFrustum)
-        {
-            return !hasInstances && base.CheckBoundingFrustum(ref boundingFrustum) || boundingFrustum.Intersects(ref instancesBound);
-        }
-
         /// <summary>
         /// 
         /// </summary>
@@ -223,63 +151,6 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.effectMaterial = new EffectMaterialVariables(this.effect, phongMaterial);
                 this.effectMaterial.CreateTextureViews(Device, this);
             }
-        }
-
-        protected override void OnAttached()
-        {
-            base.OnAttached();
-            InstancesChanged();
-        }
-
-        protected override bool CanHitTest(IRenderMatrices context)
-        {
-            return base.CanHitTest(context) && geometryInternal != null && geometryInternal.Positions != null && geometryInternal.Positions.Count > 0;
-        }
-        /// <summary>
-        /// 
-        /// </summary>        
-        public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
-        {
-            if (CanHitTest(context))
-            {
-                if ((this.Instances != null) && (this.Instances.Any()))
-                {
-                    bool hit = false;
-                    foreach (var modelMatrix in Instances)
-                    {
-                        var b = this.Bounds;
-                        this.PushMatrix(modelMatrix);
-                        this.Bounds = BoundingBox.FromPoints(this.geometryInternal.Positions.Select(x => Vector3.TransformCoordinate(x, this.modelMatrix)).ToArray());
-                        if (OnHitTest(context, rayWS, ref hits))
-                        {
-                            hit = true;
-                            var lastHit = hits[hits.Count - 1];
-                            lastHit.Tag = modelMatrix;
-                            hits[hits.Count - 1] = lastHit;
-                        }
-                        this.PopMatrix();
-                        this.Bounds = b;
-                    }
-
-                    return hit;
-                }
-                else
-                {
-                    return OnHitTest(context, rayWS, ref hits);
-                }
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public override void Dispose()
-        {
-            this.Detach();
         }
 
         public class EffectMaterialVariables : System.IDisposable
@@ -425,7 +296,6 @@ namespace HelixToolkit.Wpf.SharpDX
 
             Disposer.RemoveAndDispose(ref this.effectMaterial);
             Disposer.RemoveAndDispose(ref this.effectTransforms);
-            Disposer.RemoveAndDispose(ref this.bHasInstances);
 
             this.effectTechnique = null;
             this.vertexLayout = null;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -63,17 +63,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="rayWS"></param>
         /// <param name="hits"></param>
         /// <returns></returns>
-        public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+        protected override bool OnHitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
         {
-            if (this.Visibility == Visibility.Collapsed || this.Visibility == Visibility.Hidden)
-            {
-                return false;
-            }
-            if (this.IsHitTestVisibleInternal == false)
-            {
-                return false;
-            }
-
             var g = this.geometryInternal as IBillboardText;
             var h = false;
             var result = new HitTestResult();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -69,7 +69,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 return false;
             }
-            if (this.IsHitTestVisible == false)
+            if (this.IsHitTestVisibleInternal == false)
             {
                 return false;
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
@@ -197,14 +197,9 @@ namespace HelixToolkit.Wpf.SharpDX
             return true;
         }
 
-        public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+        protected override bool CanHitTest(IRenderMatrices context)
         {
-            if (hasBoneParameter)
-            {
-                //Disable for now. Pending implementation.
-                return false;
-            }
-            return base.HitTest(context, rayWS, ref hits);
+            return base.CanHitTest(context) && !hasBoneParameter;
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
@@ -81,6 +81,10 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public override bool HitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
         {
+            if (!IsHitTestVisibleInternal)
+            {
+                return false;
+            }
             bool hit = base.HitTest(context, ray, ref hits);
 
             foreach (var c in this.Children)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
@@ -79,13 +79,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// Compute hit-testing for all children
         /// </summary>
-        public override bool HitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
+        protected override bool OnHitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
         {
-            if (!IsHitTestVisibleInternal)
-            {
-                return false;
-            }
-            bool hit = base.HitTest(context, ray, ref hits);
+            bool hit = false;
 
             foreach (var c in this.Children)
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
@@ -83,7 +83,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 return false;
             }
-            if (this.IsHitTestVisible == false)
+            if (this.IsHitTestVisibleInternal == false)
             {
                 return false;
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
@@ -77,17 +77,25 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public virtual bool HitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
+        protected virtual bool CanHitTest()
         {
-            if (this.Visibility == Visibility.Collapsed)
-            {
-                return false;
-            }
-            if (this.IsHitTestVisibleInternal == false)
-            {
-                return false;
-            }
+            return visibleInternal && isRenderingInternal && IsHitTestVisibleInternal;
+        }
 
+        public bool HitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
+        {
+            if (CanHitTest())
+            {
+                return OnHitTest(context, ray, ref hits);
+            }
+            else
+            {
+                return false;
+            }
+        }        
+
+        protected virtual bool OnHitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
+        {
             bool hit = false;
             foreach (var c in this.Children)
             {
@@ -118,6 +126,6 @@ namespace HelixToolkit.Wpf.SharpDX
                 hits = hits.OrderBy(x => Vector3.DistanceSquared(ray.Position, x.PointHit.ToVector3())).ToList();
             }            
             return hit;
-        }        
+        }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using SharpDX;
 using SharpDX.Direct3D;
 using SharpDX.Direct3D11;
-using System.Diagnostics;
 
 namespace HelixToolkit.Wpf.SharpDX
 {
@@ -99,9 +98,14 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="rayWS"></param>
         /// <param name="hits"></param>
         /// <returns></returns>
-        public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+        protected override bool CanHitTest(IRenderMatrices context)
         {
             //Implementation pending.
+            return false;
+        }
+
+        protected override bool OnHitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+        {
             return false;
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
@@ -211,7 +211,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private void BuildOctree()
         {
-            if (IsHitTestVisible && hasInstances)
+            if (IsHitTestVisibleInternal && hasInstances)
             {
                 OctreeManager?.RebuildTree(new Element3D[] { this });
             }
@@ -223,7 +223,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
         {
-            if (!IsHitTestVisible || OctreeManager == null || OctreeManager.Octree == null)
+            if (!IsHitTestVisibleInternal || OctreeManager == null || OctreeManager.Octree == null)
             {
                 return false;
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
@@ -257,16 +257,8 @@ namespace HelixToolkit.Wpf.SharpDX
                             {
                                 tag = instanceIdx;
                             }
-                            hits[hits.Count - 1] = new HitTestResult()
-                            {
-                                Distance = result.Distance,
-                                IsValid = result.IsValid,
-                                ModelHit = result.ModelHit,
-                                NormalAtHit = result.NormalAtHit,
-                                PointHit = result.PointHit,
-                                TriangleIndices = result.TriangleIndices,
-                                Tag = tag
-                            };
+                            result.Tag = tag;
+                            hits[hits.Count - 1] = result;
                         }
                     }
                 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
@@ -221,121 +221,167 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        protected override bool CanHitTest(IRenderMatrices context)
+        {
+            return base.CanHitTest(context) && OctreeManager != null && OctreeManager.Octree != null;
+        }
+
         public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
         {
-            if (!IsHitTestVisibleInternal || OctreeManager == null || OctreeManager.Octree == null)
-            {
-                return false;
-            }
-            else
+            bool isHit = false;
+            if (CanHitTest(context))
             {
                 var boundHits = new List<HitTestResult>();
-                bool isHit = false;
+                
                 isHit = OctreeManager.Octree.HitTest(context, this, ModelMatrix, rayWS, ref boundHits);
                 if (isHit)
                 {
-                    var g = this.geometryInternal as MeshGeometry3D;
-                    isHit = false;
                     Matrix instanceMatrix;
-                    if (g.Octree != null)
+                    foreach (var hit in boundHits)
                     {
-                        foreach (var hit in boundHits)
+                        int instanceIdx = (int)hit.Tag;
+                        instanceMatrix = Instances[instanceIdx];
+                        this.PushMatrix(instanceMatrix);
+                        var h = OnHitTest(context, rayWS, ref hits);
+                        isHit |= h;
+                        this.PopMatrix();
+                        if (h && hits.Count > 0)
                         {
-                            int instanceIdx = (int)hit.Tag;
-                            instanceMatrix = Instances[instanceIdx];
-                            this.PushMatrix(instanceMatrix);
-                            var h = g.Octree.HitTest(context, this, ModelMatrix, rayWS, ref hits);
-                            isHit |= h;
-                            this.PopMatrix();
-                            if (h && hits.Count > 0)
+                            var result = hits.Last();
+                            object tag = null;
+                            if (InstanceIdentifiers != null && InstanceIdentifiers.Count == Instances.Count)
                             {
-                                var result = hits[0];
-                                object tag = null;
-                                if (InstanceIdentifiers != null && InstanceIdentifiers.Count == Instances.Count)
-                                {
-                                    tag = InstanceIdentifiers[instanceIdx];
-                                }
-                                else
-                                {
-                                    tag = instanceIdx;
-                                }
-                                hits[0] = new HitTestResult()
-                                {
-                                    Distance = result.Distance,
-                                    IsValid = result.IsValid,
-                                    ModelHit = result.ModelHit,
-                                    NormalAtHit = result.NormalAtHit,
-                                    PointHit = result.PointHit,
-                                    TriangleIndices = result.TriangleIndices,
-                                    Tag = tag
-                                };
+                                tag = InstanceIdentifiers[instanceIdx];
                             }
-                        }
-                    }
-                    else
-                    {
-                        var result = new HitTestResult();
-                        result.Distance = double.MaxValue;
-                        foreach (var hit in boundHits)
-                        {
-                            int instanceIdx = (int)hit.Tag;
-                            instanceMatrix = Instances[instanceIdx];
-                            this.PushMatrix(instanceMatrix);
-
-                            var m = this.modelMatrix;
-
-                            // put bounds to world space
-
-                            int index = 0;
-                            foreach (var t in g.Triangles)
+                            else
                             {
-                                float d;
-                                var p0 = Vector3.TransformCoordinate(t.P0, m);
-                                var p1 = Vector3.TransformCoordinate(t.P1, m);
-                                var p2 = Vector3.TransformCoordinate(t.P2, m);
-                                if (Collision.RayIntersectsTriangle(ref rayWS, ref p0, ref p1, ref p2, out d))
-                                {
-                                    if (d > 0 && d < result.Distance) // If d is NaN, the condition is false.
-                                    {
-                                        result.IsValid = true;
-                                        result.ModelHit = this;
-                                        // transform hit-info to world space now:
-                                        result.PointHit = (rayWS.Position + (rayWS.Direction * d)).ToPoint3D();
-                                        result.Distance = d;
-                                        object tag = null;
-                                        if (InstanceIdentifiers != null && InstanceIdentifiers.Count == Instances.Count)
-                                        {
-                                            tag = InstanceIdentifiers[instanceIdx];
-                                        }
-                                        else
-                                        {
-                                            tag = instanceIdx;
-                                        }
-                                        result.Tag = tag;
-                                        var n = Vector3.Cross(p1 - p0, p2 - p0);
-                                        n.Normalize();
-                                        // transform hit-info to world space now:
-                                        result.NormalAtHit = n.ToVector3D();// Vector3.TransformNormal(n, m).ToVector3D();
-                                        result.TriangleIndices = new System.Tuple<int, int, int>(g.Indices[index], g.Indices[index + 1], g.Indices[index + 2]);
-                                        isHit = true;
-                                    }
-                                }
-                                index += 3;
+                                tag = instanceIdx;
                             }
-                            this.PopMatrix();
-                        }
-                        if (isHit)
-                        {
-                            hits.Add(result);
+                            hits[hits.Count - 1] = new HitTestResult()
+                            {
+                                Distance = result.Distance,
+                                IsValid = result.IsValid,
+                                ModelHit = result.ModelHit,
+                                NormalAtHit = result.NormalAtHit,
+                                PointHit = result.PointHit,
+                                TriangleIndices = result.TriangleIndices,
+                                Tag = tag
+                            };
                         }
                     }
                 }
-#if DEBUG
-                if (isHit)
-                    Debug.WriteLine("Hit: " + hits[0].Tag + "; HitPoint: " + hits[0].PointHit);
-#endif
-                return isHit;
             }
+            return isHit;
         }
+
+//        protected override bool OnHitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+//        {
+//            var boundHits = new List<HitTestResult>();
+//            bool isHit = false;
+//            isHit = OctreeManager.Octree.HitTest(context, this, ModelMatrix, rayWS, ref boundHits);
+//            if (isHit)
+//            {
+//                var g = this.geometryInternal as MeshGeometry3D;
+//                isHit = false;
+//                Matrix instanceMatrix;
+//                if (g.Octree != null)
+//                {
+//                    foreach (var hit in boundHits)
+//                    {
+//                        int instanceIdx = (int)hit.Tag;
+//                        instanceMatrix = Instances[instanceIdx];
+//                        this.PushMatrix(instanceMatrix);
+//                        var h = g.Octree.HitTest(context, this, ModelMatrix, rayWS, ref hits);
+//                        isHit |= h;
+//                        this.PopMatrix();
+//                        if (h && hits.Count > 0)
+//                        {
+//                            var result = hits[0];
+//                            object tag = null;
+//                            if (InstanceIdentifiers != null && InstanceIdentifiers.Count == Instances.Count)
+//                            {
+//                                tag = InstanceIdentifiers[instanceIdx];
+//                            }
+//                            else
+//                            {
+//                                tag = instanceIdx;
+//                            }
+//                            hits[0] = new HitTestResult()
+//                            {
+//                                Distance = result.Distance,
+//                                IsValid = result.IsValid,
+//                                ModelHit = result.ModelHit,
+//                                NormalAtHit = result.NormalAtHit,
+//                                PointHit = result.PointHit,
+//                                TriangleIndices = result.TriangleIndices,
+//                                Tag = tag
+//                            };
+//                        }
+//                    }
+//                }
+//                else
+//                {
+//                    var result = new HitTestResult();
+//                    result.Distance = double.MaxValue;
+//                    foreach (var hit in boundHits)
+//                    {
+//                        int instanceIdx = (int)hit.Tag;
+//                        instanceMatrix = Instances[instanceIdx];
+//                        this.PushMatrix(instanceMatrix);
+
+//                        var m = this.modelMatrix;
+
+//                        // put bounds to world space
+
+//                        int index = 0;
+//                        foreach (var t in g.Triangles)
+//                        {
+//                            float d;
+//                            var p0 = Vector3.TransformCoordinate(t.P0, m);
+//                            var p1 = Vector3.TransformCoordinate(t.P1, m);
+//                            var p2 = Vector3.TransformCoordinate(t.P2, m);
+//                            if (Collision.RayIntersectsTriangle(ref rayWS, ref p0, ref p1, ref p2, out d))
+//                            {
+//                                if (d > 0 && d < result.Distance) // If d is NaN, the condition is false.
+//                                {
+//                                    result.IsValid = true;
+//                                    result.ModelHit = this;
+//                                    // transform hit-info to world space now:
+//                                    result.PointHit = (rayWS.Position + (rayWS.Direction * d)).ToPoint3D();
+//                                    result.Distance = d;
+//                                    object tag = null;
+//                                    if (InstanceIdentifiers != null && InstanceIdentifiers.Count == Instances.Count)
+//                                    {
+//                                        tag = InstanceIdentifiers[instanceIdx];
+//                                    }
+//                                    else
+//                                    {
+//                                        tag = instanceIdx;
+//                                    }
+//                                    result.Tag = tag;
+//                                    var n = Vector3.Cross(p1 - p0, p2 - p0);
+//                                    n.Normalize();
+//                                    // transform hit-info to world space now:
+//                                    result.NormalAtHit = n.ToVector3D();// Vector3.TransformNormal(n, m).ToVector3D();
+//                                    result.TriangleIndices = new System.Tuple<int, int, int>(g.Indices[index], g.Indices[index + 1], g.Indices[index + 2]);
+//                                    isHit = true;
+//                                }
+//                            }
+//                            index += 3;
+//                        }
+//                        this.PopMatrix();
+//                    }
+//                    if (isHit)
+//                    {
+//                        hits.Add(result);
+//                    }
+//                }
+//#if DEBUG
+//                if (isHit)
+//                    Debug.WriteLine("Hit: " + hits[0].Tag + "; HitPoint: " + hits[0].PointHit);
+//#endif
+//            }
+//            return isHit;
+//        }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Items3DControl.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Items3DControl.cs
@@ -298,7 +298,21 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// Compute hit-testing for all children
         /// </summary>
-        public virtual bool HitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
+        public bool HitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
+        {
+            if (CanHitTest(context))
+            {
+                return OnHitTest(context, ray, ref hits);
+            }
+            else return false;
+        }
+
+        protected virtual bool CanHitTest(IRenderMatrices context)
+        {
+            return IsHitTestVisible && Visibility == System.Windows.Visibility.Visible;
+        }
+
+        protected virtual bool OnHitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
         {
             bool hit = false;
 
@@ -328,6 +342,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             return hit;
         }        
+
+
 
         /// <summary>
         /// 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
@@ -367,6 +367,10 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public override bool HitTest(IRenderMatrices context, global::SharpDX.Ray ray, ref List<HitTestResult> hits)
         {
+            if (!IsHitTestVisibleInternal)
+            {
+                return false;
+            }
             bool isHit = false;
             if (Octree != null)
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ItemsModel3D.cs
@@ -365,12 +365,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public override bool HitTest(IRenderMatrices context, global::SharpDX.Ray ray, ref List<HitTestResult> hits)
+        protected override bool OnHitTest(IRenderMatrices context, global::SharpDX.Ray ray, ref List<HitTestResult> hits)
         {
-            if (!IsHitTestVisibleInternal)
-            {
-                return false;
-            }
             bool isHit = false;
             if (Octree != null)
             {
@@ -384,7 +380,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             else
             {
-                isHit = base.HitTest(context, ray, ref hits);
+                isHit = base.OnHitTest(context, ray, ref hits);
             }
             return isHit;
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -115,6 +115,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 if ((this.Instances != null) && (this.Instances.Any()))
                 {
                     bool hit = false;
+                    int idx = 0;
                     foreach (var modelMatrix in Instances)
                     {
                         this.PushMatrix(modelMatrix);
@@ -122,10 +123,11 @@ namespace HelixToolkit.Wpf.SharpDX
                         {
                             hit = true;
                             var lastHit = hits[hits.Count - 1];
-                            lastHit.Tag = modelMatrix;
+                            lastHit.Tag = idx;
                             hits[hits.Count - 1] = lastHit;
                         }
                         this.PopMatrix();
+                        ++idx;
                     }
 
                     return hit;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -31,7 +31,7 @@ namespace HelixToolkit.Wpf.SharpDX
     using Buffer = global::SharpDX.Direct3D11.Buffer;
     using System.Runtime.CompilerServices;
 
-    public class LineGeometryModel3D : GeometryModel3D
+    public class LineGeometryModel3D : InstanceGeometryModel3D
     {
         private LinesVertex[] vertexArrayBuffer = null;
         protected InputLayout vertexLayout;
@@ -41,11 +41,6 @@ namespace HelixToolkit.Wpf.SharpDX
         protected EffectTechnique effectTechnique;
         protected EffectTransformVariables effectTransforms;
         protected EffectVectorVariable vViewport, vLineParams; // vFrustum, 
-        //private DepthStencilState depthStencilState;
-        //private LineGeometry3D geometry;
-        protected EffectScalarVariable bHasInstances;
-        protected bool hasInstances = false;
-        protected bool isChanged = true;
 
         public override int VertexSizeInBytes
         {
@@ -83,14 +78,6 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty SmoothnessProperty =
             DependencyProperty.Register("Smoothness", typeof(double), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(0.0));
 
-        public IList<Matrix> Instances
-        {
-            get { return (IList<Matrix>)this.GetValue(InstancesProperty); }
-            set { this.SetValue(InstancesProperty, value); }
-        }
-
-        public static readonly DependencyProperty InstancesProperty =
-            DependencyProperty.Register("Instances", typeof(IList<Matrix>), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(null, InstancesChanged));
 
         public double HitTestThickness
         {
@@ -101,47 +88,40 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty HitTestThicknessProperty =
             DependencyProperty.Register("HitTestThickness", typeof(double), typeof(LineGeometryModel3D), new UIPropertyMetadata(1.0));
 
-        protected static void InstancesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var model = (LineGeometryModel3D)d;
-            model.hasInstances = model.Instances != null && model.Instances.Any();
-            model.isChanged = true;
-        }
+        //public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+        //{
+        //    if (CanHitTest(context))
+        //    {
+        //        if ((this.Instances != null) && (this.Instances.Any()))
+        //        {
+        //            bool hit = false;
+        //            int idx = 0;
+        //            foreach (var modelMatrix in Instances)
+        //            {
+        //                this.PushMatrix(modelMatrix);
+        //                if (OnHitTest(context, rayWS, ref hits))
+        //                {
+        //                    hit = true;
+        //                    var lastHit = hits[hits.Count - 1];
+        //                    lastHit.Tag = idx;
+        //                    hits[hits.Count - 1] = lastHit;
+        //                }
+        //                this.PopMatrix();
+        //                ++idx;
+        //            }
 
-        public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
-        {
-            if (CanHitTest(context))
-            {
-                if ((this.Instances != null) && (this.Instances.Any()))
-                {
-                    bool hit = false;
-                    int idx = 0;
-                    foreach (var modelMatrix in Instances)
-                    {
-                        this.PushMatrix(modelMatrix);
-                        if (OnHitTest(context, rayWS, ref hits))
-                        {
-                            hit = true;
-                            var lastHit = hits[hits.Count - 1];
-                            lastHit.Tag = idx;
-                            hits[hits.Count - 1] = lastHit;
-                        }
-                        this.PopMatrix();
-                        ++idx;
-                    }
-
-                    return hit;
-                }
-                else
-                {
-                    return OnHitTest(context, rayWS, ref hits);
-                }
-            }
-            else
-            {
-                return false;
-            }
-        }
+        //            return hit;
+        //        }
+        //        else
+        //        {
+        //            return OnHitTest(context, rayWS, ref hits);
+        //        }
+        //    }
+        //    else
+        //    {
+        //        return false;
+        //    }
+        //}
 
 
         protected override bool CanHitTest(IRenderMatrices context)
@@ -313,8 +293,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 throw new ArgumentException("Geometry must be LineGeometry3D");
             }
-          
-            bHasInstances = effect.GetVariableByName("bHasInstances").AsScalar();
+         
 
             // --- set up const variables
             vViewport = effect.GetVariableByName("vViewport").AsVector();
@@ -349,8 +328,6 @@ namespace HelixToolkit.Wpf.SharpDX
             Disposer.RemoveAndDispose(ref this.vViewport);
             Disposer.RemoveAndDispose(ref this.vLineParams);            
             Disposer.RemoveAndDispose(ref this.rasterState);
-            //Disposer.RemoveAndDispose(ref this.depthStencilState);
-            Disposer.RemoveAndDispose(ref this.bHasInstances);
 
             this.renderTechnique = null;
             this.effectTechnique = null;
@@ -417,7 +394,7 @@ namespace HelixToolkit.Wpf.SharpDX
             if (this.hasInstances)
             {
                 // --- update instance buffer
-                if (this.isChanged)
+                if (this.isInstanceChanged)
                 {
                     if(instanceBuffer == null || instanceBuffer.Description.SizeInBytes < Matrix.SizeInBytes * this.Instances.Count)
                     {
@@ -433,7 +410,7 @@ namespace HelixToolkit.Wpf.SharpDX
                         renderContext.DeviceContext.UnmapSubresource(this.instanceBuffer, 0);
                         stream.Dispose();
                     }
-                    this.isChanged = false;
+                    this.isInstanceChanged = false;
                 }
 
                 // --- INSTANCING: need to set 2 buffers            

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -113,7 +113,7 @@ namespace HelixToolkit.Wpf.SharpDX
             LineGeometry3D lineGeometry3D;
 
             if (this.Visibility == Visibility.Collapsed ||
-                this.IsHitTestVisible == false ||
+                this.IsHitTestVisibleInternal == false ||
                 context == null ||
                 (lineGeometry3D = this.geometryInternal as LineGeometry3D) == null)
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -158,7 +158,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     lastDist = dist;
                     result.PointHit = sp.ToPoint3D();
                     result.NormalAtHit = (sp - tp).ToVector3D(); // not normalized to get length
-                    result.Distance = distance;
+                    result.Distance = (rayWS.Position-sp).Length();
                     result.ModelHit = this;
                     result.IsValid = true;
                     result.Tag = index; // ToDo: LineHitTag with additional info

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -192,9 +192,6 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 throw new System.Exception("Geometry must not be null");
             }
-
-            // --- init instances buffer            
-            this.bHasInstances = this.effect.GetVariableByName("bHasInstances").AsScalar();
             // --- flush
             //this.Device.ImmediateContext.Flush();
             return true;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -316,7 +316,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="rayWS"></param>
         /// <param name="hits"></param>
         /// <returns></returns>
-        public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+        protected override bool OnHitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
         {
             // disable hittesting for patchgeometry for now
             // need to be implemented

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -101,7 +101,7 @@
             {
                 return false;
             }
-            if (this.IsHitTestVisible == false || this.geometryInternal == null)
+            if (this.IsHitTestVisibleInternal == false || this.geometryInternal == null)
             {
                 return false;
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -88,6 +88,11 @@
             return (p - pb).Length();
         }
 
+        protected override bool CanHitTest(IRenderMatrices context)
+        {
+            return base.CanHitTest(context) && geometryInternal.Positions != null && geometryInternal.Positions.Count > 0 && geometryInternal is PointGeometry3D && context != null;
+        }
+
         /// <summary>
         /// Checks if the ray hits the geometry of the model.
         /// If there a more than one hit, result returns the hit which is nearest to the ray origin.
@@ -95,33 +100,15 @@
         /// <param name="rayWS">Hitring ray from the camera.</param>
         /// <param name="hits">results of the hit.</param>
         /// <returns>True if the ray hits one or more times.</returns>
-        public override bool HitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
+        protected override bool OnHitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
         {
-            if (this.Visibility == Visibility.Collapsed)
-            {
-                return false;
-            }
-            if (this.IsHitTestVisibleInternal == false || this.geometryInternal == null)
-            {
-                return false;
-            }
             if (geometryInternal.Octree != null)
             {
                 return geometryInternal.Octree.HitTest(context, this, ModelMatrix, rayWS, ref hits);
             }
             else
             {
-                PointGeometry3D pointGeometry3D;
-
-                if (context == null ||
-                    (pointGeometry3D = this.geometryInternal as PointGeometry3D) == null)
-                {
-                    return false;
-                }
-                if (pointGeometry3D.Points == null)
-                {
-                    return false;
-                }
+                PointGeometry3D pointGeometry3D = this.geometryInternal as PointGeometry3D;
                 var svpm =  context.ScreenViewProjectionMatrix;
                 var smvpm = this.modelMatrix * svpm;
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/TransformableItems3DControl.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/TransformableItems3DControl.cs
@@ -63,7 +63,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// Compute hit-testing for all children
         /// </summary>
-        public override bool HitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
+        protected override bool OnHitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
         {
             bool hit = false;
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UICompositeManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UICompositeManipulator3D.cs
@@ -238,7 +238,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="ray"></param>
         /// <param name="hits"></param>
         /// <returns></returns>
-        public override bool HitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
+        protected override bool OnHitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
         {
             bool hit = false;
             foreach (var c in this.Children)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIRotateManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIRotateManipulator3D.cs
@@ -187,7 +187,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public override void OnMouse3DMove(object sender, RoutedEventArgs e)
         {            
-            if (IsHitTestVisible)
+            if (IsHitTestVisibleInternal)
                 base.OnMouse3DMove(sender, e);
         }
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
@@ -1395,26 +1395,6 @@ namespace HelixToolkit.Wpf.SharpDX
             return source.Contains(Positions[obj]) != ContainmentType.Disjoint;
         }
 
-        public static T FindVisualAncestor<T>(FrameworkElement obj) where T : FrameworkElement
-        {
-            if (obj != null)
-            {
-                var parent = obj.Parent;
-                while (parent != null)
-                {
-                    var typed = parent as T;
-                    if (typed != null)
-                    {
-                        return typed;
-                    }
-
-                    parent = (parent as FrameworkElement).Parent;
-                }
-            }
-
-            return null;
-        }
-
         public static double DistanceRayToPoint(ref Ray r, ref Vector3 p)
         {
             Vector3 v = r.Direction;

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/OctreeManager.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/OctreeManager.cs
@@ -17,7 +17,7 @@ using System.Windows.Markup;
 
 namespace HelixToolkit.Wpf.SharpDX
 {
-    public abstract class OctreeManagerBase : FrameworkElement, IOctreeManager
+    public abstract class OctreeManagerBase : FrameworkContentElement, IOctreeManager
     {
         public static readonly DependencyProperty OctreeProperty
             = DependencyProperty.Register("Octree", typeof(IOctree), typeof(OctreeManagerBase),


### PR DESCRIPTION
1. Change Element3D base class to more lightweight FrameworkContentElement. Since it does not need those additional layout change/visual rendering properties.
2. Reduce Dependency property latency.
3. Clean up hit test. Bug fixes.
4. Separate instance related variables into its own base class.
