### PR TITLE
Properly implement GroupElement3D

### DIFF
--- a/Source/Examples/WPF.SharpDX/DeferredShadingDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/DeferredShadingDemo/MainViewModel.cs
@@ -56,7 +56,7 @@ namespace DeferredShadingDemo
         public Transform3D PointLightTransform2 { get; private set; }
         public Transform3D PointLightTransform3 { get; private set; }
 
-        public Element3DCollection PointLightCollection { get; set; }
+        public ObservableElement3DCollection PointLightCollection { get; set; }
         public Color4 PointLightColor
         {
             get { return this.pointLightColor; }
@@ -78,7 +78,7 @@ namespace DeferredShadingDemo
             set { this.pointLightSpread = value; this.InitPointLightCollection(this.PointLightCount); }
         }
 
-        public Element3DCollection SpotLightCollection { get; set; }
+        public ObservableElement3DCollection SpotLightCollection { get; set; }
         public Color4 SpotLightColor
         {
             get { return this.spotLightColor; }
@@ -175,12 +175,12 @@ namespace DeferredShadingDemo
             this.SpotLightAttenuation = new Vector3(1.0f, 0.1f, 0.01f);
 
             // light collection
-            this.PointLightCollection = new Element3DCollection();
+            this.PointLightCollection = new ObservableElement3DCollection();
             this.PointLightCount = 7;
             this.PointLightSpread = 100;
 
             // spotlight collection
-            this.SpotLightCollection = new Element3DCollection();
+            this.SpotLightCollection = new ObservableElement3DCollection();
             this.SpotLightCount = 7;
             this.SpotLightSpread = 100;
         }
@@ -192,10 +192,10 @@ namespace DeferredShadingDemo
         private void InitPointLightCollection(int numberLights)
         {
             // store the current technique
-            var technique = this.RenderTechnique;
+          //  var technique = this.RenderTechnique;
 
             // detouch the renderer
-            this.RenderTechnique = null;
+         //   this.RenderTechnique = null;
 
             // random            
             var rndx = new Random();
@@ -220,7 +220,7 @@ namespace DeferredShadingDemo
             }
 
             // attach the renderer
-            this.RenderTechnique = technique;
+        //    this.RenderTechnique = technique;
         }
 
         /// <summary>
@@ -245,10 +245,10 @@ namespace DeferredShadingDemo
         private void InitSpotLightCollection(int numberLights)
         {
             // store the current technique
-            var technique = this.RenderTechnique;
+            //var technique = this.RenderTechnique;
 
             // detouch the renderer
-            this.RenderTechnique = null;
+            //this.RenderTechnique = null;
 
             // random            
             var rndx = new Random();
@@ -274,7 +274,7 @@ namespace DeferredShadingDemo
             }
 
             // attach the renderer
-            this.RenderTechnique = technique;
+            //this.RenderTechnique = technique;
         }
 
         /// <summary>

--- a/Source/Examples/WPF.SharpDX/DeferredShadingDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/DeferredShadingDemo/MainWindow.xaml
@@ -41,8 +41,8 @@
             <!--<hx:PointLight3D Color="{Binding PointLightColor}" Attenuation="{Binding PointLightAttenuation}" Transform="{Binding PointLightTransform1}"/>-->
             <!--<hx:PointLight3D Color="{Binding PointLightColor}" Attenuation="{Binding PointLightAttenuation}" Transform="{Binding PointLightTransform2}"/>-->
             <!--<hx:PointLight3D Color="{Binding PointLightColor}" Attenuation="{Binding PointLightAttenuation}" Transform="{Binding PointLightTransform3}"/>-->
-            <hx:Light3DCollection Children="{Binding PointLightCollection}" />
-            <hx:Light3DCollection Children="{Binding SpotLightCollection}" />
+            <hx:Light3DCollection ItemsSource="{Binding PointLightCollection}" />
+            <hx:Light3DCollection ItemsSource="{Binding SpotLightCollection}" />
             <hx:MeshGeometryModel3D x:Name="model1" Geometry="{Binding Model}" Transform = "{Binding Model1Transform}" Material="{Binding RedMaterial}"   />
             <hx:MeshGeometryModel3D x:Name="model2" Geometry="{Binding Model}" Transform = "{Binding Model2Transform}" Material="{Binding GreenMaterial}" />
             <hx:MeshGeometryModel3D x:Name="model3" Geometry="{Binding Model}" Transform = "{Binding Model3Transform}" Material="{Binding BlueMaterial}"  />

--- a/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/MainWindow.xaml
@@ -50,7 +50,7 @@
             <hx:AmbientLight3D Color="{Binding AmbientLightColor}"/>
             <hx:DirectionalLight3D Color="{Binding DirectionalLightColor}" Direction="{Binding DirectionalLightDirection}"/>
             <hx:EnvironmentMap3D x:Name="envMap" Filename="Cubemap_Grandcanyon.dds"/>
-            <hx:MeshGeometryModel3D x:Name="model" Geometry="{Binding Model}" Transform="{Binding ModelTransform}" Material="{Binding ModelMaterial}"   />
+            <hx:MeshGeometryModel3D x:Name="model" IsMultisampleEnabled="False" Geometry="{Binding Model}" Transform="{Binding ModelTransform}" Material="{Binding ModelMaterial}"   />
         </hx:Viewport3DX>
         
         <StackPanel>

--- a/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10044/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10044/MainWindow.xaml
@@ -68,17 +68,17 @@
             </hx:Viewport3DX.InputBindings>
             <hx:AmbientLight3D Color="0.1,0.1,0.1,1.0"/>
             <hx:DirectionalLight3D Color="{x:Static sdxm:Color4.White}" Direction="-2,-5,-2"/>
-            <hx:CompositeModel3D Transform="{StaticResource Model2Transform}">
+            <hx:GroupModel3D Transform="{StaticResource Model2Transform}">
                 <hx:MeshGeometryModel3D Geometry="{StaticResource Model}" Material="{x:Static hx:PhongMaterials.Green}"/>
-            </hx:CompositeModel3D>
-            <hx:CompositeModel3D Transform="{StaticResource Model3Transform}">
+            </hx:GroupModel3D>
+            <hx:GroupModel3D Transform="{StaticResource Model3Transform}">
                 <hx:MeshGeometryModel3D Geometry="{StaticResource Model}" Material="{x:Static hx:PhongMaterials.Blue}"/>
-            </hx:CompositeModel3D>
-            <hx:CompositeModel3D Transform="{StaticResource Model2Transform}">
+            </hx:GroupModel3D>
+            <hx:GroupModel3D Transform="{StaticResource Model2Transform}">
                 <hx:CompositeModel3D Transform="{StaticResource Model3Transform}">
                     <hx:LineGeometryModel3D Geometry="{StaticResource Lines}" Transform="{StaticResource Model1Transform}" Color="{x:Static sdxm:Color.Black}" Thickness="1.5"/>
                 </hx:CompositeModel3D>
-            </hx:CompositeModel3D>
+            </hx:GroupModel3D>
             <hx:MeshGeometryModel3D Geometry="{StaticResource Model}" Transform="{StaticResource Model1Transform}" Material="{x:Static hx:PhongMaterials.Red}"/>
         </hx:Viewport3DX>
 

--- a/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml
@@ -10,7 +10,7 @@
         <hx:Viewport3DX x:Name="view">
             <hx:AmbientLight3D />
             <hx:DirectionalLight3D Direction = "-2,-5,-2"/>
-      <hx:GroupModel3D x:Name="group"   Children="{Binding ModelGeometry}"   Transform = "{Binding ModelTransform}" />
+      <hx:GroupModel3D x:Name="group"   ItemsSource="{Binding ModelGeometry}"   Transform = "{Binding ModelTransform}" />
     </hx:Viewport3DX>
     <Menu Height="20" VerticalAlignment="Top">
       <MenuItem Header="File"  >

--- a/Source/Examples/WPF.SharpDX/MemoryLeakTester/MemoryLeakTester.csproj
+++ b/Source/Examples/WPF.SharpDX/MemoryLeakTester/MemoryLeakTester.csproj
@@ -63,8 +63,9 @@
       <HintPath>..\..\..\packages\SharpDX.DXGI.3.1.1\lib\net45\SharpDX.DXGI.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SharpDX.Mathematics">
-      <HintPath>..\DynamicTextureDemo\bin\Release\SharpDX.Mathematics.dll</HintPath>
+    <Reference Include="SharpDX.Mathematics, Version=3.1.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\SharpDX.Mathematics.3.1.1\lib\net45\SharpDX.Mathematics.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/Source/Examples/WPF.SharpDX/MemoryLeakTester/packages.config
+++ b/Source/Examples/WPF.SharpDX/MemoryLeakTester/packages.config
@@ -6,4 +6,5 @@
   <package id="SharpDX" version="3.1.1" targetFramework="net452" />
   <package id="SharpDX.Direct3D11" version="3.1.1" targetFramework="net452" />
   <package id="SharpDX.DXGI" version="3.1.1" targetFramework="net452" />
+  <package id="SharpDX.Mathematics" version="3.1.1" targetFramework="net452" />
 </packages>

--- a/Source/Examples/WPF.SharpDX/MouseDragDemo/InteractionHandle3D.cs
+++ b/Source/Examples/WPF.SharpDX/MouseDragDemo/InteractionHandle3D.cs
@@ -118,9 +118,9 @@ namespace MouseDragDemo
                 this.midpointHandles[i].MouseUp3D += OnNodeMouse3DUp;
                 this.midpointHandles[i].MouseDown3D += OnNodeMouse3DDown;
        
-                this.Children.Add(cornerHandles[i]);
-                this.Children.Add(edgeHandles[i]);
-                this.Children.Add(midpointHandles[i]);
+                this.ItemsSource.Add(cornerHandles[i]);
+                this.ItemsSource.Add(edgeHandles[i]);
+                this.ItemsSource.Add(midpointHandles[i]);
             }
 
             // 3 --- 2 
@@ -355,7 +355,7 @@ namespace MouseDragDemo
         {
             if (e.NewValue is PhongMaterial)
             {
-                foreach (var item in ((GroupModel3D)d).Children)
+                foreach (var item in ((GroupModel3D)d).ItemsSource)
                 {
                     var model = item as MaterialGeometryModel3D;
                     if (model != null)

--- a/Source/Examples/WPF.SharpDX/MouseDragDemo/InteractionHandle3D.cs
+++ b/Source/Examples/WPF.SharpDX/MouseDragDemo/InteractionHandle3D.cs
@@ -118,9 +118,9 @@ namespace MouseDragDemo
                 this.midpointHandles[i].MouseUp3D += OnNodeMouse3DUp;
                 this.midpointHandles[i].MouseDown3D += OnNodeMouse3DDown;
        
-                this.ItemsSource.Add(cornerHandles[i]);
-                this.ItemsSource.Add(edgeHandles[i]);
-                this.ItemsSource.Add(midpointHandles[i]);
+                this.Children.Add(cornerHandles[i]);
+                this.Children.Add(edgeHandles[i]);
+                this.Children.Add(midpointHandles[i]);
             }
 
             // 3 --- 2 
@@ -355,7 +355,7 @@ namespace MouseDragDemo
         {
             if (e.NewValue is PhongMaterial)
             {
-                foreach (var item in ((GroupModel3D)d).ItemsSource)
+                foreach (var item in ((GroupModel3D)d).Items)
                 {
                     var model = item as MaterialGeometryModel3D;
                     if (model != null)

--- a/Source/Examples/WPF.SharpDX/MouseDragDemo/ResizeManipulator3D.cs
+++ b/Source/Examples/WPF.SharpDX/MouseDragDemo/ResizeManipulator3D.cs
@@ -140,24 +140,24 @@ namespace MouseDragDemo
             this.translateYR.Length = 0.5;
             this.translateZR.Length = 0.5;
 
-            this.ItemsSource.Clear();
+            this.Children.Clear();
 
             if (this.CanTranslateX)
             {
-                this.ItemsSource.Add(this.translateXL);
-                this.ItemsSource.Add(this.translateXR);
+                this.Children.Add(this.translateXL);
+                this.Children.Add(this.translateXR);
             }
 
             if (this.CanTranslateY)
             {
-                this.ItemsSource.Add(this.translateYL);
-                this.ItemsSource.Add(this.translateYR);
+                this.Children.Add(this.translateYL);
+                this.Children.Add(this.translateYR);
             }
 
             if (this.CanTranslateZ)
             {
-                this.ItemsSource.Add(this.translateZL);
-                this.ItemsSource.Add(this.translateZR);
+                this.Children.Add(this.translateZL);
+                this.Children.Add(this.translateZR);
             }
 
 
@@ -175,7 +175,7 @@ namespace MouseDragDemo
                     IsThrowingShadow = false,
                     Geometry = g.ToLineGeometry3D(),
                 };
-                this.ItemsSource.Add(this.selectionBounds);
+                this.Children.Add(this.selectionBounds);
             }            
         }
     }

--- a/Source/Examples/WPF.SharpDX/MouseDragDemo/ResizeManipulator3D.cs
+++ b/Source/Examples/WPF.SharpDX/MouseDragDemo/ResizeManipulator3D.cs
@@ -140,24 +140,24 @@ namespace MouseDragDemo
             this.translateYR.Length = 0.5;
             this.translateZR.Length = 0.5;
 
-            this.Children.Clear();
+            this.ItemsSource.Clear();
 
             if (this.CanTranslateX)
             {
-                this.Children.Add(this.translateXL);
-                this.Children.Add(this.translateXR);
+                this.ItemsSource.Add(this.translateXL);
+                this.ItemsSource.Add(this.translateXR);
             }
 
             if (this.CanTranslateY)
             {
-                this.Children.Add(this.translateYL);
-                this.Children.Add(this.translateYR);
+                this.ItemsSource.Add(this.translateYL);
+                this.ItemsSource.Add(this.translateYR);
             }
 
             if (this.CanTranslateZ)
             {
-                this.Children.Add(this.translateZL);
-                this.Children.Add(this.translateZR);
+                this.ItemsSource.Add(this.translateZL);
+                this.ItemsSource.Add(this.translateZR);
             }
 
 
@@ -175,7 +175,7 @@ namespace MouseDragDemo
                     IsThrowingShadow = false,
                     Geometry = g.ToLineGeometry3D(),
                 };
-                this.Children.Add(this.selectionBounds);
+                this.ItemsSource.Add(this.selectionBounds);
             }            
         }
     }

--- a/Source/Examples/WPF.SharpDX/ScreenSpaceDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/ScreenSpaceDemo/MainWindow.xaml
@@ -41,7 +41,7 @@
             <hx:AmbientLight3D Color="{Binding AmbientLightColor}"/>
             <hx:DirectionalLight3D Color="{Binding DirectionalLightColor}" Direction = "{Binding DirectionalLightDirection1}"/>
             <hx:DirectionalLight3D Color="{Binding DirectionalLightColor}" Direction = "{Binding DirectionalLightDirection2}"/>
-            <hx:GroupModel3D x:Name="group"  Children="{Binding ModelGeometry}"   Transform = "{Binding ModelTransform}" />
+            <hx:GroupModel3D x:Name="group"  ItemsSource="{Binding ModelGeometry}"   Transform = "{Binding ModelTransform}" />
         </hx:Viewport3DX>
         
         <StackPanel Grid.Row="0" >

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingBoxExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingBoxExtensions.cs
@@ -54,5 +54,119 @@ namespace HelixToolkit.Wpf.SharpDX
 
             return new BoundingBox(min, max);
         }
+
+        /// <summary>
+        /// Transform AABB with Affine Transformation matrix
+        /// </summary>
+        /// <param name="box"></param>
+        /// <param name="transform"></param>
+        /// <returns></returns>
+        public static BoundingBox Transform(this BoundingBox box, Matrix transform)
+        {
+            /////////////////Row 4/////////////////
+            var min = transform.TranslationVector;
+            var max = transform.TranslationVector;
+            /////////////////Row 1/////////////////
+            if (transform.M11 > 0f)
+            {
+                min.X += transform.M11 * box.Minimum.X;
+                max.X += transform.M11 * box.Maximum.X;
+            }
+            else
+            {
+                min.X += transform.M11 * box.Maximum.X;
+                max.X += transform.M11 * box.Minimum.X;
+            }
+
+            if (transform.M12 > 0f)
+            {
+                min.Y += transform.M12 * box.Minimum.X;
+                max.Y += transform.M12 * box.Maximum.X;
+            }
+            else
+            {
+                min.Y += transform.M12 * box.Maximum.X;
+                max.Y += transform.M12 * box.Minimum.X;
+            }
+
+            if (transform.M13 > 0f)
+            {
+                min.Z += transform.M13 * box.Minimum.X;
+                max.Z += transform.M13 * box.Maximum.X;
+            }
+            else
+            {
+                min.Z += transform.M13 * box.Maximum.X;
+                max.Z += transform.M13 * box.Minimum.X;
+            }
+            /////////////////Row 2/////////////////
+            if (transform.M21 > 0f)
+            {
+                min.X += transform.M21 * box.Minimum.Y;
+                max.X += transform.M21 * box.Maximum.Y;
+            }
+            else
+            {
+                min.X += transform.M21 * box.Maximum.Y;
+                max.X += transform.M21 * box.Minimum.Y;
+            }
+
+            if (transform.M22 > 0f)
+            {
+                min.Y += transform.M22 * box.Minimum.Y;
+                max.Y += transform.M22 * box.Maximum.Y;
+            }
+            else
+            {
+                min.Y += transform.M22 * box.Maximum.Y;
+                max.Y += transform.M22 * box.Minimum.Y;
+            }
+
+            if (transform.M23 > 0f)
+            {
+                min.Z += transform.M23 * box.Minimum.Y;
+                max.Z += transform.M23 * box.Maximum.Y;
+            }
+            else
+            {
+                min.Z += transform.M23 * box.Maximum.Y;
+                max.Z += transform.M23 * box.Minimum.Y;
+            }
+            ///////////////Row 3///////////////////////
+            if (transform.M31 > 0f)
+            {
+                min.X += transform.M31 * box.Minimum.Z;
+                max.X += transform.M31 * box.Maximum.Z;
+            }
+            else
+            {
+                min.X += transform.M31 * box.Maximum.Z;
+                max.X += transform.M31 * box.Minimum.Z;
+            }
+
+            if (transform.M32 > 0f)
+            {
+                min.Y += transform.M32 * box.Minimum.Z;
+                max.Y += transform.M32 * box.Maximum.Z;
+            }
+            else
+            {
+                min.Y += transform.M32 * box.Maximum.Z;
+                max.Y += transform.M32 * box.Minimum.Z;
+            }
+
+            if (transform.M33 > 0f)
+            {
+                min.Z += transform.M33 * box.Minimum.Z;
+                max.Z += transform.M33 * box.Maximum.Z;
+            }
+            else
+            {
+                min.Z += transform.M33 * box.Maximum.Z;
+                max.Z += transform.M33 * box.Minimum.Z;
+            }
+
+            return new BoundingBox(min, max);
+        }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DeferredRenderer.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DeferredRenderer.cs
@@ -389,7 +389,7 @@ namespace HelixToolkit.Wpf.SharpDX
         private void RenderLighting(RenderContext context, IEnumerable<ILight3D> lightsCollection)
         {
             // --- extract all lights from collections an build one IEnumerable seqence
-            var lights = lightsCollection.Where(l => l is Light3D).Concat(lightsCollection.Where(l => l is Light3DCollection).SelectMany(x => (x as Light3DCollection).Children.Select(xx => xx as ILight3D)));
+            var lights = lightsCollection.Where(l => l is Light3D).Concat(lightsCollection.Where(l => l is Light3DCollection).SelectMany(x => (x as Light3DCollection).Items.Select(xx => xx as ILight3D)));
 
             // --- eye position
             this.deferredLightingVariables.vEyePos.Set(context.Camera.Position.ToVector4());

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -114,9 +114,7 @@ namespace HelixToolkit.Wpf.SharpDX
             base.OnTransformChanged(e);
             if (this.geometryInternal != null)
             {
-                BoundsWithTransform
-                    = BoundingBox.FromPoints(Bounds.GetCorners()
-                    .Select(x => Vector3.TransformCoordinate(x, this.modelMatrix)).ToArray());
+                BoundsWithTransform = Bounds.Transform(this.modelMatrix);
                 BoundsSphereWithTransform = BoundsSphere.TransformBoundingSphere(this.modelMatrix);
             }
             else
@@ -141,8 +139,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     var old = bounds;
                     bounds = value;
                     RaiseOnBoundChanged(value, old);
-                    BoundsWithTransform = Transform == null ? bounds : BoundingBox.FromPoints((bounds).GetCorners()
-                    .Select(x => Vector3.TransformCoordinate(x, this.modelMatrix)).ToArray());
+                    BoundsWithTransform = Transform == null ? bounds : bounds.Transform(this.modelMatrix);
                 }
             }
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -113,7 +113,7 @@ namespace HelixToolkit.Wpf.SharpDX
             itemsSourceInternal = itemsSource;
             if (itemsSourceInternal != null)
             {
-                if (itemsSourceInternal is INotifyCollectionChanged)
+                if (itemsSourceInternal is ObservableElement3DCollection)
                 {
                     (itemsSourceInternal as INotifyCollectionChanged).CollectionChanged += Items_CollectionChanged;
                 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -20,13 +20,17 @@ namespace HelixToolkit.Wpf.SharpDX
     public abstract class GroupElement3D : Element3D //, IElement3DCollection
     {
         private IList<Element3D> itemsSourceInternal;
-
+        /// <summary>
+        /// ItemsSource for binding to collection. Please use ObservableElement3DCollection for observable, otherwise may cause memory leak.
+        /// </summary>
         public IList<Element3D> ItemsSource
         {
             get { return (IList<Element3D>)this.GetValue(ItemsSourceProperty); }
             set { this.SetValue(ItemsSourceProperty, value); }
         }
-
+        /// <summary>
+        /// ItemsSource for binding to collection. Please use ObservableElement3DCollection for observable, otherwise may cause memory leak.
+        /// </summary>
         public static readonly DependencyProperty ItemsSourceProperty =
             DependencyProperty.Register("ItemsSource", typeof(IList<Element3D>), typeof(GroupElement3D),
                 new AffectsRenderPropertyMetadata(null, 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -6,38 +6,77 @@
 
 namespace HelixToolkit.Wpf.SharpDX
 {
+    using System.Collections.Specialized;
     using System.Windows;
     using System.Windows.Markup;
 
+    [ContentProperty("Items")]
     public abstract class GroupElement3D : Element3D //, IElement3DCollection
     {
-        private Element3DCollection childrenInternal = new Element3DCollection();
-        public Element3DCollection Children
+        private Element3DCollection childrenInternal;
+
+        public Element3DCollection ItemsSource
         {
-            get { return (Element3DCollection)this.GetValue(ChildrenProperty); }
-            set { this.SetValue(ChildrenProperty, value); }
+            get { return (Element3DCollection)this.GetValue(ItemsSourceProperty); }
+            set { this.SetValue(ItemsSourceProperty, value); }
         }
 
-        public static readonly DependencyProperty ChildrenProperty =
-            DependencyProperty.Register("Children", typeof(Element3DCollection), typeof(GroupElement3D),
-                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender,
-                    (d, e) => { (d as GroupElement3D).childrenInternal = e.NewValue as Element3DCollection; }));
+        public static readonly DependencyProperty ItemsSourceProperty =
+            DependencyProperty.Register("ItemsSource", typeof(Element3DCollection), typeof(GroupElement3D),
+                new AffectsRenderPropertyMetadata(null, 
+                    (d, e) => {
+                        (d as GroupElement3D).OnItemsSourceChanged(e.NewValue as Element3DCollection);
+                    }));
+
+        public Element3DCollection Items
+        {
+            get;
+        } = new Element3DCollection();
 
         public GroupElement3D()
         {
         }
 
+        private void OnItemsSourceChanged(Element3DCollection itemsSource)
+        {
+            if (childrenInternal != null)
+            {
+                foreach (var c in this.childrenInternal)
+                {
+                    Items.Remove(c);
+                    c.Detach();
+                    if (c.Parent == this)
+                    {
+                        this.RemoveLogicalChild(c);
+                    }
+                }
+            }
+            childrenInternal = itemsSource;
+            if (childrenInternal != null)
+            {
+                Items.AddRange(childrenInternal);
+                if (IsAttached)
+                {
+                    foreach (var c in this.childrenInternal)
+                    {
+                        if (c.Parent == null)
+                        {
+                            this.AddLogicalChild(c);
+                        }
+
+                        c.Attach(this.RenderHost);                   
+                    }  
+                }            
+            }
+        }
+
         protected override bool OnAttach(IRenderHost host)
         {
-            if (childrenInternal == null)
-            {
-                return false;
-            }
-            foreach (var c in this.childrenInternal)
+            foreach (var c in this.Items)
             {
                 if (c.Parent == null)
                 {
-                    this.AddLogicalChild(c);                    
+                    this.AddLogicalChild(c);
                 }
 
                 c.Attach(host);
@@ -48,28 +87,24 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override void OnDetach()
         {
             base.OnDetach();
-            if (childrenInternal == null)
-            {
-                return;
-            }
-            foreach (var c in this.childrenInternal)
+            foreach (var c in this.Items)
             {
                 c.Detach();
                 if (c.Parent == this)
                 {
-                    this.RemoveLogicalChild(c);                    
+                    this.RemoveLogicalChild(c);
                 }
             }
         }
 
         protected override bool CanRender(RenderContext context)
         {
-            return this.childrenInternal != null;
+            return Items.Count > 0;
         }
 
         protected override void OnRender(RenderContext context)
         {
-            foreach (var c in this.childrenInternal)
+            foreach (var c in this.Items)
             {
                 c.Render(context);
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/InstanceGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/InstanceGeometryModel3D.cs
@@ -70,10 +70,10 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             else
             {
-                var bound = BoundingBox.FromPoints(this.BoundsWithTransform.GetCorners().Select(x => Vector3.TransformCoordinate(x, instanceInternal[0])).ToArray());
+                var bound = this.BoundsWithTransform.Transform(instanceInternal[0]);// BoundingBox.FromPoints(this.BoundsWithTransform.GetCorners().Select(x => Vector3.TransformCoordinate(x, instanceInternal[0])).ToArray());
                 foreach (var instance in instanceInternal)
                 {
-                    var b = BoundingBox.FromPoints(this.BoundsWithTransform.GetCorners().Select(x => Vector3.TransformCoordinate(x, instance)).ToArray());
+                    var b = this.BoundsWithTransform.Transform(instance);// BoundingBox.FromPoints(this.BoundsWithTransform.GetCorners().Select(x => Vector3.TransformCoordinate(x, instance)).ToArray());
                     BoundingBox.Merge(ref bound, ref b, out bound);
                 }
                 InstancesBound = bound;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -26,13 +26,19 @@ namespace HelixToolkit.Wpf.SharpDX
         private EffectScalarVariable bFixedSizeVariable;
         #endregion
 
+        protected bool fixedSize = true;
+
         /// <summary>
         /// Fixed sized billboard. Default = true. 
         /// <para>When FixedSize = true, the billboard render size will be scale to normalized device coordinates(screen) size</para>
         /// <para>When FixedSize = false, the billboard render size will be actual size in 3D world space</para>
         /// </summary>
         public static readonly DependencyProperty FixedSizeProperty = DependencyProperty.Register("FixedSize", typeof(bool), typeof(BillboardTextModel3D),
-            new AffectsRenderPropertyMetadata(true));
+            new AffectsRenderPropertyMetadata(true,
+                (d,e)=> 
+                {
+                    (d as BillboardTextModel3D).fixedSize = (bool)e.NewValue;
+                }));
 
         /// <summary>
         /// Fixed sized billboard. Default = true. 
@@ -350,7 +356,7 @@ namespace HelixToolkit.Wpf.SharpDX
             // --- set constant paramerers             
             var worldMatrix = modelMatrix * renderContext.worldMatrix;
             effectTransforms.mWorld.SetMatrix(ref worldMatrix);
-            bFixedSizeVariable?.Set(FixedSize);
+            bFixedSizeVariable?.Set(fixedSize);
             // --- check shadowmaps
             //this.hasShadowMap = this.renderHost.IsShadowMapEnabled;
             //this.effectMaterial.bHasShadowMapVariable.Set(this.hasShadowMap);

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Element3DCollection.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/Element3DCollection.cs
@@ -11,7 +11,9 @@ namespace HelixToolkit.Wpf.SharpDX
 {
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-
+    using System.Collections.Specialized;
+    using System.ComponentModel;
+    using System.Linq;
     /// <summary>
     /// Provides a collection of Element3D.
     /// </summary>
@@ -29,11 +31,15 @@ namespace HelixToolkit.Wpf.SharpDX
     /// </summary>
     public class ObservableElement3DCollection : ObservableCollection<Element3D>
     {
-        //internal void PreRenderSort()
-        //{
-        //    var comparer = new ElementComparer();
-        //    this.Sort(comparer);
-        //}
+        protected override void ClearItems()
+        {
+            CheckReentrancy();
+            var items = Items.ToList();
+            base.ClearItems();
+            OnPropertyChanged(new PropertyChangedEventArgs("Count"));
+            OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, items, -1));
+        }
     }
 
     //public class ElementComparer : IComparer

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/GroupModel3D.cs
@@ -58,7 +58,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         protected override void OnRender(RenderContext renderContext)
         {
-            foreach (var c in this.Children)
+            foreach (var c in this.Items)
             {
                 var model = c as ITransformable;
                 if (model != null)
@@ -97,7 +97,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected virtual bool OnHitTest(IRenderMatrices context, Ray ray, ref List<HitTestResult> hits)
         {
             bool hit = false;
-            foreach (var c in this.Children)
+            foreach (var c in this.Items)
             {
                 var hc = c as IHitable;
                 if (hc != null)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -37,7 +37,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected InputLayout vertexLayout;
         private readonly ImmutableBufferProxy<LinesVertex> vertexBuffer = new ImmutableBufferProxy<LinesVertex>(LinesVertex.SizeInBytes, BindFlags.VertexBuffer);
         private readonly ImmutableBufferProxy<int> indexBuffer = new ImmutableBufferProxy<int>(sizeof(int), BindFlags.IndexBuffer);
-        protected Vector4 lineParams = new Vector4(1, 0, 0, 0);
+        protected Vector4 lineParams = new Vector4();
         /// <summary>
         /// For subclass override
         /// </summary>
@@ -106,6 +106,13 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public static readonly DependencyProperty HitTestThicknessProperty =
             DependencyProperty.Register("HitTestThickness", typeof(double), typeof(LineGeometryModel3D), new UIPropertyMetadata(1.0));
+
+
+        public LineGeometryModel3D() : base()
+        {
+            lineParams.X = (float)Thickness;
+            lineParams.Y = (float)Smoothness;
+        }
 
 
         protected override bool CanHitTest(IRenderMatrices context)

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -37,6 +37,7 @@ namespace HelixToolkit.Wpf.SharpDX
         protected InputLayout vertexLayout;
         private readonly ImmutableBufferProxy<LinesVertex> vertexBuffer = new ImmutableBufferProxy<LinesVertex>(LinesVertex.SizeInBytes, BindFlags.VertexBuffer);
         private readonly ImmutableBufferProxy<int> indexBuffer = new ImmutableBufferProxy<int>(sizeof(int), BindFlags.IndexBuffer);
+        protected Vector4 lineParams = new Vector4(1, 0, 0, 0);
         /// <summary>
         /// For subclass override
         /// </summary>
@@ -78,7 +79,10 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty ThicknessProperty =
-            DependencyProperty.Register("Thickness", typeof(double), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(1.0));
+            DependencyProperty.Register("Thickness", typeof(double), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(1.0, (d, e) =>
+            {
+                (d as LineGeometryModel3D).lineParams.X = (float)(double)e.NewValue;
+            }));
 
         public double Smoothness
         {
@@ -87,7 +91,11 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly DependencyProperty SmoothnessProperty =
-            DependencyProperty.Register("Smoothness", typeof(double), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(0.0));
+            DependencyProperty.Register("Smoothness", typeof(double), typeof(LineGeometryModel3D), new AffectsRenderPropertyMetadata(0.0, 
+                (d,e)=>
+                {
+                    (d as LineGeometryModel3D).lineParams.Y = (float)(double)e.NewValue;
+                }));
 
 
         public double HitTestThickness
@@ -357,7 +365,6 @@ namespace HelixToolkit.Wpf.SharpDX
             this.effectTransforms.mWorld.SetMatrix(ref worldMatrix);
 
             // --- set effect per object const vars
-            var lineParams = new Vector4((float)this.Thickness, (float)this.Smoothness, 0, 0);
             this.vLineParams.Set(lineParams);
             
             // --- set context

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -320,7 +320,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     var m = this.modelMatrix;
 
                     // put bounds to world space
-                    var b = BoundingBox.FromPoints(this.Bounds.GetCorners().Select(x => Vector3.TransformCoordinate(x, m)).ToArray());
+                    var b = this.Bounds.Transform(m);// BoundingBox.FromPoints(this.Bounds.GetCorners().Select(x => Vector3.TransformCoordinate(x, m)).ToArray());
 
                     //var b = this.Bounds;
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -300,8 +300,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         protected override void OnRender(RenderContext renderContext)
         {
-            // --- set model transform paramerers                         
-            effectTransforms.mWorld.SetMatrix(ref modelMatrix);
+            // --- set model transform paramerers        
+            var worldMatrix = modelMatrix * renderContext.worldMatrix;
+            effectTransforms.mWorld.SetMatrix(ref worldMatrix);
             this.effectMaterial.AttachMaterial();
 
             // --- set primitive type

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -22,6 +22,7 @@
         protected EffectTransformVariables effectTransforms;
         protected EffectVectorVariable vPointParams;
         private readonly ImmutableBufferProxy<PointsVertex> vertexBuffer = new ImmutableBufferProxy<PointsVertex>(PointsVertex.SizeInBytes, BindFlags.VertexBuffer);
+        protected Vector4 pointParams = new Vector4();
         /// <summary>
         /// For subclass override
         /// </summary>
@@ -51,7 +52,14 @@
         }
 
         public static readonly DependencyProperty SizeProperty =
-            DependencyProperty.Register("Size", typeof(Size), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(new Size(1.0, 1.0)));
+            DependencyProperty.Register("Size", typeof(Size), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(new Size(1.0, 1.0),
+                (d,e)=> 
+                {
+                    var size = (Size)e.NewValue;
+                    var model = (d as PointGeometryModel3D);
+                    model.pointParams.X = (float)size.Width;
+                    model.pointParams.Y = (float)size.Height;
+                }));
 
         public PointFigure Figure
         {
@@ -60,7 +68,13 @@
         }
 
         public static readonly DependencyProperty FigureProperty =
-            DependencyProperty.Register("Figure", typeof(PointFigure), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(PointFigure.Rect));
+            DependencyProperty.Register("Figure", typeof(PointFigure), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(PointFigure.Rect,
+                (d, e)=> 
+                {
+                    var figure = (PointFigure)e.NewValue;
+                    var model = (d as PointGeometryModel3D);
+                    model.pointParams.Z = (float)figure;
+                }));
 
         public double FigureRatio
         {
@@ -69,7 +83,13 @@
         }
 
         public static readonly DependencyProperty FigureRatioProperty =
-            DependencyProperty.Register("FigureRatio", typeof(double), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(0.25));
+            DependencyProperty.Register("FigureRatio", typeof(double), typeof(PointGeometryModel3D), new AffectsRenderPropertyMetadata(0.25,
+                (d, e)=> 
+                {
+                    var ratio = (double)e.NewValue;
+                    var model = (d as PointGeometryModel3D);
+                    model.pointParams.W = (float)ratio;
+                }));
 
         public double HitTestThickness
         {
@@ -79,6 +99,14 @@
 
         public static readonly DependencyProperty HitTestThicknessProperty =
             DependencyProperty.Register("HitTestThickness", typeof(double), typeof(PointGeometryModel3D), new UIPropertyMetadata(4.0));
+
+        public PointGeometryModel3D() : base()
+        {
+            pointParams.X = (float)Size.Width;
+            pointParams.Y = (float)Size.Height;
+            pointParams.Z = (float)Figure;
+            pointParams.W = (float)FigureRatio;
+        }
 
         public static double DistanceRayToPoint(Ray r, Vector3 p)
         {
@@ -317,7 +345,6 @@
             this.effectTransforms.mWorld.SetMatrix(ref worldMatrix);
 
             // --- set effect per object const vars
-            var pointParams = new Vector4((float)this.Size.Width, (float)this.Size.Height, (float)this.Figure, (float)this.FigureRatio);
             this.vPointParams.Set(pointParams);
 
             // --- set context

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ThreePointLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ThreePointLight3D.cs
@@ -23,7 +23,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
         protected override bool OnAttach(IRenderHost host)
         {
             Light3DSceneShared = host.Light3DSceneShared;
-            foreach (var c in this.ItemsSource)
+            foreach (var c in this.Items)
             {
                 c.Attach(host);
             }
@@ -33,7 +33,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
         protected override void OnDetach()
         {
             base.OnDetach();
-            foreach (var c in this.ItemsSource)
+            foreach (var c in this.Items)
             {
                 c.Detach();
             }
@@ -41,7 +41,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
 
         protected override void OnRender(RenderContext context)
         {
-            foreach (var c in this.ItemsSource)
+            foreach (var c in this.Items)
             {
                 c.Render(context);
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ThreePointLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ThreePointLight3D.cs
@@ -23,7 +23,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
         protected override bool OnAttach(IRenderHost host)
         {
             Light3DSceneShared = host.Light3DSceneShared;
-            foreach (var c in this.Children)
+            foreach (var c in this.ItemsSource)
             {
                 c.Attach(host);
             }
@@ -33,7 +33,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
         protected override void OnDetach()
         {
             base.OnDetach();
-            foreach (var c in this.Children)
+            foreach (var c in this.ItemsSource)
             {
                 c.Detach();
             }
@@ -41,7 +41,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Lights3D
 
         protected override void OnRender(RenderContext context)
         {
-            foreach (var c in this.Children)
+            foreach (var c in this.ItemsSource)
             {
                 c.Render(context);
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/Octree.cs
@@ -1232,7 +1232,7 @@ namespace HelixToolkit.Wpf.SharpDX
             var isHit = false;
             var result = new HitTestResult();
             result.Distance = double.MaxValue;
-            var bound = BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
+            var bound = Bound.Transform(modelMatrix);// BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
             bool checkBoundSphere = false;
             global::SharpDX.BoundingSphere boundSphere;
             if (model != null)
@@ -1427,7 +1427,7 @@ namespace HelixToolkit.Wpf.SharpDX
             var isHit = false;
             var result = new HitTestResult();
             result.Distance = double.MaxValue;
-            var bound = BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
+            var bound = Bound.Transform(modelMatrix);// BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
 
             if (rayWS.Intersects(ref bound) && context != null)
             {
@@ -1584,7 +1584,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 return false;
             }
             bool isHit = false;
-            var bound = BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
+            var bound = Bound.Transform(modelMatrix);// BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
             var tempHits = new List<HitTestResult>();
             if (rayWS.Intersects(ref bound))
             {
@@ -1814,10 +1814,10 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             InstanceMatrix = instanceMatrix;
             int counter = 0;
-            var totalBound = BoundingBox.FromPoints(geometryBound.GetCorners().Select(x => Vector3.TransformCoordinate(x, instanceMatrix[0])).ToArray());
+            var totalBound = geometryBound.Transform(instanceMatrix[0]);// BoundingBox.FromPoints(geometryBound.GetCorners().Select(x => Vector3.TransformCoordinate(x, instanceMatrix[0])).ToArray());
             foreach (var m in instanceMatrix)
             {
-                var b = BoundingBox.FromPoints(geometryBound.GetCorners().Select(x => Vector3.TransformCoordinate(x, m)).ToArray());
+                var b = geometryBound.Transform(m);// BoundingBox.FromPoints(geometryBound.GetCorners().Select(x => Vector3.TransformCoordinate(x, m)).ToArray());
                 Objects.Add(new Tuple<int, BoundingBox>(counter, b));
                 BoundingBox.Merge(ref totalBound, ref b, out totalBound);
                 ++counter;
@@ -1844,13 +1844,13 @@ namespace HelixToolkit.Wpf.SharpDX
                 return false;
             }
             bool isHit = false;
-            var bound = BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
+            var bound = Bound.Transform(modelMatrix);// BoundingBox.FromPoints(Bound.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
             if (rayWS.Intersects(ref bound))
             {
                 isIntersect = true;
                 foreach (var t in this.Objects)
                 {
-                    var b = BoundingBox.FromPoints(t.Item2.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
+                    var b = t.Item2.Transform(modelMatrix);// BoundingBox.FromPoints(t.Item2.GetCorners().Select(x => Vector3.TransformCoordinate(x, modelMatrix)).ToArray());
                     if (b.Intersects(ref rayWS))
                     {
                         var result = new HitTestResult()


### PR DESCRIPTION
1. Properly implement GroupElement3D. Children for xaml children, ItemsSource for collection binding. 
2. Fix environment Map Demo artifacts.
3. Use faster boundingbox transformation function.
4. Reduce dependency property latency for LineGeometryModel3D and PointGeometryModel3D.