### PR TITLE
Fix #473 OBJ File Invalid polygon

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Core/Polygon3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Polygon3D.cs
@@ -118,14 +118,16 @@ namespace HelixToolkit.Wpf.SharpDX
             for (int i = 2; i < this.Points.Count; i++)
             {
                 var n = Vector3D.Cross(v1, this.Points[i] - this.Points[0]);
-                if (n.LengthSquared() > 1e-8)
+                if (n.LengthSquared() > 1e-10)
                 {
                     n.Normalize();
                     return n;
                 }
             }
 
-            throw new InvalidOperationException("Invalid polygon.");
+            Vector3D result = Vector3D.Cross(v1, this.Points[2] - this.Points[0]);
+            result.Normalize();
+            return result;
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Geometry/Polygon3DTests.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Geometry/Polygon3DTests.cs
@@ -1,0 +1,33 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Polygon3DTests.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace HelixToolkit.Wpf.SharpDX.Tests.Geometry
+{
+    using System.Collections.Generic;
+    using global::SharpDX;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class Polygon3DTests
+    {
+        [Test]
+        public void Polygon_GetNormal_NotThrows()
+        {
+            var points = new List<Vector3>()
+            {
+                new Vector3(-1.39943f, 0.328622f, 0.97968f),
+                new Vector3(-1.39969f, 0.328622f, 0.99105f),
+                new Vector3(-1.39963f, 0.328631f, 0.99105f),
+                new Vector3(-1.39954f, 0.328631f, 0.98726f),
+                new Vector3(-1.39937f, 0.328631f, 0.97968f),
+            };
+
+            var polygon = new Polygon3D(points);
+            Vector3 normal = polygon.GetNormal();
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/HelixToolkit.Wpf.SharpDX.Tests.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/HelixToolkit.Wpf.SharpDX.Tests.csproj
@@ -112,6 +112,7 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Controls\CanvasMock.cs" />
+    <Compile Include="Geometry\Polygon3DTests.cs" />
     <Compile Include="Elements3D\MeshGeometryModel3DTests.cs" />
     <Compile Include="Importers\ObjReaderTests.cs" />
     <Compile Include="Properties\AssemblyDescription.cs" />

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Importers/ObjReaderTests.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Importers/ObjReaderTests.cs
@@ -323,6 +323,42 @@ map_bump " + prefix + Path.GetFileName(tempTexBump) + @"
                 //File.Delete(tempTexBump);
             }
         }
+
+        [Test]
+        public void MaterialLib_LoadMultipleTimes_Valid()
+        {
+            var tempObj = Path.GetTempFileName();
+            var tempMtl = Path.GetTempFileName();
+
+            try
+            {
+                File.WriteAllText(tempObj, @"
+mtllib " + Path.GetFileName(tempMtl) + @"
+mtllib " + Path.GetFileName(tempMtl) + @"
+v -0.5 0 0.5
+v 0.5 0 0.5
+v -0.5 0 -0.5
+vt 0 1
+usemtl TestMaterial
+f 1/1 2/1 3/1
+");
+
+                File.WriteAllText(tempMtl, @"
+newmtl TestMaterial
+Kd 1 1 1
+newmtl TestMaterial
+Kd 0 0 0
+");
+
+                var model = _objReader.Read(tempObj);
+                Assert.AreEqual(new Color4(1, 1, 1, 1), _objReader.Materials["TestMaterial"].Diffuse);
+            }
+            finally
+            {
+                File.Delete(tempObj);
+                File.Delete(tempMtl);
+            }
+        }
     }
 
     public static class TestExtensions 

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjReader.cs
@@ -860,10 +860,17 @@ namespace HelixToolkit.Wpf.SharpDX
                     switch (keyword.ToLower())
                     {
                         case "newmtl":
-                            if (value != null && !Materials.ContainsKey(value))
+                            if (value != null)
                             {
-                                currentMaterial = new MaterialDefinition();
-                                this.Materials.Add(value, currentMaterial);
+                                if (this.Materials.ContainsKey(value))
+                                {
+                                    currentMaterial = null;
+                                }
+                                else
+                                {
+                                    currentMaterial = new MaterialDefinition();
+                                    this.Materials.Add(value, currentMaterial);
+                                }
                             }
 
                             break;

--- a/Source/HelixToolkit.Wpf.Tests/Geometry/Polygon3DTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Geometry/Polygon3DTests.cs
@@ -1,0 +1,33 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="Polygon3DTests.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace HelixToolkit.Wpf.Tests.Geometry
+{
+    using System.Collections.Generic;
+    using System.Windows.Media.Media3D;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class Polygon3DTests
+    {
+        [Test]
+        public void Polygon_GetNormal_NotThrows()
+        {
+            var points = new List<Point3D>()
+            {
+                new Point3D(-1.39943, 0.328622, 0.97968),
+                new Point3D(-1.39969, 0.328622, 0.99105),
+                new Point3D(-1.39963, 0.328631, 0.99105),
+                new Point3D(-1.39954, 0.328631, 0.98726),
+                new Point3D(-1.39937, 0.328631, 0.97968),
+            };
+
+            var polygon = new Polygon3D(points);
+            Vector3D normal = polygon.GetNormal();
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf.Tests/HelixToolkit.Wpf.Tests.csproj
+++ b/Source/HelixToolkit.Wpf.Tests/HelixToolkit.Wpf.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Geometry\BoundingSphereTests.cs" />
     <Compile Include="Geometry\CuttingEarsTriangulatorTests.cs" />
     <Compile Include="Geometry\LineSegmentTests.cs" />
+    <Compile Include="Geometry\Polygon3DTests.cs" />
     <Compile Include="Geometry\Ray3DTests.cs" />
     <Compile Include="Helpers\ContourHelperTests.cs" />
     <Compile Include="Helpers\Vector3DExtensionsTests.cs" />

--- a/Source/HelixToolkit.Wpf.Tests/Importers/ObjReaderTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Importers/ObjReaderTests.cs
@@ -395,6 +395,42 @@ map_Ka " + prefix + Path.GetFileName(tempTexAmbient) + @"
                 File.Delete(tempTexAmbient);
             }
         }
+
+        [Test]
+        public void MaterialLib_LoadMultipleTimes_Valid()
+        {
+            var tempObj = Path.GetTempFileName();
+            var tempMtl = Path.GetTempFileName();
+
+            try
+            {
+                File.WriteAllText(tempObj, @"
+mtllib " + Path.GetFileName(tempMtl) + @"
+mtllib " + Path.GetFileName(tempMtl) + @"
+v -0.5 0 0.5
+v 0.5 0 0.5
+v -0.5 0 -0.5
+vt 0 1
+usemtl TestMaterial
+f 1/1 2/1 3/1
+");
+
+                File.WriteAllText(tempMtl, @"
+newmtl TestMaterial
+Kd 1 1 1
+newmtl TestMaterial
+Kd 0 0 0
+");
+
+                var model = _objReader.Read(tempObj);
+                Assert.AreEqual(Color.FromRgb(255, 255, 255), _objReader.Materials["TestMaterial"].Diffuse);
+            }
+            finally
+            {
+                File.Delete(tempObj);
+                File.Delete(tempMtl);
+            }
+        }
     }
 
     public static class Model3DTestExtensions 

--- a/Source/HelixToolkit.Wpf/Geometry/Polygon3D.cs
+++ b/Source/HelixToolkit.Wpf/Geometry/Polygon3D.cs
@@ -123,7 +123,9 @@ namespace HelixToolkit.Wpf
                 }
             }
 
-            throw new InvalidOperationException("Invalid polygon.");
+            Vector3D result = Vector3D.CrossProduct(v1, this.Points[2] - this.Points[0]);
+            result.Normalize();
+            return result;
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
@@ -773,8 +773,15 @@ namespace HelixToolkit.Wpf
                         case "newmtl":
                             if (value != null)
                             {
-                                currentMaterial = new MaterialDefinition(value);
-                                this.Materials.Add(value, currentMaterial);
+                                if (this.Materials.ContainsKey(value))
+                                {
+                                    currentMaterial = null;
+                                }
+                                else
+                                {
+                                    currentMaterial = new MaterialDefinition(value);
+                                    this.Materials.Add(value, currentMaterial);
+                                }
                             }
 
                             break;


### PR DESCRIPTION
Fix #473 
- Add tests & fix for `Polygon3D.GetNormal`
- Add tests & fix for `OBJReader.LoadMaterialLib newmtl`
