### PR TITLE
[SharpDX] Update GetBestAdapter to use ulong instead of long

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\BoundingSphereExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CollectionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\Vector3DExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\PointerSizeHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Geometry\Geometry3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Geometry\MeshGeometry3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Interfaces.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Helpers/PointerSizeHelpers.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Helpers/PointerSizeHelpers.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PointerSizeHelpers.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using SharpDX;
+
+namespace HelixToolkit.SharpDX.Helpers
+{
+    /// <summary>
+    /// Helpers methods for <see cref="PointerSize"/>.
+    /// </summary>
+    public static class PointerSizeHelpers
+    {
+        /// <summary>
+        /// Converts a <see cref="PointerSize"/> to a 64-bit unsigned integer.
+        /// </summary>
+        /// <param name="ptr">The pointer to convert.</param>
+        /// <returns>An <c>unsigned long</c>.</returns>
+        public static ulong ToUInt64(this PointerSize ptr)
+        {
+            if (UIntPtr.Size == 8)
+            {
+                return (ulong)(long)ptr;
+            }
+            else
+            {
+                return (uint)(int)ptr;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Effects.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Effects.cs
@@ -19,6 +19,7 @@ namespace HelixToolkit.Wpf.SharpDX
     using global::SharpDX.D3DCompiler;
     using global::SharpDX.Direct3D;
     using System.IO;
+    using HelixToolkit.SharpDX.Helpers;
 
     public interface IEffectsManager
     {
@@ -86,8 +87,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 Adapter bestAdapter = null;
                 bestAdapterIndex = -1;
                 int adapterIndex = -1;
-                long bestVideoMemory = 0;
-                long bestSystemMemory = 0;
+                ulong bestVideoMemory = 0;
+                ulong bestSystemMemory = 0;
 
                 foreach (var item in f.Adapters)
                 {
@@ -110,8 +111,8 @@ namespace HelixToolkit.Wpf.SharpDX
                         continue;
                     }
 
-                    long videoMemory = item.Description.DedicatedVideoMemory;
-                    long systemMemory = item.Description.DedicatedSystemMemory;
+                    ulong videoMemory = item.Description.DedicatedVideoMemory.ToUInt64();
+                    ulong systemMemory = item.Description.DedicatedSystemMemory.ToUInt64();
 
                     if ((bestAdapter == null) || (videoMemory > bestVideoMemory) || ((videoMemory == bestVideoMemory) && (systemMemory > bestSystemMemory)))
                     {


### PR DESCRIPTION
Avoids having negative memory sizes on x86 when memory >= 2GB.