### PR TITLE
Added LineHitTestResult class with line-specific information about the hit

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/HitTestResult.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/HitTestResult.cs
@@ -66,6 +66,11 @@ namespace HelixToolkit.Wpf.SharpDX
     public class LineHitTestResult : HitTestResult
     {
         /// <summary>
+        /// Gets or sets the index of the line segment that was hit.
+        /// </summary>
+        public int LineIndex { get; set; }
+
+        /// <summary>
         /// Gets or sets the shortest distance between the hit test ray and the line that was hit.
         /// </summary>
         public double RayToLineDistance { get; set; }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/HitTestResult.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/HitTestResult.cs
@@ -66,12 +66,17 @@ namespace HelixToolkit.Wpf.SharpDX
     public class LineHitTestResult : HitTestResult
     {
         /// <summary>
-        /// Scalar of the closest point on ray.
+        /// Gets or sets the shortest distance between the hit test ray and the line that was hit.
+        /// </summary>
+        public double RayToLineDistance { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scalar of the closest point on the hit test ray.
         /// </summary>
         public double Sc { get; set; }
 
         /// <summary>
-        /// Scalar of the closest point on line.
+        /// Gets or sets the scalar of the closest point on the line that was hit.
         /// </summary>
         public double Tc { get; set; }
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/HitTestResult.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/HitTestResult.cs
@@ -59,4 +59,20 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public System.Tuple<int, int, int> TriangleIndices { set; get; }
     }
+
+    /// <summary>
+    /// A specialized line hit test result.
+    /// </summary>
+    public class LineHitTestResult : HitTestResult
+    {
+        /// <summary>
+        /// Scalar of the closest point on ray.
+        /// </summary>
+        public double Sc { get; set; }
+
+        /// <summary>
+        /// Scalar of the closest point on line.
+        /// </summary>
+        public double Tc { get; set; }
+    }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/HitTestResult.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/HitTestResult.cs
@@ -78,11 +78,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// Gets or sets the scalar of the closest point on the hit test ray.
         /// </summary>
-        public double Sc { get; set; }
+        public double RayHitPointScalar { get; set; }
 
         /// <summary>
         /// Gets or sets the scalar of the closest point on the line that was hit.
         /// </summary>
-        public double Tc { get; set; }
+        public double LineHitPointScalar { get; set; }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -132,11 +132,15 @@ namespace HelixToolkit.Wpf.SharpDX
 
         protected override bool OnHitTest(IRenderMatrices context, Ray rayWS, ref List<HitTestResult> hits)
         {
-            LineGeometry3D lineGeometry3D = this.geometryInternal as LineGeometry3D;
+            var lineGeometry3D = this.geometryInternal as LineGeometry3D;
+            if (lineGeometry3D == null)
+            {
+                return false;
+            }
 
-            var result = new HitTestResult { IsValid = false, Distance = double.MaxValue };
+            var result = new LineHitTestResult { IsValid = false, Distance = double.MaxValue };
             var lastDist = double.MaxValue;
-            var index = 0;
+            var lineIndex = 0;
             foreach (var line in lineGeometry3D.Lines)
             {
                 var t0 = Vector3.TransformCoordinate(line.P0, this.ModelMatrix);
@@ -158,13 +162,16 @@ namespace HelixToolkit.Wpf.SharpDX
                     lastDist = dist;
                     result.PointHit = sp.ToPoint3D();
                     result.NormalAtHit = (sp - tp).ToVector3D(); // not normalized to get length
-                    result.Distance = (rayWS.Position-sp).Length();
+                    result.Distance = distance;
                     result.ModelHit = this;
                     result.IsValid = true;
-                    result.Tag = index; // ToDo: LineHitTag with additional info
+                    result.Tag = lineIndex; // For compatibility
+                    result.TriangleIndices = new Tuple<int, int, int>(lineIndex, lineIndex + 1, -1);
+                    result.Sc = sc;
+                    result.Tc = tc;
                 }
 
-                index++;
+                lineIndex++;
             }
 
             if (result.IsValid)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -147,7 +147,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 var t1 = Vector3.TransformCoordinate(line.P1, this.ModelMatrix);
                 Vector3 sp, tp;
                 float sc, tc;
-                var distance = LineBuilder.GetRayToLineDistance(rayWS, t0, t1, out sp, out tp, out sc, out tc);
+                var rayToLineDistance = LineBuilder.GetRayToLineDistance(rayWS, t0, t1, out sp, out tp, out sc, out tc);
                 var svpm = context.ScreenViewProjectionMatrix;
                 Vector4 sp4;
                 Vector4 tp4;
@@ -162,7 +162,8 @@ namespace HelixToolkit.Wpf.SharpDX
                     lastDist = dist;
                     result.PointHit = sp.ToPoint3D();
                     result.NormalAtHit = (sp - tp).ToVector3D(); // not normalized to get length
-                    result.Distance = distance;
+                    result.Distance = (rayWS.Position - sp).Length();
+                    result.RayToLineDistance = rayToLineDistance;
                     result.ModelHit = this;
                     result.IsValid = true;
                     result.Tag = lineIndex; // For compatibility

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -167,7 +167,8 @@ namespace HelixToolkit.Wpf.SharpDX
                     result.ModelHit = this;
                     result.IsValid = true;
                     result.Tag = lineIndex; // For compatibility
-                    result.TriangleIndices = new Tuple<int, int, int>(lineIndex, lineIndex + 1, -1);
+                    result.LineIndex = lineIndex;
+                    result.TriangleIndices = null; // Since triangles are shader-generated
                     result.Sc = sc;
                     result.Tc = tc;
                 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -169,8 +169,8 @@ namespace HelixToolkit.Wpf.SharpDX
                     result.Tag = lineIndex; // For compatibility
                     result.LineIndex = lineIndex;
                     result.TriangleIndices = null; // Since triangles are shader-generated
-                    result.Sc = sc;
-                    result.Tc = tc;
+                    result.RayHitPointScalar = sc;
+                    result.LineHitPointScalar = tc;
                 }
 
                 lineIndex++;


### PR DESCRIPTION
The scalar of the closest point on line ("Tc") is useful if you need to know at which percentage of the line the hit was.