### PR TITLE
Fix for #586

### DIFF
--- a/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
@@ -422,6 +422,18 @@ namespace HelixToolkit.Wpf
             AddCorners();
             AddEdges();
             EnableDisableEdgeClicks();
+            
+            var parent = VisualTreeHelper.GetParent(this);
+
+            if (parent != null)
+            {
+                Viewport3DVisual parentViewport = parent as Viewport3DVisual;
+                if (parentViewport != null)
+                {
+                    parentViewport.Children.Remove(this);
+                    parentViewport.Children.Add(this);
+                }
+            }
         }
 
         private Brush GetCubefaceColor(int index)


### PR DESCRIPTION
The change of the modelup direction disables the clickability of the viewcube. Readding it to the viewport fixes this