### PR TITLE
CameraExtensions get correct viewmatrix.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraExtensions.cs
@@ -472,11 +472,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
             if (camera is ProjectionCamera)
             {
-                var projcam = camera as ProjectionCamera;
-                return Matrix.LookAtRH(
-                    projcam.Position.ToVector3(),
-                    (projcam.Position + projcam.LookDirection).ToVector3(),
-                    projcam.UpDirection.ToVector3());
+                return camera.CreateViewMatrix();
             }
 
             throw new HelixToolkitException("Unknown camera type.");


### PR DESCRIPTION
The GetViewMatrix function in CameraExtension was creating a new ViewMatrix based on Matrix.LookAtRH.

When setting "CreateLeftHandSystem = true" when creating a camera, HitTesting would not work, since it would get the wrong ViewMatrix.