### PR TITLE
Call update bound automatically if not updated. Refer to #571

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GeometryModel3D.cs
@@ -159,6 +159,10 @@ namespace HelixToolkit.Wpf.SharpDX
                 (e.NewValue as INotifyPropertyChanged).PropertyChanged += model.OnGeometryPropertyChangedPrivate;
             }
             model.geometryInternal = e.NewValue == null ? null : e.NewValue as Geometry3D;
+            if (model.geometryInternal != null && model.geometryInternal.Bound.Maximum == Vector3.Zero && model.geometryInternal.Bound.Minimum == Vector3.Zero)
+            {
+                model.geometryInternal.UpdateBounds();
+            }
             model.OnGeometryChanged(e);
             //Debug.WriteLine("Geometry Changed");
             model.InvalidateRender();


### PR DESCRIPTION
Call update bound automatically if new GeometryModel3D bound has not been updated. Refer to #571