### PR TITLE
[UWP] Update SharpDX packages

### DIFF
--- a/Source/Examples/UWP/SimpleDemo/project.json
+++ b/Source/Examples/UWP/SimpleDemo/project.json
@@ -3,13 +3,13 @@
     "Microsoft.ApplicationInsights": "1.2.3",
     "Microsoft.ApplicationInsights.PersistenceChannel": "1.2.3",
     "Microsoft.ApplicationInsights.WindowsApps": "1.1.1",
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
-    "SharpDX": "3.1.1",
-    "SharpDX.D3DCompiler": "3.1.1",
-    "SharpDX.Direct2D1": "3.1.1",
-    "SharpDX.Direct3D11": "3.1.1",
-    "SharpDX.DXGI": "3.1.1",
-    "SharpDX.Mathematics": "3.1.1"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
+    "SharpDX": "4.0.1",
+    "SharpDX.D3DCompiler": "4.0.1",
+    "SharpDX.Direct2D1": "4.0.1",
+    "SharpDX.Direct3D11": "4.0.1",
+    "SharpDX.DXGI": "4.0.1",
+    "SharpDX.Mathematics": "4.0.1"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Source/HelixToolkit.UWP/project.json
+++ b/Source/HelixToolkit.UWP/project.json
@@ -1,12 +1,12 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
-    "SharpDX": "3.1.1",
-    "SharpDX.D3DCompiler": "3.1.1",
-    "SharpDX.Direct2D1": "3.1.1",
-    "SharpDX.Direct3D11": "3.1.1",
-    "SharpDX.DXGI": "3.1.1",
-    "SharpDX.Mathematics": "3.1.1",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
+    "SharpDX": "4.0.1",
+    "SharpDX.D3DCompiler": "4.0.1",
+    "SharpDX.Direct2D1": "4.0.1",
+    "SharpDX.Direct3D11": "4.0.1",
+    "SharpDX.DXGI": "4.0.1",
+    "SharpDX.Mathematics": "4.0.1",
     "System.ComponentModel.TypeConverter": "4.3.0"
   },
   "frameworks": {


### PR DESCRIPTION
Update `SharpDX` packages from 3.1.1 to 4.0.1.
Update `Microsoft.NETCore.UniversalWindowsPlatform` from 5.0.0 to 5.2.2 (this is the minimum version required by `SharpDX`).