### PR TITLE
fixed crash bug due to undefined model bounds

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/ViewportExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/ViewportExtensions.cs
@@ -192,7 +192,7 @@ namespace HelixToolkit.Wpf.SharpDX
             foreach (var element in viewport.Renderables)
             {
                 var model = element as IBoundable;
-                if (model != null)
+                if (model != null && !model.Bounds.Minimum.IsUndefined() && !model.Bounds.Maximum.IsUndefined())
                 {
                     if (model.Visibility != Visibility.Collapsed)
                     {


### PR DESCRIPTION
Reproduction:
- Create a ViewportScene with a Empty MeshGeometryVisual3D (The model.Bounds have to be undefined)
- Toggle between the Viewport and another tab forth and back

Result:
- Program termination