### PR TITLE
Fixed orthographic zoom bug. Use the same factor for camera width as …

### DIFF
--- a/Source/HelixToolkit.Wpf/Controls/CameraController/ZoomHandler.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/ZoomHandler.cs
@@ -127,7 +127,7 @@ namespace HelixToolkit.Wpf
                     var ocamera = this.Camera as OrthographicCamera;
                     if (ocamera != null)
                     {
-                        ocamera.Width *= 1 + delta;
+                        ocamera.Width *= Math.Pow(2.5, delta);
                     }
 
                     break;


### PR DESCRIPTION
…for camera distance.

This fixes observable drift (and sometimes jumping) when zooming in and out with the mouse wheel using an orthographic camera, when ZoomAroundMouseDownPoint is true. This drift can be easily observed in the CameraControlDemo: position the mouse over a grid intersection and zoom in and out with the mouse wheel - the grid intersection should remain under the cursor.

Possibly related to #134 and #40. 

I believe this bug was introduced with commit a86978e5c8e398c9b83a62062c949219b47514c2, which changed the scale factor for camera distance but not camera width.