### PR TITLE
Billboard text visual3d metadata

### DIFF
--- a/Source/HelixToolkit.Wpf.Tests/HelixToolkit.Wpf.Tests.csproj
+++ b/Source/HelixToolkit.Wpf.Tests/HelixToolkit.Wpf.Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="StereoHelperTests.cs" />
     <Compile Include="Properties\AssemblyDescription.cs" />
     <Compile Include="Visual3Ds\MeshVisuals\CubeVisual3DTests.cs" />
+    <Compile Include="Visual3Ds\Text\BillboardTextVisual3DTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Source/HelixToolkit.Wpf.Tests/Visual3Ds/Text/BillboardTextVisual3DTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Visual3Ds/Text/BillboardTextVisual3DTests.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CubeVisual3DTests.cs" company="Helix Toolkit">
+// <copyright file="BillboardTextVisual3DTests.cs" company="Helix Toolkit">
 //   Copyright (c) 2014 Helix Toolkit contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/HelixToolkit.Wpf.Tests/Visual3Ds/Text/BillboardTextVisual3DTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Visual3Ds/Text/BillboardTextVisual3DTests.cs
@@ -1,0 +1,25 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CubeVisual3DTests.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace HelixToolkit.Wpf.Tests.Visual3Ds.Text
+{
+    using System.Windows;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class BillboardTextVisual3DTests
+    {
+        [Test]
+        public void MaterialTypeProperty_Metadata_DefaultValues()
+        {
+            PropertyMetadata metadata = BillboardTextVisual3D.MaterialTypeProperty.GetMetadata(typeof(BillboardTextVisual3D));
+
+            Assert.AreEqual((MaterialType)metadata.DefaultValue, MaterialType.Diffuse);
+            Assert.NotNull(metadata.PropertyChangedCallback);
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf/Visual3Ds/Text/BillboardTextVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Text/BillboardTextVisual3D.cs
@@ -114,7 +114,7 @@ namespace HelixToolkit.Wpf
         /// Identifies the <see cref="MaterialType"/> dependency property.
         /// </summary>        
         public static readonly DependencyProperty MaterialTypeProperty =
-            DependencyProperty.Register("MaterialType", typeof(MaterialType), typeof(BillboardTextVisual3D), new PropertyMetadata(MaterialType.Diffuse));
+            DependencyProperty.Register("MaterialType", typeof(MaterialType), typeof(BillboardTextVisual3D), new PropertyMetadata(MaterialType.Diffuse, VisualChanged));
 
 
         /// <summary>


### PR DESCRIPTION
Fix #127 BillboardTextVisual3D with Emissive material still affected by lights.

Include test and fix.