### PR TITLE
Implement the 'ViewportsCommand.SetTarget'-Command in Wpf.SharpDx.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -115,6 +115,11 @@ namespace HelixToolkit.Wpf.SharpDX
         private readonly RotateHandler rotateHandler;
 
         /// <summary>
+        /// The set target handler.
+        /// </summary>
+        private RotateHandler setTargetHandler;
+
+        /// <summary>
         /// The zoom handler
         /// </summary>
         private readonly ZoomHandler zoomHandler;
@@ -253,13 +258,14 @@ namespace HelixToolkit.Wpf.SharpDX
             //this.Children = new Element3DCollection();
 
             this.rotateHandler = new RotateHandler(this);
+            this.setTargetHandler = new RotateHandler(this, true);
             this.panHandler = new PanHandler(this);
             this.zoomHandler = new ZoomHandler(this);
             this.changeFieldOfViewHandler = new ZoomHandler(this, true);
             this.zoomRectangleHandler = new ZoomRectangleHandler(this);
 
             this.CommandBindings.Add(new CommandBinding(ViewportCommands.ZoomExtents, this.ZoomExtentsHandler));
-            this.CommandBindings.Add(new CommandBinding(ViewportCommands.SetTarget, this.SetTargetHandler));
+            this.CommandBindings.Add(new CommandBinding(ViewportCommands.SetTarget, this.setTargetHandler.Execute));
             this.CommandBindings.Add(new CommandBinding(ViewportCommands.Reset, this.ResetHandler));
 
             this.CommandBindings.Add(new CommandBinding(ViewportCommands.Zoom, this.zoomHandler.Execute));
@@ -1512,15 +1518,6 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 this.cameraController.OnKeyDown(sender, e);
             }
-        }
-
-        /// <summary>
-        /// Handles the SetTarget command.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="ExecutedRoutedEventArgs" /> instance containing the event data.</param>
-        private void SetTargetHandler(object sender, ExecutedRoutedEventArgs e)
-        {
         }
 
         /// <summary>


### PR DESCRIPTION
It was not yet possible in SharpDx to change the camera target with the `ViewportCommands.SetTarget`-functionality. The implementation seems to have been forgotten - the function was empty. The functionality exists and is working in HelixToolkit.Wpf.

The bug was already mentioned in [this issue](https://github.com/helix-toolkit/helix-toolkit/issues/310).