### PR TITLE
Fixed null reference exception if point geometry is empty

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -124,7 +124,7 @@
 
         protected override bool CanHitTest(IRenderMatrices context)
         {
-            return base.CanHitTest(context) && geometryInternal.Positions != null && geometryInternal.Positions.Count > 0 && geometryInternal is PointGeometry3D && context != null;
+            return base.CanHitTest(context) && geometryInternal != null && geometryInternal.Positions != null && geometryInternal.Positions.Count > 0 && geometryInternal is PointGeometry3D && context != null;
         }
 
         /// <summary>


### PR DESCRIPTION
Case: `geometryInternal ` is null.

Reproduction: 
- Create empty instance of PointGeometry3D 
- load model into the Viewport
- click into the view.

Result: 
-> Crash