### PR TITLE
Let DPFCanvas(Threading) and DPFSurfaceSwapChain(Threading) recover from DeviceLost (really)

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -848,6 +848,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             pendingValidationCycles = false;
             StopRendering();
+            EndD3D(true);
 
             var sdxException = exception as SharpDXException;
             if (sdxException != null &&

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
@@ -29,6 +29,8 @@ namespace HelixToolkit.Wpf.SharpDX
     using Model.Lights3D;
     using Helpers;
     using System.Linq;
+    using System.Windows.Interop;
+
     using Controls;
 
     // ---- BASED ON ORIGNAL CODE FROM -----
@@ -299,6 +301,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 return;
             }
             loaded = true;
+            ((HwndSource)PresentationSource.FromVisual(this)).AddHook(OnWindowMessage);
             try
             {
                 if (StartD3D())
@@ -330,6 +333,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 return;
             }
             loaded = false;
+            ((HwndSource)PresentationSource.FromVisual(this)).RemoveHook(OnWindowMessage);
             StopRendering();
             EndD3D(true);
         }
@@ -803,22 +807,33 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 //if (surfaceD3D != null)
                 {
-                    if (RenderTechnique != null)
+                    try
                     {
-                        if (RenderTechnique == deferred)
+                        if (RenderTechnique != null)
                         {
-                            deferredRenderer.InitBuffers(this, Format.R32G32B32A32_Float);
+                            if (RenderTechnique == deferred)
+                            {
+                                deferredRenderer.InitBuffers(this, Format.R32G32B32A32_Float);
+                            }
+                            else if (RenderTechnique == gbuffer)
+                            {
+                                deferredRenderer.InitBuffers(this, Format.B8G8R8A8_UNorm);
+                            }
                         }
-                        else if (RenderTechnique == gbuffer)
+
+                        StopRendering();
+                        CreateAndBindTargets();
+                        SetDefaultRenderTargets();
+                        StartRendering();
+                        InvalidateRender();
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!HandleExceptionOccured(ex))
                         {
-                            deferredRenderer.InitBuffers(this, Format.B8G8R8A8_UNorm);
+                            MessageBox.Show(string.Format("DPFCanvas: Error while rendering: {0}", ex.Message), "Error");
                         }
                     }
-                    StopRendering();
-                    CreateAndBindTargets();
-                    SetDefaultRenderTargets();
-                    StartRendering();
-                    InvalidateRender();
                 }
             }));
         }
@@ -853,36 +868,34 @@ namespace HelixToolkit.Wpf.SharpDX
             StopRendering();
             EndD3D(true);
 
-            var args = new RelayExceptionEventArgs(exception);
-            ExceptionOccurred(this, args);
-            return args.Handled;
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void OnIsFrontBufferAvailableChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            // We don't need to handle this on NET45+ because of software fallback (Remote Desktop, Sleep).
-            // See: http://msdn.microsoft.com/en-us/library/hh140978%28v=vs.110%29.aspx
-#if NET40
-            // this fires when the screensaver kicks in, the machine goes into sleep or hibernate
-            // and any other catastrophic losses of the d3d device from WPF's point of view
-            if (this.surfaceD3D.IsFrontBufferAvailable)
+            var sdxException = exception as SharpDXException;
+            if (sdxException != null &&
+                (sdxException.Descriptor == global::SharpDX.DXGI.ResultCode.DeviceRemoved ||
+                 sdxException.Descriptor == global::SharpDX.DXGI.ResultCode.DeviceReset))
             {
-                // We need to re-create the render targets because the get lost on NET40.
-                this.CreateAndBindTargets();
-                this.SetDefaultRenderTargets();
-                this.InvalidateRender();
-                this.StartRendering();
+                // Try to recover from DeviceRemoved/DeviceReset
+                RestartRendering();
+                return true;
             }
             else
             {
-                this.StopRendering();
+                var args = new RelayExceptionEventArgs(exception);
+                ExceptionOccurred(this, args);
+                return args.Handled;
             }
-#endif
+        }
+
+        private IntPtr OnWindowMessage(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            const int WM_DISPLAYCHANGE = 0x7E;
+            if (msg == WM_DISPLAYCHANGE)
+            {
+                // Realize invalidation caused by DeviceRemoved/DeviceReset
+                // if there is no rendering pending (SimpleDemo)
+                InvalidateRender();
+            }
+
+            return IntPtr.Zero;
         }
     }
 }


### PR DESCRIPTION
This pull request solves issue #553 for DPFCanvas(Threading) and DPFSurfaceSwapChain(Threading). Pull request #561 failed because I messed up my local git repo. :)