### PR TITLE
 Improve composition target render trigger

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraController.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/CameraController.cs
@@ -2095,6 +2095,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.PushCameraSetting();
         }
 
+        private TimeSpan _last;
         /// <summary>
         /// The rendering event handler.
         /// </summary>
@@ -2106,8 +2107,10 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         private void OnCompositionTargetRendering(object sender, RenderingEventArgs e)
         {
-            if (skipper.IsSkip())
+            RenderingEventArgs args = (RenderingEventArgs)e;
+            if (args.RenderingTime == _last)
                 return;
+            _last = args.RenderingTime;
             var ticks = e.RenderingTime.Ticks;
             var time = 100e-9 * (ticks - this.lastTick);
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -708,7 +708,7 @@ namespace HelixToolkit.Wpf.SharpDX
             CompositionTarget.Rendering -= OnRendering;
             renderTimer.Stop();
         }
-
+        private TimeSpan _last = TimeSpan.Zero;
         /// <summary>
         /// Handles the <see cref="CompositionTarget.Rendering"/> event.
         /// </summary>
@@ -718,6 +718,10 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             if (!renderTimer.IsRunning || !IsRendering)
                 return;
+            RenderingEventArgs args = (RenderingEventArgs)e;
+            if (args.RenderingTime == _last)
+                return;
+            _last = args.RenderingTime;
             UpdateAndRender();
         }
 
@@ -727,7 +731,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         private void UpdateAndRender()
         {
-            if (((pendingValidationCycles && !skipper.IsSkip()) || skipper.DelayTrigger()) && surfaceD3D != null && renderRenderable != null)
+            if (pendingValidationCycles && surfaceD3D != null && renderRenderable != null)
             {
                 var t0 = renderTimer.Elapsed;
 
@@ -736,25 +740,23 @@ namespace HelixToolkit.Wpf.SharpDX
                 //renderRenderable.Update(t0);
                 try
                 {
+                    // Unfortunately, if DeviceRemoved/DeviceReset occurs while trying to acquire a lock,
+                    // the render thread will throw "COMException: UCEERR_RENDERTHREADFAILURE".
+                    // You can test this by executing the following command as administrator while running a demo: 
+                    //
+                    // "dxcap -forcetdr"
+                    //
+                    // Demos with permanent rendering like "LightingDemo" will fail to recover from 
+                    // DeviceRemoved/DeviceReset while static ones like "SimpleDemo" succeed.
+                    // See: https://blogs.msdn.microsoft.com/dsui_team/2013/11/18/wpf-render-thread-failures/
+                    // See: https://github.com/Microsoft/WPFDXInterop/issues/22
+                    // See: https://docs.microsoft.com/en-us/windows/uwp/gaming/handling-device-lost-scenarios
+                    surfaceD3D.Lock();
                     try
                     {
-                        // Unfortunately, if DeviceRemoved/DeviceReset occurs while trying to acquire a lock,
-                        // the render thread will throw "COMException: UCEERR_RENDERTHREADFAILURE".
-                        // You can test this by executing the following command as administrator while running a demo: 
-                        //
-                        // "dxcap -forcetdr"
-                        //
-                        // Demos with permanent rendering like "LightingDemo" will fail to recover from 
-                        // DeviceRemoved/DeviceReset while static ones like "SimpleDemo" succeed.
-                        // See: https://blogs.msdn.microsoft.com/dsui_team/2013/11/18/wpf-render-thread-failures/
-                        // See: https://github.com/Microsoft/WPFDXInterop/issues/22
-                        // See: https://docs.microsoft.com/en-us/windows/uwp/gaming/handling-device-lost-scenarios
-                        if (surfaceD3D.TryLock(new Duration(TimeSpan.FromMilliseconds(skipper.lag))))
-                        {
-                            pendingValidationCycles = false;
-                            Render(t0);
-                            surfaceD3D.AddDirtyRect(new Int32Rect(0, 0, surfaceD3D.PixelWidth, surfaceD3D.PixelHeight));
-                        }
+                        pendingValidationCycles = false;
+                        Render(t0);
+                        surfaceD3D.AddDirtyRect(new Int32Rect(0, 0, surfaceD3D.PixelWidth, surfaceD3D.PixelHeight));
                     }
                     finally
                     {

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvasThreading.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvasThreading.cs
@@ -802,7 +802,7 @@ namespace HelixToolkit.Wpf.SharpDX
             CompositionTarget.Rendering -= OnRendering;
             renderTimer.Stop();
         }
-
+        private TimeSpan _last = TimeSpan.Zero;
         /// <summary>
         /// Handles the <see cref="CompositionTarget.Rendering"/> event.
         /// </summary>
@@ -813,6 +813,10 @@ namespace HelixToolkit.Wpf.SharpDX
 
             if (!renderTimer.IsRunning || !IsRendering)
                 return;
+            RenderingEventArgs args = (RenderingEventArgs)e;
+            if (args.RenderingTime == _last)
+                return;
+            _last = args.RenderingTime;
             UpdateAndRender();
         }
 
@@ -824,7 +828,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             try
             {
-                if (pendingValidationCycles && !mRenderThread.IsBusy && !skipper.IsSkip())
+                if (pendingValidationCycles && !mRenderThread.IsBusy)
                 {
                     var t0 = renderTimer.Elapsed;
                     if (mRenderThread.IsInitalized && renderRenderable != null)

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
@@ -739,7 +739,7 @@ namespace HelixToolkit.Wpf.SharpDX
             CompositionTarget.Rendering -= OnRendering;
             renderTimer.Stop();
         }
-
+        private TimeSpan _last = TimeSpan.Zero;
         /// <summary>
         /// Handles the <see cref="CompositionTarget.Rendering"/> event.
         /// </summary>
@@ -750,6 +750,10 @@ namespace HelixToolkit.Wpf.SharpDX
 
             if (!renderTimer.IsRunning || !IsRendering)
                 return;
+            RenderingEventArgs args = (RenderingEventArgs)e;
+            if (args.RenderingTime == _last)
+                return;
+            _last = args.RenderingTime;
             UpdateAndRender();
         }
 
@@ -760,7 +764,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         private void UpdateAndRender()
         {
-            if (((pendingValidationCycles && !skipper.IsSkip()) || skipper.DelayTrigger()) && renderRenderable != null)
+            if (pendingValidationCycles && renderRenderable != null)
             {
                 var t0 = renderTimer.Elapsed;
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChainThreading.cs
@@ -861,7 +861,7 @@ namespace HelixToolkit.Wpf.SharpDX
             CompositionTarget.Rendering -= OnRendering;
             renderTimer.Stop();
         }
-
+        private TimeSpan _last = TimeSpan.Zero;
         /// <summary>
         /// Handles the <see cref="CompositionTarget.Rendering"/> event.
         /// </summary>
@@ -872,6 +872,10 @@ namespace HelixToolkit.Wpf.SharpDX
 
             if (!renderTimer.IsRunning || !IsRendering)
                 return;
+            RenderingEventArgs args = (RenderingEventArgs)e;
+            if (args.RenderingTime == _last)
+                return;
+            _last = args.RenderingTime;
             UpdateAndRender();
         }
 
@@ -882,7 +886,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         private void UpdateAndRender()
         {
-            if (((pendingValidationCycles && !skipper.IsSkip()) || skipper.DelayTrigger()) && !renderThread.IsBusy && renderRenderable != null)
+            if (pendingValidationCycles && !renderThread.IsBusy && renderRenderable != null)
             {
                 var t0 = renderTimer.Elapsed;
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -1350,6 +1350,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        private TimeSpan _last;
         /// <summary>
         /// The rendering event handler.
         /// </summary>
@@ -1361,6 +1362,10 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         private void OnCompositionTargetRendering(object sender, RenderingEventArgs e)
         {
+            RenderingEventArgs args = (RenderingEventArgs)e;
+            if (args.RenderingTime == _last)
+                return;
+            _last = args.RenderingTime;
             if (this.ShowFrameRate && this.fpsWatch.ElapsedMilliseconds > 500)
             {
                 this.FrameRate = (int)this.FpsCounter.Value;


### PR DESCRIPTION
Improve composition target render trigger. Check duplicate time stamp to skip the redundant frame.