### PR TITLE
Add DPFSurfaceSwapChainThreading to separate rendering thread from main UI thread

### DIFF
--- a/Source/Examples/WPF.SharpDX/SwapChainRenderingDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/SwapChainRenderingDemo/MainWindow.xaml
@@ -18,7 +18,7 @@
         </Grid.RowDefinitions>
         <hx:Viewport3DX x:Name="view1"
             Grid.Row="0" Grid.Column="0" MSAA="Four"
-            Camera="{Binding Camera}" EnableSwapChainRendering="True"
+            Camera="{Binding Camera}" EnableSwapChainRendering="True" EnableDeferredRendering="True"
              Background="Black" BackgroundColor="0,0,0,0"
             SubTitle="{Binding SubTitle}"
             TextBrush="Black"

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -265,7 +265,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Unloaded += OnUnloaded;
             ClearColor = global::SharpDX.Color.Gray;
             IsShadowMapEnabled = false;
-            MSAA = MSAALevel.Maximum;
+            MSAA = MSAALevel.Disable;
            // invalidAction = new Action(InvalidateRender);
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvasThreading.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvasThreading.cs
@@ -346,7 +346,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Unloaded += OnUnloaded;
             ClearColor = global::SharpDX.Color.Gray;
             IsShadowMapEnabled = false;
-            MSAA = MSAALevel.Maximum;
+            MSAA = MSAALevel.Disable;
             invalidAction = new Action(InvalidateRender);
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
@@ -182,6 +182,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
                 sceneAttached = false;
                 renderRenderable = value;
+                ParentControl = renderRenderable as UIElement;
                 InvalidateRender();
             }
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
@@ -252,7 +252,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Unloaded += OnUnloaded;
             ClearColor = global::SharpDX.Color.Gray;
             IsShadowMapEnabled = false;
-            MSAA = MSAALevel.Maximum;
+            MSAA = MSAALevel.Disable;
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
@@ -53,7 +53,8 @@ namespace HelixToolkit.Wpf.SharpDX
     // THE SOFTWARE.
 
     /// <summary>
-    /// <para>Use HwndHost as rendering surface, swapchain for rendering. Much faster than using D3DImage.</para> 
+    /// <para>Use HwndHost as rendering surface, swapchain for rendering. Much faster than using D3DImage.</para>
+    /// <para>Render on seperate rendering thread. EnableSwapChainRendering=True to use this rendering method.</para>
     /// <para>Drawbacks: The rendering surface will cover all WPF controls in the same Viewport region. Move controls out of viewport region to solve this problem.</para>
     /// <para>For displaying ViewCube and CoordinateSystem, separate Model needs to create to render along with the other models. WPF viewport will not be visibled.</para>
     /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
@@ -54,7 +54,8 @@ namespace HelixToolkit.Wpf.SharpDX
     // THE SOFTWARE.
 
     /// <summary>
-    /// <para>Use HwndHost as rendering surface, swapchain for rendering. Much faster than using D3DImage.</para> 
+    /// <para>Use HwndHost as rendering surface, use seperate rendering thread. Faster than DPFSwapChainRendering.</para> 
+    /// <para>EnableSwapChainRendering=True and EnableDeferredRendering=Ture to use this rendering method.</para>
     /// <para>Drawbacks: The rendering surface will cover all WPF controls in the same Viewport region. Move controls out of viewport region to solve this problem.</para>
     /// <para>For displaying ViewCube and CoordinateSystem, separate Model needs to create to render along with the other models. WPF viewport will not be visibled.</para>
     /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
@@ -1,0 +1,947 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DPFCanvas.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// <summary>
+//
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+//#define DoubleBuffer
+namespace HelixToolkit.Wpf.SharpDX
+{
+    using System;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.Windows;
+    using System.Windows.Media;
+    using System.Windows.Threading;
+
+    using global::SharpDX;
+
+    using global::SharpDX.Direct3D11;
+
+    using global::SharpDX.DXGI;
+
+    using HelixToolkit.Wpf.SharpDX.Utilities;
+    using HelixToolkit.Wpf.SharpDX.Extensions;
+
+    using Device = global::SharpDX.Direct3D11.Device;
+    using Model.Lights3D;
+    using Helpers;
+    using System.Linq;
+    using Controls;
+    using System.Threading;
+
+    // ---- BASED ON ORIGNAL CODE FROM -----
+    // Copyright (c) 2010-2012 SharpDX - Alexandre Mutel
+    // 
+    // Permission is hereby granted, free of charge, to any person obtaining a copy
+    // of this software and associated documentation files (the "Software"), to deal
+    // in the Software without restriction, including without limitation the rights
+    // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    // copies of the Software, and to permit persons to whom the Software is
+    // furnished to do so, subject to the following conditions:
+    // 
+    // The above copyright notice and this permission notice shall be included in
+    // all copies or substantial portions of the Software.
+    // 
+    // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    // THE SOFTWARE.
+
+    /// <summary>
+    /// <para>Use HwndHost as rendering surface, swapchain for rendering. Much faster than using D3DImage.</para> 
+    /// <para>Drawbacks: The rendering surface will cover all WPF controls in the same Viewport region. Move controls out of viewport region to solve this problem.</para>
+    /// <para>For displaying ViewCube and CoordinateSystem, separate Model needs to create to render along with the other models. WPF viewport will not be visibled.</para>
+    /// </summary>
+    public class DPFSurfaceSwapChainThreading : WinformHostExtend, IRenderHost
+    {
+        private sealed class RenderThreadWrapper
+        {
+            public bool IsInitalized { get { return RenderThread!=null && RenderThread.IsAlive; } }
+            public bool IsBusy { private set; get; } = false;
+            private Thread RenderThread;
+            private ManualResetEventSlim renderThreadEvent = new ManualResetEventSlim(false);
+            private DeviceContext renderContext;
+            private SwapChain1 swapChain;
+            private CancellationTokenSource tsc;
+            private CommandList commandList;
+            public void InitializeRenderThread(DeviceContext renderContext, SwapChain1 swapChain)
+            {
+                DestoryRenderThread();
+                this.renderContext = renderContext;
+                this.swapChain = swapChain;
+                tsc = new CancellationTokenSource();
+                var token = tsc.Token;
+                RenderThread = new Thread(new ThreadStart(() =>
+                {
+                    while (!token.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            renderThreadEvent.Wait();
+                            if (token.IsCancellationRequested)
+                            {
+                                break;
+                            }
+                            renderContext.ExecuteCommandList(commandList, true);
+                            renderContext.Flush();
+                            swapChain.Present(0, 0);
+                        }
+                        finally
+                        {
+                            Disposer.RemoveAndDispose(ref commandList);
+                            renderThreadEvent.Reset();
+                            IsBusy = false;
+                        }
+                    }
+                }));
+                RenderThread.Start();
+            }
+
+            public void DestoryRenderThread()
+            {
+                if (!IsInitalized)
+                {
+                    return;
+                }
+                tsc.Cancel();
+                renderThreadEvent.Set();
+                RenderThread.Join();
+                tsc.Dispose();
+                RenderThread = null;
+            }
+
+            public bool InvalidateD3D(CommandList command)
+            {
+                if (IsBusy || !IsInitalized)
+                { return false; }
+                IsBusy = true;
+                commandList = command;
+                renderThreadEvent.Set();
+                return true;
+            }
+        }
+        private RenderThreadWrapper renderThread = new RenderThreadWrapper();
+        private readonly Stopwatch renderTimer;
+        private Device device;
+        private Texture2D depthStencilBuffer;
+        private Texture2D colorBuffer;
+        private RenderTargetView colorBufferView;
+        private DepthStencilView depthStencilBufferView;
+        private RenderControl surfaceD3D;
+        private IRenderer renderRenderable;
+        private RenderContext renderContext;
+        private DeferredRenderer deferredRenderer;
+        private bool sceneAttached;
+        private int targetWidth, targetHeight;
+        private bool pendingValidationCycles;
+        private TimeSpan lastRenderingDuration;
+        private RenderTechnique deferred;
+        private RenderTechnique gbuffer;
+        private Texture2D backBuffer;
+        private bool loaded = false;
+        private IEffectsManager defaultEffectsManager = null;
+        private global::SharpDX.DXGI.SwapChain1 swapChain;
+        /// <summary>
+        /// Get RenderContext
+        /// </summary>
+        public RenderContext RenderContext { get { return renderContext; } }
+
+        private readonly Light3DSceneShared light3DPerScene = new Light3DSceneShared();
+        /// <summary>
+        /// Light3D shared data per each secne
+        /// </summary>
+        public Light3DSceneShared Light3DSceneShared { get { return light3DPerScene; } }
+
+        /// <summary>
+        /// Fired whenever an exception occurred on this object.
+        /// </summary>
+        public event EventHandler<RelayExceptionEventArgs> ExceptionOccurred = delegate { };
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public Color4 ClearColor { get; internal set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool IsShadowMapEnabled { get; private set; }
+
+        /// <summary>
+        /// Set MSAA level. If set to Two/Four/Eight, the actual level is set to minimum between Maximum and Two/Four/Eight
+        /// </summary>
+        public MSAALevel MSAA { get; set; }
+        /// <summary>
+        /// Gets or sets the maximum time that rendering is allowed to take. When exceeded,
+        /// the next cycle will be enqueued at <see cref="DispatcherPriority.Input"/> to reduce input lag.
+        /// </summary>
+        public TimeSpan MaxRenderingDuration { get; set; }
+
+        private uint mMaxFPS = 60;
+        public uint MaxFPS
+        {
+            set
+            {
+                mMaxFPS = value;
+                skipper.Threshold = (long)Math.Floor(1000.0 / mMaxFPS);
+            }
+            get
+            {
+                return mMaxFPS;
+            }
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        public RenderTechnique RenderTechnique
+        {
+            get { return renderTechnique; }
+            private set
+            {
+                renderTechnique = value;
+                IsDeferredLighting = RenderTechniquesManager != null && (renderTechnique == RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred)
+                    || renderTechnique == RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer));
+            }
+        }
+        private RenderTechnique renderTechnique;
+
+        public bool IsDeferredLighting { private set; get; } = false;
+
+        private bool enableRenderFrustum = false;
+        public bool EnableRenderFrustum
+        {
+            set
+            {
+                enableRenderFrustum = value;
+                if (renderContext != null)
+                {
+                    renderContext.EnableBoundingFrustum = value;
+                }
+            }
+            get
+            {
+                return enableRenderFrustum;
+            }
+        }
+        /// <summary>
+        /// The instance of currently attached IRenderable - this is in general the Viewport3DX
+        /// </summary>
+        IRenderer IRenderHost.Renderable
+        {
+            get { return renderRenderable; }
+            set
+            {
+                if (ReferenceEquals(renderRenderable, value))
+                {
+                    return;
+                }
+
+                if (renderRenderable != null)
+                {
+                    renderRenderable.Detach();
+                    renderRenderable = null;
+                }
+
+                sceneAttached = false;
+                renderRenderable = value;
+                ParentControl = renderRenderable as UIElement;
+                InvalidateRender();
+            }
+        }
+
+        /// <summary>
+        /// The currently used Direct3D Device
+        /// </summary>
+        Device IRenderHost.Device
+        {
+            get { return device; }
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool EnableSharingModelMode { set; get; } = false;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IModelContainer SharedModelContainer { set; get; } = null;
+
+        private IEffectsManager effectsManager;
+        public IEffectsManager EffectsManager
+        {
+            set
+            {
+                if (effectsManager != value)
+                {
+                    effectsManager = value;
+                    RestartRendering();
+                }
+            }
+            get
+            {
+                return effectsManager;
+            }
+        }
+
+        public IRenderTechniquesManager RenderTechniquesManager { get { return EffectsManager != null ? EffectsManager.RenderTechniquesManager : null; } }
+
+        /// <summary>
+        /// Gets a value indicating whether the control is in design mode
+        /// (running in Blend or Visual Studio).
+        /// </summary>
+        public static bool IsInDesignMode
+        {
+            get
+            {
+                var prop = DesignerProperties.IsInDesignModeProperty;
+                return (bool)DependencyPropertyDescriptor.FromProperty(prop, typeof(FrameworkElement)).Metadata.DefaultValue;
+            }
+        }
+
+        /// <summary>
+        /// Indicates if DPFCanvas busy on rendering.
+        /// </summary>
+        public bool IsBusy { get { return pendingValidationCycles; } }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public DPFSurfaceSwapChainThreading()
+        {
+            renderTimer = new Stopwatch();
+            MaxRenderingDuration = TimeSpan.FromMilliseconds(20.0);
+            Loaded += OnLoaded;
+            Unloaded += OnUnloaded;
+            ClearColor = global::SharpDX.Color.Gray;
+            IsShadowMapEnabled = false;
+            MSAA = MSAALevel.Disable;
+        }
+
+        /// <summary>
+        /// Invalidates the current render and requests an update.
+        /// </summary>
+        private void InvalidateRender()
+        {
+            pendingValidationCycles = true;
+        }
+
+
+        /// <summary>
+        /// Invalidates the current render and requests an update.
+        /// </summary>
+        void IRenderHost.InvalidateRender()
+        {
+            InvalidateRender();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (IsInDesignMode)
+            {
+                return;
+            }
+            loaded = true;
+            try
+            {
+                if (StartD3D())
+                { StartRendering(); }
+            }
+            catch (Exception ex)
+            {
+                // Exceptions in the Loaded event handler are silently swallowed by WPF.
+                // https://social.msdn.microsoft.com/Forums/vstudio/en-US/9ed3d13d-0b9f-48ac-ae8d-daf0845c9e8f/bug-in-wpf-windowloaded-exception-handling?forum=wpf
+                // http://stackoverflow.com/questions/19140593/wpf-exception-thrown-in-eventhandler-is-swallowed
+                // tl;dr: M$ says it's "by design" and "working as indended" but may change in the future :).
+
+                if (!HandleExceptionOccured(ex))
+                {
+                    MessageBox.Show(string.Format("DPFCanvas: Error starting rendering: {0}", ex.Message), "Error");
+                }
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            if (IsInDesignMode)
+            {
+                return;
+            }
+            loaded = false;
+            StopRendering();
+            EndD3D(true);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private bool StartD3D()
+        {
+            if (!loaded || EffectsManager == null || RenderTechniquesManager == null)
+            {
+                if (EffectsManager == null)
+                {
+                    EffectsManager = defaultEffectsManager = new DefaultEffectsManager(new DefaultRenderTechniquesManager());
+                }
+                //RenderTechniquesManager = DefaultRenderTechniquesManagerObj.Value;
+                //EffectsManager = DefaultEffectsManagerObj.Value;
+                return false; // StardD3D() is called from DP changed handler
+            }
+            this.IsHitTestVisible = false;
+            surfaceD3D = new RenderControl();
+            Child = surfaceD3D;
+            device = EffectsManager.Device;
+            deferredRenderer = new DeferredRenderer();
+            renderRenderable.DeferredRenderer = deferredRenderer;
+
+            CreateAndBindTargets();
+            SetDefaultRenderTargets();
+            //Source = surfaceD3D;
+            InvalidateRender();
+            return true;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void EndD3D(bool dispose)
+        {
+            if (renderRenderable != null)
+            {
+                renderRenderable.Detach();
+                sceneAttached = false;
+            }
+            this.Child = null;
+            Disposer.RemoveAndDispose(ref renderContext);
+            Disposer.RemoveAndDispose(ref deferredRenderer);
+            Disposer.RemoveAndDispose(ref surfaceD3D);
+            Disposer.RemoveAndDispose(ref colorBufferView);
+            Disposer.RemoveAndDispose(ref colorBuffer);
+            Disposer.RemoveAndDispose(ref backBuffer);
+            Disposer.RemoveAndDispose(ref depthStencilBufferView);
+            Disposer.RemoveAndDispose(ref depthStencilBuffer);
+            Disposer.RemoveAndDispose(ref swapChain);
+            if (dispose && defaultEffectsManager != null)
+            {
+                (defaultEffectsManager as IDisposable)?.Dispose();
+                if (effectsManager == defaultEffectsManager)
+                { effectsManager = null; }
+                defaultEffectsManager = null;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void CreateAndBindTargets()
+        {
+            //surfaceD3D.SetRenderTargetDX11(null);
+
+            int width = System.Math.Max((int)ActualWidth, 100);
+            int height = System.Math.Max((int)ActualHeight, 100);
+            device.ImmediateContext.OutputMerger.ResetTargets();
+            Disposer.RemoveAndDispose(ref colorBufferView);
+            Disposer.RemoveAndDispose(ref colorBuffer);
+            Disposer.RemoveAndDispose(ref backBuffer);
+            Disposer.RemoveAndDispose(ref depthStencilBufferView);
+            Disposer.RemoveAndDispose(ref depthStencilBuffer);
+            device.ImmediateContext.Flush();
+            CreateSwapChain();
+            backBuffer = Texture2D.FromSwapChain<Texture2D>(swapChain, 0);
+
+            int sampleCount = 1;
+            int sampleQuality = 0;
+#if DoubleBuffer
+            if (MSAA != MSAALevel.Disable)
+            {
+                do
+                {
+                    var newSampleCount = sampleCount * 2;
+                    var newSampleQuality = device.CheckMultisampleQualityLevels(Format.B8G8R8A8_UNorm, newSampleCount) - 1;
+
+                    if (newSampleQuality < 0)
+                        break;
+
+                    sampleCount = newSampleCount;
+                    sampleQuality = newSampleQuality;
+                    if (sampleCount == (int)MSAA)
+                    {
+                        break;
+                    }
+                } while (sampleCount < 32);
+            }
+            var sampleDesc = new SampleDescription(sampleCount, sampleQuality);
+            var colordesc = new Texture2DDescription
+            {
+                BindFlags = BindFlags.RenderTarget | BindFlags.ShaderResource,
+                Format = Format.B8G8R8A8_UNorm,
+                Width = width,
+                Height = height,
+                MipLevels = 1,
+                SampleDescription = sampleDesc,
+                Usage = ResourceUsage.Default,
+                OptionFlags = ResourceOptionFlags.None,
+                CpuAccessFlags = CpuAccessFlags.None,
+                ArraySize = 1
+            };
+            colorBuffer = new Texture2D(device, colordesc);
+            colorBufferView = new RenderTargetView(device, colorBuffer);
+#else
+            var sampleDesc = swapChain.Description1.SampleDescription;
+            colorBufferView = new RenderTargetView(device, backBuffer);
+#endif
+            var depthdesc = new Texture2DDescription
+            {
+                BindFlags = BindFlags.DepthStencil,
+                //Format = Format.D24_UNorm_S8_UInt,
+                Format = Format.D32_Float_S8X24_UInt,
+                Width = width,
+                Height = height,
+                MipLevels = 1,
+                SampleDescription = sampleDesc,
+                Usage = ResourceUsage.Default,
+                OptionFlags = ResourceOptionFlags.None,
+                CpuAccessFlags = CpuAccessFlags.None,
+                ArraySize = 1,
+            };
+            depthStencilBuffer = new Texture2D(device, depthdesc);
+            depthStencilBufferView = new DepthStencilView(device, depthStencilBuffer);
+            this.device.ImmediateContext.Rasterizer.SetScissorRectangle(0, 0, width, height);
+        }
+
+        private void CreateSwapChain()
+        {
+            //if (swapChain != null)
+            //{
+            //    swapChain.ResizeBuffers(swapChain.Description1.BufferCount, (int)ActualWidth, (int)ActualHeight, swapChain.Description.ModeDescription.Format, swapChain.Description.Flags);
+            //}
+            //else
+            {
+                Disposer.RemoveAndDispose(ref swapChain);
+                var desc = CreateSwapChainDescription();
+                using (var dxgiDevice2 = device.QueryInterface<global::SharpDX.DXGI.Device2>())
+                using (var dxgiAdapter = dxgiDevice2.Adapter)
+                using (var dxgiFactory2 = dxgiAdapter.GetParent<global::SharpDX.DXGI.Factory2>())
+                using (var output = dxgiAdapter.Outputs.First())
+                {
+                    // The CreateSwapChain method is used so we can descend
+                    // from this class and implement a swapchain for a desktop
+                    // or a Windows 8 AppStore app
+                    swapChain = new SwapChain1(dxgiFactory2, device, surfaceD3D.Handle, ref desc);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates the swap chain description.
+        /// </summary>
+        /// <returns>A swap chain description</returns>
+        /// <remarks>
+        /// This method can be overloaded in order to modify default parameters.
+        /// </remarks>
+        protected virtual global::SharpDX.DXGI.SwapChainDescription1 CreateSwapChainDescription()
+        {
+            int sampleCount = 1;
+            int sampleQuality = 0;
+            // SwapChain description
+#if DoubleBuffer
+#else
+            if (MSAA != MSAALevel.Disable)
+            {
+                do
+                {
+                    var newSampleCount = sampleCount * 2;
+                    var newSampleQuality = device.CheckMultisampleQualityLevels(Format.B8G8R8A8_UNorm, newSampleCount) - 1;
+
+                    if (newSampleQuality < 0)
+                        break;
+
+                    sampleCount = newSampleCount;
+                    sampleQuality = newSampleQuality;
+                    if (sampleCount == (int)MSAA)
+                    {
+                        break;
+                    }
+                } while (sampleCount < 32);
+            }
+#endif
+            var desc = new global::SharpDX.DXGI.SwapChainDescription1()
+            {
+                Width = (int)ActualWidth,
+                Height = (int)ActualHeight,
+                // B8G8R8A8_UNorm gives us better performance 
+                Format = global::SharpDX.DXGI.Format.B8G8R8A8_UNorm,
+                Stereo = false,
+                SampleDescription = new global::SharpDX.DXGI.SampleDescription(sampleCount, sampleQuality),
+#if DoubleBuffer
+                Usage = Usage.BackBuffer,
+                BufferCount = 2,
+                SwapEffect = global::SharpDX.DXGI.SwapEffect.FlipSequential,
+#else
+                Usage = Usage.RenderTargetOutput,
+                BufferCount = 1,
+                SwapEffect = global::SharpDX.DXGI.SwapEffect.Discard,
+#endif
+                Scaling = global::SharpDX.DXGI.Scaling.Stretch,
+                Flags = SwapChainFlags.AllowModeSwitch
+            };
+            return desc;
+        }
+        /// <summary>
+        /// Sets the default render-targets
+        /// </summary>
+        public void SetDefaultRenderTargets(bool clear = true)
+        {
+            SetDefaultRenderTargets(swapChain.Description1.Width, swapChain.Description1.Height, clear);
+        }
+
+        /// <summary>
+        /// Sets the default render-targets
+        /// </summary>
+        public void SetDefaultRenderTargets(int width, int height, bool clear = true)
+        {
+            targetWidth = width;
+            targetHeight = height;
+
+            device.ImmediateContext.OutputMerger.SetTargets(depthStencilBufferView, colorBufferView);
+            device.ImmediateContext.Rasterizer.SetViewport(0, 0, width, height, 0.0f, 1.0f);
+            device.ImmediateContext.Rasterizer.SetScissorRectangle(0, 0, width, height);
+
+            renderContext?.DeviceContext.OutputMerger.SetTargets(depthStencilBufferView, colorBufferView);
+            renderContext?.DeviceContext.Rasterizer.SetViewport(0, 0, width, height, 0f, 1f);
+            renderContext?.DeviceContext.Rasterizer.SetScissorRectangle(0, 0, width, height);
+            if (clear)
+            {
+                ClearRenderTarget();
+            }
+        }
+
+        /// <summary>
+        /// Sets the default render-targets
+        /// </summary>
+        public void SetDefaultColorTargets(DepthStencilView dsv)
+        {
+            targetWidth = swapChain.Description1.Width;
+            targetHeight = swapChain.Description1.Height;
+
+            device.ImmediateContext.OutputMerger.SetTargets(dsv, colorBufferView);
+            device.ImmediateContext.Rasterizer.SetViewport(0, 0, targetWidth, targetHeight, 0.0f, 1.0f);
+
+            device.ImmediateContext.ClearRenderTargetView(colorBufferView, ClearColor);
+            device.ImmediateContext.ClearDepthStencilView(depthStencilBufferView, DepthStencilClearFlags.Depth | DepthStencilClearFlags.Stencil, 1.0f, 0);
+        }
+
+        /// <summary>
+        /// Clears the buffers with the clear-color
+        /// </summary>
+        /// <param name="clearBackBuffer"></param>
+        /// <param name="clearDepthStencilBuffer"></param>
+        internal void ClearRenderTarget(bool clearBackBuffer = true, bool clearDepthStencilBuffer = true)
+        {
+            if (clearBackBuffer)
+            {
+                // device.ImmediateContext.ClearRenderTargetView(colorBufferView, ClearColor);
+                renderContext?.DeviceContext.ClearRenderTargetView(colorBufferView, ClearColor);
+            }
+
+            if (clearDepthStencilBuffer)
+            {
+                //  device.ImmediateContext.ClearDepthStencilView(depthStencilBufferView, DepthStencilClearFlags.Depth | DepthStencilClearFlags.Stencil, 1.0f, 0);
+                renderContext?.DeviceContext.ClearDepthStencilView(depthStencilBufferView, DepthStencilClearFlags.Depth | DepthStencilClearFlags.Stencil, 1.0f, 0);
+            }
+        }
+
+        private void Render(TimeSpan timeStamp)
+        {
+            var device = this.device;
+            if (device == null)
+                return;
+            if (swapChain == null)
+                return;
+            if (renderRenderable != null)
+            {
+                // ---------------------------------------------------------------------------
+                // this part is done only if the scene is not attached
+                // it is an attach and init pass for all elements in the scene-graph                
+                if (!sceneAttached)
+                {
+                    try
+                    {
+                        Light3DSceneShared.Reset();
+                        sceneAttached = true;
+                        ClearColor = renderRenderable.BackgroundColor;
+                        IsShadowMapEnabled = renderRenderable.IsShadowMappingEnabled;
+
+                        RenderTechnique = renderRenderable.RenderTechnique == null ? RenderTechniquesManager?.RenderTechniques[DefaultRenderTechniqueNames.Blinn] : renderRenderable.RenderTechnique;
+
+                        if (renderContext != null)
+                        {
+                            renderContext.Dispose();
+                        }
+                        renderContext = new RenderContext(this, EffectsManager.GetEffect(RenderTechnique), new DeviceContext(device));
+                        renderContext.EnableBoundingFrustum = EnableRenderFrustum;
+                        if (EnableSharingModelMode && SharedModelContainer != null)
+                        {
+                            SharedModelContainer.CurrentRenderHost = this;
+                            renderRenderable.Attach(SharedModelContainer);
+                        }
+                        else
+                        {
+                            renderRenderable.Attach(this);
+                        }
+
+                        RenderTechniquesManager.RenderTechniques.TryGetValue(DeferredRenderTechniqueNames.GBuffer, out gbuffer);
+                        RenderTechniquesManager.RenderTechniques.TryGetValue(DeferredRenderTechniqueNames.Deferred, out deferred);
+
+                        if (RenderTechnique == deferred)
+                        {
+                            deferredRenderer.InitBuffers(this, Format.R32G32B32A32_Float);
+                        }
+                        else if (RenderTechnique == gbuffer)
+                        {
+                            deferredRenderer.InitBuffers(this, Format.B8G8R8A8_UNorm);
+                        }
+                        SetDefaultRenderTargets(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        //MessageBox.Show("DPFCanvas: Error attaching element: " + string.Format(ex.Message), "Error");
+                        Debug.WriteLine("DPFCanvas: Error attaching element: " + string.Format(ex.Message), "Error");
+                        throw;
+                    }
+                }
+                renderContext.TimeStamp = timeStamp;
+                // ---------------------------------------------------------------------------
+                // this part is per frame
+                // ---------------------------------------------------------------------------
+                if (EnableSharingModelMode && SharedModelContainer != null)
+                {
+                    SharedModelContainer.CurrentRenderHost = this;
+                }
+                ClearRenderTarget();
+                if (RenderTechnique == deferred)
+                {
+                    // set G-Buffer                    
+                    deferredRenderer.SetGBufferTargets(renderContext);
+
+                    // render G-Buffer pass                
+                    renderRenderable.Render(renderContext);
+
+                    // call deferred render 
+                    deferredRenderer.RenderDeferred(renderContext, renderRenderable);
+
+                }
+                else if (RenderTechnique == gbuffer)
+                {
+                    // set G-Buffer
+                    deferredRenderer.SetGBufferTargets(targetWidth / 2, targetHeight / 2, renderContext);
+
+                    // render G-Buffer pass                    
+                    renderRenderable.Render(renderContext);
+
+                    // reset render targets and run lighting pass                                         
+#if DoubleBuffer
+                    deferredRenderer.RenderGBufferOutput(renderContext, ref backBuffer);
+#else
+                    this.deferredRenderer.RenderGBufferOutput(renderContext, ref this.backBuffer);
+#endif
+                }
+                else
+                {
+                    renderRenderable.Render(renderContext);
+                }
+#if DoubleBuffer
+                device.ImmediateContext.ResolveSubresource(colorBuffer, 0, backBuffer, 0, Format.B8G8R8A8_UNorm);
+#endif
+            }
+        }
+
+        private void StartRendering()
+        {
+            if (renderTimer.IsRunning)
+                return;
+
+            lastRenderingDuration = TimeSpan.Zero;
+            renderThread.InitializeRenderThread(device.ImmediateContext, swapChain);
+            CompositionTarget.Rendering += OnRendering;
+            renderTimer.Start();
+        }
+
+        private void StopRendering()
+        {
+            if (!renderTimer.IsRunning)
+                return;
+            renderThread.DestoryRenderThread();
+            CompositionTarget.Rendering -= OnRendering;
+            renderTimer.Stop();
+        }
+
+        /// <summary>
+        /// Handles the <see cref="CompositionTarget.Rendering"/> event.
+        /// </summary>
+        /// <param name="sender">The sender is in fact a the UI <see cref="Dispatcher"/>.</param>
+        /// <param name="e">Is in fact <see cref="RenderingEventArgs"/>.</param>
+        private void OnRendering(object sender, EventArgs e)
+        {
+
+            if (!renderTimer.IsRunning)
+                return;
+            UpdateAndRender();
+        }
+
+        private readonly EventSkipper skipper = new EventSkipper();
+        private readonly PresentParameters presentParams = new PresentParameters();
+        /// <summary>
+        /// Updates and renders the scene.
+        /// </summary>
+        private void UpdateAndRender()
+        {
+            if (!renderThread.IsBusy && ((pendingValidationCycles && !skipper.IsSkip()) || skipper.DelayTrigger()) && renderRenderable != null)
+            {
+                var t0 = renderTimer.Elapsed;
+
+                // Update all renderables before rendering 
+                // giving them the chance to invalidate the current render.                                                            
+                //renderRenderable.Update(t0);
+                try
+                {
+                    Render(t0);
+                    var commandList = renderContext.DeviceContext.FinishCommandList(true);
+                    if (!renderThread.InvalidateD3D(commandList))
+                    {
+                        pendingValidationCycles = false;
+                    }
+                    else
+                    {
+                        device.ImmediateContext.Flush();
+                        Disposer.RemoveAndDispose(ref commandList);                        
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (!HandleExceptionOccured(ex))
+                    {
+                        MessageBox.Show(string.Format("DPFCanvas: Error while rendering: {0}", ex.Message), "Error");
+                    }
+                }
+                lastRenderingDuration = renderTimer.Elapsed - t0;
+            }
+        }
+
+        private DispatcherOperation resizeOperation = null;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sizeInfo"></param>
+        protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+        {
+            if (!loaded)
+            {
+                return;
+            }
+            if (resizeOperation != null && resizeOperation.Status == DispatcherOperationStatus.Pending)
+            {
+                resizeOperation.Abort();
+            }
+            resizeOperation = Dispatcher.BeginInvoke(DispatcherPriority.Background, (Action)(() =>
+            {
+                //if (surfaceD3D != null)
+                {
+                    if (RenderTechnique != null)
+                    {
+                        if (RenderTechnique == deferred)
+                        {
+                            deferredRenderer.InitBuffers(this, Format.R32G32B32A32_Float);
+                        }
+                        else if (RenderTechnique == gbuffer)
+                        {
+                            deferredRenderer.InitBuffers(this, Format.B8G8R8A8_UNorm);
+                        }
+                    }
+                    StopRendering();
+                    CreateAndBindTargets();
+                    SetDefaultRenderTargets();
+                    StartRendering();
+                    InvalidateRender();
+                }
+            }));
+        }
+
+        /// <summary>
+        /// Handles the change of the effects manager.
+        /// </summary>
+        private void RestartRendering()
+        {
+            StopRendering();
+            EndD3D(false);
+            if (loaded)
+            {
+                if (EffectsManager != null && RenderTechniquesManager != null)
+                {
+                    IsDeferredLighting = (renderTechnique == RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.Deferred)
+                        || renderTechnique == RenderTechniquesManager.RenderTechniques.Get(DeferredRenderTechniqueNames.GBuffer));
+                }
+                if (StartD3D())
+                { StartRendering(); }
+            }
+        }
+
+        /// <summary>
+        /// Invoked whenever an exception occurs. Stops rendering, frees resources and throws 
+        /// </summary>
+        /// <param name="exception">The exception that occured.</param>
+        /// <returns><c>true</c> if the exception has been handled, <c>false</c> otherwise.</returns>
+        private bool HandleExceptionOccured(Exception exception)
+        {
+            pendingValidationCycles = false;
+            StopRendering();
+            EndD3D(true);
+
+            var args = new RelayExceptionEventArgs(exception);
+            ExceptionOccurred(this, args);
+            return args.Handled;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnIsFrontBufferAvailableChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            // We don't need to handle this on NET45+ because of software fallback (Remote Desktop, Sleep).
+            // See: http://msdn.microsoft.com/en-us/library/hh140978%28v=vs.110%29.aspx
+#if NET40
+            // this fires when the screensaver kicks in, the machine goes into sleep or hibernate
+            // and any other catastrophic losses of the d3d device from WPF's point of view
+            if (this.surfaceD3D.IsFrontBufferAvailable)
+            {
+                // We need to re-create the render targets because the get lost on NET40.
+                this.CreateAndBindTargets();
+                this.SetDefaultRenderTargets();
+                this.InvalidateRender();
+                this.StartRendering();
+            }
+            else
+            {
+                this.StopRendering();
+            }
+#endif
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
@@ -811,7 +811,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         private void UpdateAndRender()
         {
-            if (!renderThread.IsBusy && ((pendingValidationCycles && !skipper.IsSkip()) || skipper.DelayTrigger()) && renderRenderable != null)
+            if (((pendingValidationCycles && !skipper.IsSkip()) || skipper.DelayTrigger()) && !renderThread.IsBusy && renderRenderable != null)
             {
                 var t0 = renderTimer.Elapsed;
 
@@ -822,7 +822,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     Render(t0);
                     var commandList = renderContext.DeviceContext.FinishCommandList(true);
-                    if (!renderThread.InvalidateD3D(commandList))
+                    if (renderThread.InvalidateD3D(commandList))
                     {
                         pendingValidationCycles = false;
                     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
@@ -854,7 +854,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 try
                 {
                     Render(t0);
-                    var commandList = renderContext.DeviceContext.FinishCommandList(true);
+                    var commandList = deferredContext.FinishCommandList(true);
                     if (renderThread.InvalidateD3D(commandList))
                     {
                         pendingValidationCycles = false;

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/MultiViewports/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/MultiViewports/ModelContainer3DX.cs
@@ -9,6 +9,7 @@ using HelixToolkit.Wpf.SharpDX.Model.Lights3D;
 using HelixToolkit.Wpf.SharpDX.Utilities;
 using SharpDX;
 using SharpDX.Direct3D11;
+using System.ComponentModel;
 
 namespace HelixToolkit.Wpf.SharpDX
 {
@@ -81,7 +82,8 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public ModelContainer3DX()
         {
-            EffectsManager = new DefaultEffectsManager(new DefaultRenderTechniquesManager());
+            if(!DesignerProperties.GetIsInDesignMode(this))
+                EffectsManager = new DefaultEffectsManager(new DefaultRenderTechniquesManager());
         }
         /// <summary>
         /// Handles the change of the effects manager.

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/RenderContext.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/RenderContext.cs
@@ -58,7 +58,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public bool EnableBoundingFrustum = false;
 
-        public DeviceContext DeviceContext { private set; get; }
+        public DeviceContext DeviceContext { set; get; }
 
         public double ActualWidth { get; private set; }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -710,7 +710,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Set MSAA Level
         /// </summary>
         public static readonly DependencyProperty MSAAProperty = DependencyProperty.Register("MSAA", typeof(MSAALevel), typeof(Viewport3DX), 
-            new PropertyMetadata(MSAALevel.Maximum, (s,e)=> 
+            new PropertyMetadata(MSAALevel.Disable, (s,e)=> 
             {
                 var viewport = s as Viewport3DX;
                 if (viewport.RenderHost != null)

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -776,7 +776,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }, (s,e)=> { return Math.Max(1, (int)e); }));
 
         /// <summary>
-        /// <para>Enable deferred rendering.</para> 
+        /// <para>Enable deferred rendering. Not supported with EnableSharedModelMode = true</para> 
         /// <para>If this is enabled, seperate UI thread is created and used for rendering. Main UI thread is used to create command list for deferred context.</para>
         /// <para>This does not guarantee better performance. Please fully test before deciding which rendering method being used.</para>
         /// <para>Deferred Rendering: <see cref="https://msdn.microsoft.com/en-us/library/windows/desktop/ff476892(v=vs.85).aspx"/></para>
@@ -2631,7 +2631,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// <para>Enable deferred rendering.</para> 
+        /// <para>Enable deferred rendering. Not supported with EnableSharedModelMode = true</para> 
         /// <para>If this is enabled, seperate UI thread is created and used for rendering. Main UI thread is used to create command list for deferred context.</para>
         /// <para>This does not guarantee better performance. Please fully test before deciding which rendering method being used.</para>
         /// <para>Deferred Rendering: <see cref="https://msdn.microsoft.com/en-us/library/windows/desktop/ff476892(v=vs.85).aspx"/></para>
@@ -2683,6 +2683,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <para>Use HwndHost as rendering surface, swapchain for rendering. Much faster than using D3DImage.</para> 
         /// <para>Drawbacks: The rendering surface will cover all WPF controls in the same Viewport region. Move controls out of viewport region to solve this problem.</para>
         /// <para>For displaying ViewCube and CoordinateSystem, separate Model needs to create to render along with the other models. WPF viewport will not be visibled.</para>
+        /// <para>Note: Enable deferred rendering will use seperate rendering thread or rendering.</para>
         /// </summary>
         public bool EnableSwapChainRendering
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -559,7 +559,7 @@ namespace HelixToolkit.Wpf.SharpDX
 #if DX11
             if (EnableSwapChainRendering)
             {
-                if (EnableDeferredRendering)
+                if (EnableDeferredRendering && !EnableSharedModelMode)
                 {
                     hostPresenter.Content = new DPFSurfaceSwapChainThreading();
                 }
@@ -570,7 +570,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             else
             {
-                if (EnableDeferredRendering)
+                if (EnableDeferredRendering && !EnableSharedModelMode)
                 {
                     hostPresenter.Content = new DPFCanvasThreading();
                 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -559,7 +559,14 @@ namespace HelixToolkit.Wpf.SharpDX
 #if DX11
             if (EnableSwapChainRendering)
             {
-                hostPresenter.Content = new DPFSurfaceSwapChain();
+                if (EnableDeferredRendering)
+                {
+                    hostPresenter.Content = new DPFSurfaceSwapChainThreading();
+                }
+                else
+                {
+                    hostPresenter.Content = new DPFSurfaceSwapChain();
+                }
             }
             else
             {

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/WinformHostExtend.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/WinformHostExtend.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Forms.Integration;
 using System.Windows.Input;
@@ -11,6 +12,7 @@ namespace HelixToolkit.Wpf.SharpDX.Controls
 {
     public class WinformHostExtend : WindowsFormsHost
     {
+        protected UIElement ParentControl { set; get; }
         public WinformHostExtend()
         {
             ChildChanged += OnChildChanged;
@@ -40,26 +42,20 @@ namespace HelixToolkit.Wpf.SharpDX.Controls
             });
         }
 
-        private void Child_MouseUp(object sender, System.Windows.Forms.MouseEventArgs mouseEventArgs)
-        {
-            MouseButton? wpfButton = ConvertToWpf(mouseEventArgs.Button);
-            if (!wpfButton.HasValue)
-                return;
-
-            RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, wpfButton.Value)
-            {
-                RoutedEvent = Mouse.MouseUpEvent,
-                Source = this,
-            });
-        }
-
         private void OnMouseDown(object sender, System.Windows.Forms.MouseEventArgs mouseEventArgs)
         {
             MouseButton? wpfButton = ConvertToWpf(mouseEventArgs.Button);
             if (!wpfButton.HasValue)
                 return;
-            this.CaptureMouse();
-            this.ReleaseMouseCapture();
+            if (ParentControl != null)
+            {
+                Mouse.Capture(ParentControl, CaptureMode.Element);
+            }
+            else
+            {
+                this.CaptureMouse();
+                this.ReleaseMouseCapture();
+            }
             RaiseEvent(new MouseButtonEventArgs(Mouse.PrimaryDevice, 0, wpfButton.Value)
             {
                 RoutedEvent = Mouse.MouseDownEvent,

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Controls\DPFCanvas.cs" />
     <Compile Include="Controls\DPFCanvasThreading.cs" />
     <Compile Include="Controls\DPFSurfaceSwapChain.cs" />
+    <Compile Include="Controls\DPFSurfaceSwapChainThreading.cs" />
     <Compile Include="Controls\IRenderMatrices.cs" />
     <Compile Include="Controls\MultiViewports\IModelContainer.cs" />
     <Compile Include="Controls\MultiViewports\ModelContainer3DX.cs" />


### PR DESCRIPTION
Enable both swapchain rendering and deferred rendering to use this feature.  Much faster and smoother on large scene.
Currently not supported if enable SharedModelMode.