### PR TITLE
Fix GroupElement3D itemsSource only take ObservableElement3DCollection issue #566.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -113,7 +113,7 @@ namespace HelixToolkit.Wpf.SharpDX
             itemsSourceInternal = itemsSource;
             if (itemsSourceInternal != null)
             {
-                if (itemsSourceInternal is ObservableElement3DCollection)
+                if (itemsSourceInternal is INotifyCollectionChanged)
                 {
                     (itemsSourceInternal as INotifyCollectionChanged).CollectionChanged += Items_CollectionChanged;
                 }


### PR DESCRIPTION
Fix GroupElement3D itemsSource only take ObservableElement3DCollection issue. Now it is working with IList<Element3D>. Issue mentioned in #566.