### PR TITLE
Code optimization

### DIFF
--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomMeshGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomMeshGeometryModel3D.cs
@@ -48,7 +48,7 @@ namespace CustomShaderDemo
             }
         }
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new CustomMeshCore();
         }
@@ -58,7 +58,7 @@ namespace CustomShaderDemo
             return host.EffectsManager[CustomShaderNames.DataSampling];
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as CustomMeshCore).ColorGradients = ColorGradient;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
@@ -184,7 +184,7 @@ namespace HelixToolkit.UWP.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="GeometryRenderCore{MODELSTRUCT}"/> class.
         /// </summary>
-        public GeometryRenderCore() : base(RenderType.Normal) { }
+        public GeometryRenderCore() : base(RenderType.Opaque) { }
         /// <summary>
         /// Initializes a new instance of the <see cref="GeometryRenderCore{MODELSTRUCT}"/> class.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/MaterialGeometryRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/MaterialGeometryRenderCore.cs
@@ -163,7 +163,7 @@ namespace HelixToolkit.UWP.Core
                 MaterialVariables.RenderDisplacementMap = this.RenderDisplacementMap;
                 MaterialVariables.RenderDiffuseAlphaMap = this.RenderDiffuseAlphaMap;
                 MaterialVariables.RenderEnvironmentMap = this.RenderEnvironmentMap;
-                MaterialVariables.OnInvalidateRenderer += (s,e)=> { InvalidateRenderer(); };
+                MaterialVariables.OnInvalidateRenderer += (s,e)=> { InvalidateRenderer(); };                
                 return true;
             }
             else

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
@@ -1,0 +1,254 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+using SharpDX;
+using SharpDX.Direct3D11;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX.Core
+#else
+namespace HelixToolkit.UWP.Core
+#endif
+{
+    using Model;
+    using Render;
+    /// <summary>
+    /// 
+    /// </summary>
+    public abstract class RenderCore : DisposeObject, IGUID, IThrowingShadow
+    {
+        #region Properties
+        /// <summary>
+        /// 
+        /// </summary>
+        public event EventHandler<EventArgs> OnInvalidateRenderer;
+        /// <summary>
+        /// <see cref="IGUID.GUID"/>
+        /// </summary>
+        public Guid GUID { get; } = Guid.NewGuid();
+
+        private RenderType renderType = RenderType.None;
+        /// <summary>
+        /// Gets or sets the type of the render.
+        /// </summary>
+        /// <value>
+        /// The type of the render.
+        /// </value>
+        public RenderType RenderType
+        {
+            set
+            {
+                SetAffectsRender(ref renderType, value);
+            }
+            get { return renderType; }
+        }
+
+        private bool isThrowingShadow = false;
+        /// <summary>
+        /// <see cref="IThrowingShadow.IsThrowingShadow"/>
+        /// </summary>
+        public bool IsThrowingShadow
+        {
+            set
+            {
+                SetAffectsRender(ref isThrowingShadow, value);
+            }
+            get { return isThrowingShadow; }
+        }
+
+
+        /// <summary>
+        /// Model matrix
+        /// </summary>
+        public Matrix ModelMatrix { set; get; } = Matrix.Identity;
+        /// <summary>
+        /// 
+        /// </summary>
+        public IRenderTechnique EffectTechnique { private set; get; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public Device Device { get { return EffectTechnique?.Device; } }
+        /// <summary>
+        /// Is render core has been attached
+        /// </summary>
+        public bool IsAttached { private set; get; } = false;
+
+        /// <summary>
+        /// Gets or sets the post effects.
+        /// </summary>
+        /// <value>
+        /// The post effects.
+        /// </value>
+        private readonly Dictionary<string, IEffectAttributes> postEffectNames = new Dictionary<string, IEffectAttributes>();
+
+        /// <summary>
+        /// Gets the post effect names.
+        /// </summary>
+        /// <value>
+        /// The post effect names.
+        /// </value>
+        public IEnumerable<string> PostEffectNames
+        {
+            get { return postEffectNames.Keys; }
+        }
+        /// <summary>
+        /// Gets a value indicating whether this instance has any post effect.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance has any post effect; otherwise, <c>false</c>.
+        /// </value>
+        public bool HasAnyPostEffect { get { return postEffectNames.Count > 0; } }
+        #endregion
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RenderCoreBase{TModelStruct}"/> class.
+        /// </summary>
+        /// <param name="renderType">Type of the render.</param>
+        public RenderCore(RenderType renderType)
+        {
+            RenderType = renderType;
+        }
+        /// <summary>
+        /// Call to attach the render core.
+        /// </summary>
+        /// <param name="technique"></param>
+        public void Attach(IRenderTechnique technique)
+        {
+            if (IsAttached)
+            {
+                return;
+            }
+            EffectTechnique = technique;
+            IsAttached = OnAttach(technique);
+        }
+
+        /// <summary>
+        /// During attatching render core. Create all local resources. Use Collect(resource) to let object be released automatically during Detach().
+        /// </summary>
+        /// <param name="technique"></param>
+        /// <returns></returns>
+        protected abstract bool OnAttach(IRenderTechnique technique);
+
+        /// <summary>
+        /// Detach render core. Release all resources
+        /// </summary>
+        public void Detach()
+        {
+            IsAttached = false;
+            OnDetach();
+        }
+        /// <summary>
+        /// On detaching, default is to release all resources
+        /// </summary>
+        protected virtual void OnDetach()
+        {
+            DisposeAndClear();
+        }
+        /// <summary>
+        /// Trigger OnRender function delegate if CanRender()==true
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="deviceContext"></param>
+        public abstract void Render(IRenderContext context, DeviceContextProxy deviceContext);
+
+        /// <summary>
+        /// Resets the invalidate handler.
+        /// </summary>
+        public void ResetInvalidateHandler()
+        {
+            OnInvalidateRenderer = null;
+        }
+
+        /// <summary>
+        /// Invalidates the renderer.
+        /// </summary>
+        protected void InvalidateRenderer()
+        {
+            OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
+        }
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="backingField"></param>
+        /// <param name="value"></param>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        protected bool SetAffectsRender<T>(ref T backingField, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (EqualityComparer<T>.Default.Equals(backingField, value))
+            {
+                return false;
+            }
+
+            backingField = value;
+            this.RaisePropertyChanged(propertyName);
+            InvalidateRenderer();
+            return true;
+        }
+
+        #region POST EFFECT        
+
+        /// <summary>
+        /// Adds the post effect.
+        /// </summary>
+        /// <param name="effect">The effect.</param>
+        public void AddPostEffect(IEffectAttributes effect)
+        {
+            if (postEffectNames.ContainsKey(effect.EffectName))
+            {
+                return;
+            }
+            postEffectNames.Add(effect.EffectName, effect);
+            InvalidateRenderer();
+        }
+        /// <summary>
+        /// Removes the post effect.
+        /// </summary>
+        /// <param name="effectName">Name of the effect.</param>
+        public void RemovePostEffect(string effectName)
+        {
+            if (postEffectNames.Remove(effectName))
+            {
+                InvalidateRenderer();
+            }
+        }
+        /// <summary>
+        /// Determines whether [has post effect] [the specified effect name].
+        /// </summary>
+        /// <param name="effectName">Name of the effect.</param>
+        /// <returns>
+        ///   <c>true</c> if [has post effect] [the specified effect name]; otherwise, <c>false</c>.
+        /// </returns>
+        public bool HasPostEffect(string effectName)
+        {
+            return postEffectNames.ContainsKey(effectName);
+        }
+        /// <summary>
+        /// Tries the get post effect.
+        /// </summary>
+        /// <param name="effectName">Name of the effect.</param>
+        /// <param name="effect">The effect.</param>
+        /// <returns></returns>
+        public bool TryGetPostEffect(string effectName, out IEffectAttributes effect)
+        {
+            return postEffectNames.TryGetValue(effectName, out effect);
+        }
+        /// <summary>
+        /// Clears the post effect.
+        /// </summary>
+        public void ClearPostEffect()
+        {
+            postEffectNames.Clear();
+            InvalidateRenderer();
+        }
+        #endregion
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
@@ -32,13 +32,22 @@ namespace HelixToolkit.UWP.Core
         /// <see cref="IGUID.GUID"/>
         /// </summary>
         public Guid GUID { get; } = Guid.NewGuid();
+
+        private RenderType renderType = RenderType.None;
         /// <summary>
         /// Gets or sets the type of the render.
         /// </summary>
         /// <value>
         /// The type of the render.
         /// </value>
-        public RenderType RenderType { set; get; }
+        public RenderType RenderType
+        {
+            set
+            {
+                SetAffectsRender(ref renderType, value);
+            }
+            get { return renderType; }
+        }
 
         private bool isThrowingShadow = false;
         /// <summary>
@@ -48,10 +57,7 @@ namespace HelixToolkit.UWP.Core
         {
             set
             {
-                if (Set(ref isThrowingShadow, value))
-                {
-                    InvalidateRenderer();
-                }
+                SetAffectsRender(ref isThrowingShadow, value);
             }
             get { return isThrowingShadow; }
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
@@ -2,9 +2,7 @@
 The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
-using SharpDX;
 using SharpDX.Direct3D11;
-using System;
 
 #if !NETFX_CORE
 namespace HelixToolkit.Wpf.SharpDX.Core
@@ -12,82 +10,17 @@ namespace HelixToolkit.Wpf.SharpDX.Core
 namespace HelixToolkit.UWP.Core
 #endif
 {
-    using Shaders;
-    using System.Collections.Generic;
-    using System.Runtime.CompilerServices;
-    using Utilities;
     using Render;
-    using Model;
+    using Shaders;
+    using Utilities;
+
+
     /// <summary>
     /// Base class for all render core classes
     /// </summary>
-    public abstract class RenderCoreBase<TModelStruct> : DisposeObject, IRenderCore where TModelStruct : struct
+    public abstract class RenderCoreBase<TModelStruct> : RenderCore where TModelStruct : struct
     {
         #region Properties
-        /// <summary>
-        /// <see cref="IRenderCore.OnInvalidateRenderer"/>
-        /// </summary>
-        public event EventHandler<EventArgs> OnInvalidateRenderer;
-        /// <summary>
-        /// <see cref="IGUID.GUID"/>
-        /// </summary>
-        public Guid GUID { get; } = Guid.NewGuid();
-
-        private RenderType renderType = RenderType.None;
-        /// <summary>
-        /// Gets or sets the type of the render.
-        /// </summary>
-        /// <value>
-        /// The type of the render.
-        /// </value>
-        public RenderType RenderType
-        {
-            set
-            {
-                SetAffectsRender(ref renderType, value);
-            }
-            get { return renderType; }
-        }
-
-        private bool isThrowingShadow = false;
-        /// <summary>
-        /// <see cref="IThrowingShadow.IsThrowingShadow"/>
-        /// </summary>
-        public bool IsThrowingShadow
-        {
-            set
-            {
-                SetAffectsRender(ref isThrowingShadow, value);
-            }
-            get { return isThrowingShadow; }
-        }
-
-
-        /// <summary>
-        /// Model matrix
-        /// </summary>
-        public Matrix ModelMatrix { set; get; } = Matrix.Identity;
-        /// <summary>
-        /// 
-        /// </summary>
-        public IRenderTechnique EffectTechnique { private set; get; }
-        /// <summary>
-        /// 
-        /// </summary>
-        public Device Device { get { return EffectTechnique == null ? null : EffectTechnique.Device; } }
-        /// <summary>
-        /// Is render core has been attached
-        /// </summary>
-        public bool IsAttached { private set; get; } = false;
-
-        /// <summary>
-        /// Gets or sets the post effects.
-        /// </summary>
-        /// <value>
-        /// The post effects.
-        /// </value>
-        private readonly Dictionary<string, IEffectAttributes> postEffectNames = new Dictionary<string, IEffectAttributes>();
-
         /// <summary>
         /// The model structure
         /// </summary>
@@ -98,46 +31,15 @@ namespace HelixToolkit.UWP.Core
         /// <value>
         /// The model cb.
         /// </value>
-        protected IConstantBufferProxy modelCB { private set; get; }
-        /// <summary>
-        /// Gets the post effect names.
-        /// </summary>
-        /// <value>
-        /// The post effect names.
-        /// </value>
-        public IEnumerable<string> PostEffectNames
-        {
-            get { return postEffectNames.Keys; }
-        }
-        /// <summary>
-        /// Gets a value indicating whether this instance has any post effect.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance has any post effect; otherwise, <c>false</c>.
-        /// </value>
-        public bool HasAnyPostEffect { get { return postEffectNames.Count > 0; } }
+        protected IConstantBufferProxy ModelConstBuffer { private set; get; }
         #endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RenderCoreBase{TModelStruct}"/> class.
         /// </summary>
         /// <param name="renderType">Type of the render.</param>
-        public RenderCoreBase(RenderType renderType)
+        public RenderCoreBase(RenderType renderType) : base(renderType)
         {
-            RenderType = renderType;
-        }
-        /// <summary>
-        /// Call to attach the render core.
-        /// </summary>
-        /// <param name="technique"></param>
-        public void Attach(IRenderTechnique technique)
-        {
-            if (IsAttached)
-            {
-                return;
-            }
-            EffectTechnique = technique;
-            IsAttached = OnAttach(technique);
         }
 
         /// <summary>
@@ -145,9 +47,9 @@ namespace HelixToolkit.UWP.Core
         /// </summary>
         /// <param name="technique"></param>
         /// <returns></returns>
-        protected virtual bool OnAttach(IRenderTechnique technique)
+        protected override bool OnAttach(IRenderTechnique technique)
         {
-            modelCB = technique.ConstantBufferPool.Register(GetModelConstantBufferDescription());
+            ModelConstBuffer = technique.ConstantBufferPool.Register(GetModelConstantBufferDescription());
             return true;
         }        
 
@@ -156,27 +58,13 @@ namespace HelixToolkit.UWP.Core
         /// </summary>
         /// <returns></returns>
         protected abstract ConstantBufferDescription GetModelConstantBufferDescription();
-        /// <summary>
-        /// Detach render core. Release all resources
-        /// </summary>
-        public void Detach()
-        {
-            IsAttached = false;
-            OnDetach();
-        }
-        /// <summary>
-        /// On detaching, default is to release all resources
-        /// </summary>
-        protected virtual void OnDetach()
-        {
-            DisposeAndClear();
-        }
+
         /// <summary>
         /// Trigger OnRender function delegate if CanRender()==true
         /// </summary>
         /// <param name="context"></param>
         /// <param name="deviceContext"></param>
-        public void Render(IRenderContext context, DeviceContextProxy deviceContext)
+        public override void Render(IRenderContext context, DeviceContextProxy deviceContext)
         {
             if (CanRender(context))
             {
@@ -227,7 +115,8 @@ namespace HelixToolkit.UWP.Core
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="deviceContext"></param>
-        protected virtual void OnRenderShadow(IRenderContext context, DeviceContextProxy deviceContext) { }
+        protected virtual void OnRenderShadow(IRenderContext context, DeviceContextProxy deviceContext)
+        { }
 
         /// <summary>
         /// Attach vertex buffer routine
@@ -235,15 +124,15 @@ namespace HelixToolkit.UWP.Core
         /// <param name="context"></param>
         /// <param name="vertStartSlot">Start slot for vertex buffer binding</param>
         protected virtual void OnAttachBuffers(DeviceContext context, ref int vertStartSlot)
-        {
-            
+        {            
         }
 
         /// <summary>
         /// Set model default raster state
         /// </summary>
         /// <param name="context"></param>
-        protected virtual void OnBindRasterState(DeviceContextProxy context) { }
+        protected virtual void OnBindRasterState(DeviceContextProxy context)
+        { }
 
         /// <summary>
         /// Actual render function. Used to attach different render states and call the draw call.
@@ -253,7 +142,8 @@ namespace HelixToolkit.UWP.Core
         /// <summary>
         /// Render function for custom shader pass. Used to do special effects
         /// </summary>
-        protected virtual void OnRenderCustom(IRenderContext context, DeviceContextProxy deviceContext, IShaderPass shaderPass) { }
+        protected virtual void OnRenderCustom(IRenderContext context, DeviceContextProxy deviceContext, IShaderPass shaderPass)
+        { }
 
         /// <summary>
         /// Called when [update per model structure].
@@ -268,14 +158,15 @@ namespace HelixToolkit.UWP.Core
         /// <param name="context">The context.</param>
         protected virtual void OnUploadPerModelConstantBuffers(DeviceContext context)
         {
-            modelCB.UploadDataToBuffer(context, ref modelStruct);
+            ModelConstBuffer.UploadDataToBuffer(context, ref modelStruct);
         }
 
         /// <summary>
         /// After calling OnRender. Restore some variables, such as HasInstance etc.
         /// </summary>
         /// <param name="context"></param>
-        protected virtual void PostRender(IRenderContext context) { }
+        protected virtual void PostRender(IRenderContext context)
+        { }
 
         /// <summary>
         /// Check if can render
@@ -285,107 +176,5 @@ namespace HelixToolkit.UWP.Core
         {
             return IsAttached;
         }
-
-        /// <summary>
-        /// Invalidates the renderer.
-        /// </summary>
-        protected void InvalidateRenderer()
-        {
-            OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Resets the invalidate handler.
-        /// </summary>
-        public void ResetInvalidateHandler()
-        {
-            OnInvalidateRenderer = null;
-        }
-
-        protected override void OnDispose(bool disposeManagedResources)
-        {
-            OnInvalidateRenderer = null;
-            base.OnDispose(disposeManagedResources);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="backingField"></param>
-        /// <param name="value"></param>
-        /// <param name="propertyName"></param>
-        /// <returns></returns>
-        protected bool SetAffectsRender<T>(ref T backingField, T value, [CallerMemberName] string propertyName = "")
-        {
-            if (EqualityComparer<T>.Default.Equals(backingField, value))
-            {
-                return false;
-            }
-
-            backingField = value;
-            this.RaisePropertyChanged(propertyName);
-            InvalidateRenderer();
-            return true;
-        }
-
-
-
-        #region POST EFFECT        
-
-        /// <summary>
-        /// Adds the post effect.
-        /// </summary>
-        /// <param name="effect">The effect.</param>
-        public void AddPostEffect(IEffectAttributes effect)
-        {
-            if (postEffectNames.ContainsKey(effect.EffectName))
-            {
-                return;
-            }
-            postEffectNames.Add(effect.EffectName, effect);
-            InvalidateRenderer();
-        }
-        /// <summary>
-        /// Removes the post effect.
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        public void RemovePostEffect(string effectName)
-        {
-            if (postEffectNames.Remove(effectName))
-            {
-                InvalidateRenderer();
-            }
-        }
-        /// <summary>
-        /// Determines whether [has post effect] [the specified effect name].
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        /// <returns>
-        ///   <c>true</c> if [has post effect] [the specified effect name]; otherwise, <c>false</c>.
-        /// </returns>
-        public bool HasPostEffect(string effectName)
-        {
-            return postEffectNames.ContainsKey(effectName);
-        }
-        /// <summary>
-        /// Tries the get post effect.
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        /// <param name="effect">The effect.</param>
-        /// <returns></returns>
-        public bool TryGetPostEffect(string effectName, out IEffectAttributes effect)
-        {
-            return postEffectNames.TryGetValue(effectName, out effect);
-        }
-        /// <summary>
-        /// Clears the post effect.
-        /// </summary>
-        public void ClearPostEffect()
-        {
-            postEffectNames.Clear();
-            InvalidateRenderer();
-        }
-        #endregion
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Lights/LightCoreBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Lights/LightCoreBase.cs
@@ -21,22 +21,8 @@ namespace HelixToolkit.UWP.Core
     /// <summary>
     /// 
     /// </summary>
-    public abstract class LightCoreBase : DisposeObject, ILight3D, IRenderCore
+    public abstract class LightCoreBase : RenderCore, ILight3D
     {
-        /// <summary>
-        /// Gets the unique identifier.
-        /// </summary>
-        /// <value>
-        /// The unique identifier.
-        /// </value>
-        public Guid GUID { get; } = Guid.NewGuid();
-        /// <summary>
-        /// Gets the type of the render.
-        /// </summary>
-        /// <value>
-        /// The type of the render.
-        /// </value>
-        public RenderType RenderType { set; get; } = RenderType.Light;
         /// <summary>
         /// Gets a value indicating whether this instance is empty.
         /// </summary>
@@ -64,63 +50,20 @@ namespace HelixToolkit.UWP.Core
             set { SetAffectsRender(ref color, value); }
             get { return color; }
         }
-        /// <summary>
-        /// Gets or sets the model matrix.
-        /// </summary>
-        /// <value>
-        /// The model matrix.
-        /// </value>
-        public Matrix ModelMatrix { set; get; } = Matrix.Identity;
-        /// <summary>
-        /// Gets the effect technique.
-        /// </summary>
-        /// <value>
-        /// The effect technique.
-        /// </value>
-        /// <exception cref="NotImplementedException"></exception>
-        public IRenderTechnique EffectTechnique { get; }
-        /// <summary>
-        /// Gets the device.
-        /// </summary>
-        /// <value>
-        /// The device.
-        /// </value>
-        /// <exception cref="NotImplementedException"></exception>
-        public Device Device { get; }
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is attached.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is attached; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsAttached { private set; get; } = false;
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is throwing shadow.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is throwing shadow; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsThrowingShadow { get; set; } = false;
 
-        public IEnumerable<string> PostEffectNames { get { return Enumerable.Empty<string>(); } }
-        /// <summary>
-        /// Gets a value indicating whether this instance has post effect.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance has post effect; otherwise, <c>false</c>.
-        /// </value>
-        public bool HasAnyPostEffect { get { return false; } }
+        protected LightCoreBase() : base(RenderType.Light) { }
 
-        /// <summary>
-        /// Occurs when [on invalidate renderer].
-        /// </summary>
-        public event EventHandler<EventArgs> OnInvalidateRenderer;
+        protected override bool OnAttach(IRenderTechnique technique)
+        {
+            return true;
+        }
+
         /// <summary>
         /// Renders the specified context.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="deviceContext">The device context.</param>
-        public void Render(IRenderContext context, DeviceContextProxy deviceContext)
+        public override void Render(IRenderContext context, DeviceContextProxy deviceContext)
         {
             if (CanRender(context.LightScene))
             {
@@ -155,104 +98,7 @@ namespace HelixToolkit.UWP.Core
         {
             lightScene.LightModels.Lights[idx].LightColor = Color;
             lightScene.LightModels.Lights[idx].LightType = (int)LightType;
-        }
-        
-        /// <summary>
-        /// Invalidates the renderer.
-        /// </summary>
-        protected void InvalidateRenderer()
-        {
-            OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
-        }
-        /// <summary>
-        /// Attaches the specified technique.
-        /// </summary>
-        /// <param name="technique">The technique.</param>
-        public void Attach(IRenderTechnique technique)
-        {
-            IsAttached = true;
-        }
-        /// <summary>
-        /// Detaches this instance.
-        /// </summary>
-        public void Detach()
-        {
-            IsAttached = false;
-        }
-        /// <summary>
-        /// Resets the invalidate handler.
-        /// </summary>
-        public void ResetInvalidateHandler()
-        {
-            OnInvalidateRenderer = null;
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="backingField"></param>
-        /// <param name="value"></param>
-        /// <param name="propertyName"></param>
-        /// <returns></returns>
-        protected bool SetAffectsRender<T>(ref T backingField, T value, [CallerMemberName] string propertyName = "")
-        {
-            if (EqualityComparer<T>.Default.Equals(backingField, value))
-            {
-                return false;
-            }
-
-            backingField = value;
-            this.RaisePropertyChanged(propertyName);
-            InvalidateRenderer();
-            return true;
-        }
-
-        #region POST EFFECT        
-
-        /// <summary>
-        /// Adds the post effect.
-        /// </summary>
-        /// <param name="effect">The effect.</param>
-        public void AddPostEffect(IEffectAttributes effect)
-        {
-        }
-        /// <summary>
-        /// Removes the post effect.
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        public void RemovePostEffect(string effectName)
-        {
-        }
-        /// <summary>
-        /// Determines whether [has post effect] [the specified effect name].
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        /// <returns>
-        ///   <c>true</c> if [has post effect] [the specified effect name]; otherwise, <c>false</c>.
-        /// </returns>
-        public bool HasPostEffect(string effectName)
-        {
-            return false;
-        }
-        /// <summary>
-        /// Clears the post effect.
-        /// </summary>
-        public void ClearPostEffect()
-        {
-        }
-        /// <summary>
-        /// Tries the get post effect.
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        /// <param name="effect">The effect.</param>
-        /// <returns></returns>
-        public bool TryGetPostEffect(string effectName, out IEffectAttributes effect)
-        {
-            effect = null;
-            return false;
-        }
-        #endregion
+        }      
     }
     /// <summary>
     /// 

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRay.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRay.cs
@@ -112,7 +112,7 @@ namespace HelixToolkit.UWP.Core
             Color = global::SharpDX.Color.Blue;
         }
 
-        private readonly List<KeyValuePair<IRenderCore, IEffectAttributes>> currentCores = new List<KeyValuePair<IRenderCore, IEffectAttributes>>();
+        private readonly List<KeyValuePair<RenderCore, IEffectAttributes>> currentCores = new List<KeyValuePair<RenderCore, IEffectAttributes>>();
 
         /// <summary>
         /// Gets the model constant buffer description.
@@ -141,7 +141,7 @@ namespace HelixToolkit.UWP.Core
                     var mesh = context.RenderHost.PerFrameGeneralCoresWithPostEffect[i];
                     if (mesh.TryGetPostEffect(EffectName, out effect))
                     {
-                        currentCores.Add(new KeyValuePair<IRenderCore, IEffectAttributes>(mesh, effect));
+                        currentCores.Add(new KeyValuePair<RenderCore, IEffectAttributes>(mesh, effect));
                         context.CustomPassName = DefaultPassNames.EffectMeshXRayP1;
                         var pass = mesh.EffectTechnique[DefaultPassNames.EffectMeshXRayP1];
                         if (pass.IsNULL) { continue; }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenCloneRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenCloneRenderCore.cs
@@ -161,7 +161,7 @@ namespace HelixToolkit.Wpf.SharpDX.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="ScreenCloneRenderCore"/> class.
         /// </summary>
-        public ScreenCloneRenderCore() : base(RenderType.Others) { }
+        public ScreenCloneRenderCore() : base(RenderType.Opaque) { }
         /// <summary>
         /// Gets the model constant buffer description.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenCloneRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenCloneRenderCore.cs
@@ -259,7 +259,7 @@ namespace HelixToolkit.Wpf.SharpDX.Core
                 }
                 if (invalidRender)
                 {
-                    modelCB.UploadDataToBuffer(deviceContext, ref modelStruct);
+                    ModelConstBuffer.UploadDataToBuffer(deviceContext, ref modelStruct);
                     DefaultShaderPass.BindShader(deviceContext);
                     DefaultShaderPass.BindStates(deviceContext,StateType.BlendState | StateType.DepthStencilState | StateType.RasterState);                  
                     deviceContext.DeviceContext.InputAssembler.PrimitiveTopology = global::SharpDX.Direct3D.PrimitiveTopology.TriangleStrip;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ShadowMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ShadowMapCore.cs
@@ -223,28 +223,21 @@ namespace HelixToolkit.UWP.Core
             context.BoundingFrustum = new BoundingFrustum(LightViewProjectMatrix);
 #if !TEST            
             deviceContext.DeviceContext.Rasterizer.SetViewport(0, 0, Width, Height);
-            try
+
+            deviceContext.DeviceContext.OutputMerger.SetTargets(viewResource.DepthStencilView, new RenderTargetView[0]);
+            for (int i = 0; i < context.RenderHost.PerFrameGeneralRenderCores.Count; ++i)
             {
-                deviceContext.DeviceContext.OutputMerger.SetTargets(viewResource.DepthStencilView, new RenderTargetView[0]);
-                for (int i = 0; i < context.RenderHost.PerFrameGeneralRenderCores.Count; ++i)
+                var core = context.RenderHost.PerFrameGeneralRenderCores[i];
+                if (core.IsThrowingShadow && core.RenderType == RenderType.Opaque)
                 {
-                    if (context.RenderHost.PerFrameGeneralRenderCores[i].IsThrowingShadow)
-                    {
-                        context.RenderHost.PerFrameGeneralRenderCores[i].Render(context, deviceContext);
-                    }
+                    core.Render(context, deviceContext);
                 }
             }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
-            finally
-            {
-                context.IsShadowPass = false;
-                context.BoundingFrustum = orgFrustum;
-                context.RenderHost.SetDefaultRenderTargets(false);
-                context.SharedResource.ShadowView = viewResource.TextureView;
-            }
+
+            context.IsShadowPass = false;
+            context.BoundingFrustum = orgFrustum;
+            context.RenderHost.SetDefaultRenderTargets(false);
+            context.SharedResource.ShadowView = viewResource.TextureView;
 #endif
         }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Core2D/Abstract/RenderCore2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core2D/Abstract/RenderCore2D.cs
@@ -1,0 +1,218 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+using SharpDX;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+#if NETFX_CORE
+namespace HelixToolkit.UWP.Core2D
+#else
+namespace HelixToolkit.Wpf.SharpDX.Core2D
+#endif
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public abstract class RenderCore2D : DisposeObject
+    {
+        /// <summary>
+        /// Occurs when [on invalidate renderer].
+        /// </summary>
+        public event EventHandler<EventArgs> OnInvalidateRenderer;
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is empty.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is empty; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsEmpty { get; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is rendering.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is rendering; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsRendering
+        {
+            set; get;
+        } = true;
+
+        private RectangleF rect = new RectangleF();
+        /// <summary>
+        /// Absolute layout rectangle cooridnate for renderable
+        /// </summary>
+        public RectangleF LayoutBound
+        {
+            set
+            {
+                if (SetAffectsRender(ref rect, value))
+                {
+                    OnLayoutBoundChanged(value);
+                }
+            }
+            get
+            {
+                return rect;
+            }
+        }
+
+        private RectangleF clippingBound = new RectangleF();
+        /// <summary>
+        /// Gets or sets the layout clipping bound, includes border.
+        /// </summary>
+        /// <value>
+        /// The layout clipping bound.
+        /// </value>
+        public RectangleF LayoutClippingBound
+        {
+            set
+            {
+                SetAffectsRender(ref clippingBound, value);
+            }
+            get { return clippingBound; }
+        }
+
+        private Matrix3x2 transform = Matrix3x2.Identity;
+        /// <summary>
+        /// Gets or sets the transform. <see cref="RenderCore2D.Transform"/>
+        /// </summary>
+        /// <value>
+        /// The transform.
+        /// </value>
+        public Matrix3x2 Transform
+        {
+            set
+            {
+                SetAffectsRender(ref transform, value);
+            }
+            get
+            {
+                return transform;
+            }
+        }
+
+        private Matrix3x2 localTransform = Matrix3x2.Identity;
+        /// <summary>
+        /// Gets or sets the local transform. This only transform local position. Same as RenderTransform
+        /// </summary>
+        /// <value>
+        /// The local transform.
+        /// </value>
+        public Matrix3x2 LocalTransform
+        {
+            set
+            {
+                SetAffectsRender(ref localTransform, value);
+            }
+            get
+            {
+                return localTransform;
+            }
+        }
+
+        private bool isMouseOver = false;
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is mouse over.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is mouse over; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsMouseOver
+        {
+            set
+            {
+                SetAffectsRender(ref isMouseOver, value);
+            }
+            get
+            {
+                return isMouseOver;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is attached.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is attached; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsAttached { private set; get; } = false;
+        /// <summary>
+        /// Attaches the specified host.
+        /// </summary>
+        /// <param name="host">The host.</param>
+        public void Attach(IRenderHost host)
+        {
+            if (IsAttached)
+            { return; }
+            IsAttached = OnAttach(host);
+        }
+        /// <summary>
+        /// Called when [attach].
+        /// </summary>
+        /// <param name="host">The target.</param>
+        /// <returns></returns>
+        protected virtual bool OnAttach(IRenderHost host)
+        {
+            return true;
+        }
+        /// <summary>
+        /// Detaches this instance.
+        /// </summary>
+        public void Detach()
+        {
+            IsAttached = false;
+            OnDetach();
+            DisposeAndClear();
+        }
+        /// <summary>
+        /// Called when [detach].
+        /// </summary>
+        protected virtual void OnDetach() { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="layoutBound"></param>
+        protected virtual void OnLayoutBoundChanged(RectangleF layoutBound) { }
+
+        /// <summary>
+        /// Renders the specified context.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        public abstract void Render(IRenderContext2D context);
+
+        /// <summary>
+        /// Invalidates the renderer.
+        /// </summary>
+        protected void InvalidateRenderer()
+        {
+            OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="backingField"></param>
+        /// <param name="value"></param>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        protected bool SetAffectsRender<T>(ref T backingField, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (EqualityComparer<T>.Default.Equals(backingField, value))
+            {
+                return false;
+            }
+
+            backingField = value;
+            this.RaisePropertyChanged(propertyName);
+            InvalidateRenderer();
+            return true;
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Core2D/Abstract/RenderCore2DBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core2D/Abstract/RenderCore2DBase.cs
@@ -4,9 +4,6 @@ Copyright (c) 2018 Helix Toolkit contributors
 */
 //#define DEBUGBOUNDS
 using SharpDX;
-using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using D2D = global::SharpDX.Direct2D1;
 
 #if NETFX_CORE
@@ -18,105 +15,8 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
     /// <summary>
     /// 
     /// </summary>
-    public abstract class RenderCore2DBase : DisposeObject, IRenderCore2D
+    public abstract class RenderCore2DBase : RenderCore2D
     {
-        /// <summary>
-        /// Occurs when [on invalidate renderer].
-        /// </summary>
-        public event EventHandler<EventArgs> OnInvalidateRenderer;
-
-        /// <summary>
-        /// Gets a value indicating whether this instance is empty.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is empty; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsEmpty { get; } = false;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is rendering.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is rendering; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsRendering
-        {
-            set; get;
-        } = true;
-
-        private RectangleF rect = new RectangleF();
-        /// <summary>
-        /// Absolute layout rectangle cooridnate for renderable
-        /// </summary>
-        public RectangleF LayoutBound
-        {
-            set
-            {
-                if(SetAffectsRender(ref rect, value))
-                {
-                    OnLayoutBoundChanged(value);
-                }
-            }
-            get
-            {
-                return rect;
-            }
-        }
-
-        private RectangleF clippingBound = new RectangleF();
-        /// <summary>
-        /// Gets or sets the layout clipping bound, includes border.
-        /// </summary>
-        /// <value>
-        /// The layout clipping bound.
-        /// </value>
-        public RectangleF LayoutClippingBound
-        {
-            set
-            {
-                SetAffectsRender(ref clippingBound, value);
-            }
-            get { return clippingBound; }
-        }
-
-        private Matrix3x2 transform = Matrix3x2.Identity;
-        /// <summary>
-        /// Gets or sets the transform. <see cref="IRenderCore2D.Transform"/>
-        /// </summary>
-        /// <value>
-        /// The transform.
-        /// </value>
-        public Matrix3x2 Transform
-        {
-            set
-            {
-                SetAffectsRender(ref transform, value);
-            }
-            get
-            {
-                return transform;
-            }
-        }
-
-        private Matrix3x2 localTransform = Matrix3x2.Identity;
-        /// <summary>
-        /// Gets or sets the local transform. This only transform local position. Same as RenderTransform
-        /// </summary>
-        /// <value>
-        /// The local transform.
-        /// </value>
-        public Matrix3x2 LocalTransform
-        {
-            set
-            {
-                SetAffectsRender(ref localTransform, value);
-            }
-            get
-            {
-                return localTransform;
-            }
-        }
-
 #if DEBUGBOUNDS
         /// <summary>
         /// 
@@ -128,70 +28,11 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
         /// </summary>
         public bool ShowDrawingBorder { set; get; } = false;
 #endif
-
-        private bool isMouseOver = false;
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is mouse over.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is mouse over; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsMouseOver
-        {
-            set
-            {
-                SetAffectsRender(ref isMouseOver, value);
-            }
-            get
-            {
-                return isMouseOver;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is attached.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is attached; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsAttached { private set; get; } = false;
-        /// <summary>
-        /// Attaches the specified host.
-        /// </summary>
-        /// <param name="host">The host.</param>
-        public void Attach(IRenderHost host)
-        {
-            if (IsAttached)
-            { return; }
-            IsAttached = OnAttach(host);
-        }
-        /// <summary>
-        /// Called when [attach].
-        /// </summary>
-        /// <param name="host">The target.</param>
-        /// <returns></returns>
-        protected virtual bool OnAttach(IRenderHost host)
-        {
-            return true;
-        }
-        /// <summary>
-        /// Detaches this instance.
-        /// </summary>
-        public void Detach()
-        {
-            IsAttached = false;
-            OnDetach();
-            DisposeAndClear();
-        }
-        /// <summary>
-        /// Called when [detach].
-        /// </summary>
-        protected virtual void OnDetach() { }
         /// <summary>
         /// Renders the specified context.
         /// </summary>
         /// <param name="context">The context.</param>
-        public void Render(IRenderContext2D context)
+        public override void Render(IRenderContext2D context)
         {
             if (CanRender(context))
             {
@@ -228,39 +69,6 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
         protected virtual bool CanRender(IRenderContext2D context)
         {
             return IsAttached && IsRendering;
-        }
-        /// <summary>
-        /// Invalidates the renderer.
-        /// </summary>
-        protected void InvalidateRenderer()
-        {
-            OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
-        }
-
-        /// <summary>
-        /// Called when [layout bound changed].
-        /// </summary>
-        /// <param name="layoutBound">The layout bound.</param>
-        protected virtual void OnLayoutBoundChanged(RectangleF layoutBound) { }
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="backingField"></param>
-        /// <param name="value"></param>
-        /// <param name="propertyName"></param>
-        /// <returns></returns>
-        protected bool SetAffectsRender<T>(ref T backingField, T value, [CallerMemberName] string propertyName = "")
-        {
-            if (EqualityComparer<T>.Default.Equals(backingField, value))
-            {
-                return false;
-            }
-
-            backingField = value;
-            this.RaisePropertyChanged(propertyName);
-            InvalidateRenderer();
-            return true;
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core2D/TextRenderCore2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core2D/TextRenderCore2D.cs
@@ -19,7 +19,7 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
         {
             set
             {
-                if(Set(ref text, value))
+                if(SetAffectsRender(ref text, value))
                 {
                     textLayoutDirty = true;
                 }

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>HelixToolkit.SharpDX.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Core2D\Abstract\RenderCore2D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core2D\Abstract\RenderCore2DBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core2D\Abstract\ShapeRenderCore2DBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core2D\BorderRenderCore2D.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core2D\RectangleRenderCore2D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Abstract\GeometryRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Abstract\MaterialGeometryRenderCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Abstract\RenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Abstract\RenderCoreBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\BillboardRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\BoneSkinRenderCore.cs" />
@@ -98,7 +99,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRandomVector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderable2D.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderCoreParams.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderHost.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderTechnique.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/Constants.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/Constants.cs
@@ -82,7 +82,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly char[] Separators = { ';', ' ', ',' };
 
         public static readonly List<IRenderable> EmptyRenderable = new List<IRenderable>();
-        public static readonly List<IRenderCore> EmptyCore = new List<IRenderCore>();
+        public static readonly List<RenderCore> EmptyCore = new List<RenderCore>();
         public static readonly IList<IRenderable2D> EmptyRenderable2D = new List<IRenderable2D>();
         public static readonly IList<IRenderCore2D> EmptyCore2D = new List<IRenderCore2D>();
     }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/Constants.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/Constants.cs
@@ -11,6 +11,7 @@ namespace HelixToolkit.Wpf.SharpDX
 #endif
 {
     using Core;
+    using Core2D;
     using System.Collections.Generic;
 
     /// <summary>
@@ -84,6 +85,6 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly List<IRenderable> EmptyRenderable = new List<IRenderable>();
         public static readonly List<RenderCore> EmptyCore = new List<RenderCore>();
         public static readonly IList<IRenderable2D> EmptyRenderable2D = new List<IRenderable2D>();
-        public static readonly IList<IRenderCore2D> EmptyCore2D = new List<IRenderCore2D>();
+        public static readonly IList<RenderCore2D> EmptyCore2D = new List<RenderCore2D>();
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/Enums.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/Enums.cs
@@ -9,16 +9,23 @@ namespace HelixToolkit.UWP
 namespace HelixToolkit.Wpf.SharpDX
 #endif
 {
+    /// <summary>
+    /// Used for render ordering. Order is the same as render type defined.
+    /// </summary>
     public enum RenderType : ushort
     {
-        None, Light, PreProc, Normal, Particle, PostProc, ScreenSpaced, Others
+        None, Light, PreProc, Opaque, Particle, Transparent, PostProc, ScreenSpaced
     }
-
+    /// <summary>
+    /// 
+    /// </summary>
     public enum MSAALevel : ushort
     {
         Disable = 0, Maximum = 1, Two = 2, Four = 4, Eight = 8
     }
-
+    /// <summary>
+    /// 
+    /// </summary>
     public enum LightType : ushort
     {
         Ambient = 0, Directional = 1, Point = 2, Spot = 3, ThreePoint = 4, None = 5
@@ -79,7 +86,9 @@ namespace HelixToolkit.Wpf.SharpDX
         TriangleInfo = 4,
         Camera = 8,
     }
-
+    /// <summary>
+    /// 
+    /// </summary>
     public struct EnumHelper
     {
         public static bool HasFlag(ShaderStage option, ShaderStage flag)

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
@@ -4,7 +4,6 @@ Copyright (c) 2018 Helix Toolkit contributors
 */
 using SharpDX;
 using SharpDX.Direct3D11;
-using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -15,107 +14,6 @@ namespace HelixToolkit.UWP.Core
 #endif
 {
     using Model;
-    using Render;
-    /// <summary>
-    /// 
-    /// </summary>
-    public interface IRenderCore : IGUID, IThrowingShadow
-    {
-        RenderType RenderType { set; get; }
-        /// <summary>
-        /// Occurs when [on invalidate renderer].
-        /// </summary>
-        event EventHandler<EventArgs> OnInvalidateRenderer;
-
-        /// <summary>
-        /// Gets or sets the model matrix.
-        /// </summary>
-        /// <value>
-        /// The model matrix.
-        /// </value>
-        Matrix ModelMatrix { set; get; }
-        /// <summary>
-        /// Gets the effect technique.
-        /// </summary>
-        /// <value>
-        /// The effect technique.
-        /// </value>
-        IRenderTechnique EffectTechnique { get; }
-        /// <summary>
-        /// Gets the device.
-        /// </summary>
-        /// <value>
-        /// The device.
-        /// </value>
-        Device Device { get; }
-        /// <summary>
-        /// If render core is attached or not
-        /// </summary>
-        bool IsAttached { get; }
-        /// <summary>
-        /// Gets the post effect name collections for this model.
-        /// </summary>
-        /// <value>
-        /// The post effect names
-        /// </value>
-        IEnumerable<string> PostEffectNames { get; }
-        /// <summary>
-        /// Gets a value indicating whether this instance has any post effect.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance has any post effect; otherwise, <c>false</c>.
-        /// </value>
-        bool HasAnyPostEffect { get; }
-
-        /// <summary>
-        /// Adds the post effect.
-        /// </summary>
-        /// <param name="effect">The effect.</param>
-        void AddPostEffect(IEffectAttributes effect);
-        /// <summary>
-        /// Removes the post effect.
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        void RemovePostEffect(string effectName);
-        /// <summary>
-        /// Determines whether [has post effect] [the specified effect name].
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        /// <returns>
-        ///   <c>true</c> if [has post effect] [the specified effect name]; otherwise, <c>false</c>.
-        /// </returns>
-        bool HasPostEffect(string effectName);
-        /// <summary>
-        /// Tries the get post effect.
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        /// <param name="effect">The effect.</param>
-        /// <returns></returns>
-        bool TryGetPostEffect(string effectName, out IEffectAttributes effect);
-        /// <summary>
-        /// Clears the post effect.
-        /// </summary>
-        void ClearPostEffect();
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="technique"></param>
-        void Attach(IRenderTechnique technique);
-        /// <summary>
-        /// 
-        /// </summary>
-        void Detach();
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="context"></param>
-        /// <param name="deviceContext"></param>
-        void Render(IRenderContext context, DeviceContextProxy deviceContext);
-        /// <summary>
-        /// Unsubscribe all OnInvalidateRenderer event handler;
-        /// </summary>
-        void ResetInvalidateHandler();
-    }
     /// <summary>
     /// 
     /// </summary>
@@ -150,6 +48,7 @@ namespace HelixToolkit.UWP.Core
         /// </value>
         RasterizerStateDescription RasterDescription { set; get; }
     }
+
     /// <summary>
     /// 
     /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -215,12 +215,12 @@ namespace HelixToolkit.UWP
         /// <value>
         /// The per frame post effects cores.
         /// </value>
-        List<IRenderCore> PerFrameGeneralCoresWithPostEffect { get; }
+        List<RenderCore> PerFrameGeneralCoresWithPostEffect { get; }
         /// <summary>
         /// Gets the per frame render cores for normal rendering routine. <see cref="RenderType.Opaque"/>, <see cref="RenderType.Transparent"/>, <see cref="RenderType.Particle"/>
         /// <para>This does not include <see cref="RenderType.PreProc"/>, <see cref="RenderType.PostProc"/>, <see cref="RenderType.Light"/>, <see cref="RenderType.ScreenSpaced"/></para>
         /// </summary>
-        List<IRenderCore> PerFrameGeneralRenderCores { get; }
+        List<RenderCore> PerFrameGeneralRenderCores { get; }
         /// <summary>
         /// Starts the d3 d.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -217,7 +217,7 @@ namespace HelixToolkit.UWP
         /// </value>
         List<IRenderCore> PerFrameGeneralCoresWithPostEffect { get; }
         /// <summary>
-        /// Gets the per frame render cores for normal rendering routine. <see cref="RenderType.Normal"/>, <see cref="RenderType.Others"/>, <see cref="RenderType.Particle"/>
+        /// Gets the per frame render cores for normal rendering routine. <see cref="RenderType.Opaque"/>, <see cref="RenderType.Transparent"/>, <see cref="RenderType.Particle"/>
         /// <para>This does not include <see cref="RenderType.PreProc"/>, <see cref="RenderType.PostProc"/>, <see cref="RenderType.Light"/>, <see cref="RenderType.ScreenSpaced"/></para>
         /// </summary>
         List<IRenderCore> PerFrameGeneralRenderCores { get; }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderable.cs
@@ -39,7 +39,7 @@ namespace HelixToolkit.UWP
         /// </summary>
         IList<IRenderable> Items { get; }
 
-        IRenderCore RenderCore { get; }
+        RenderCore RenderCore { get; }
         /// <summary>
         /// Update render related parameters such as model matrix by scene graph and bounding boxes
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderable2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderable2D.cs
@@ -3,8 +3,6 @@ The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
 using SharpDX;
-using SharpDX.Direct2D1;
-using System;
 using System.Collections.Generic;
 
 #if NETFX_CORE
@@ -13,73 +11,7 @@ namespace HelixToolkit.UWP
 namespace HelixToolkit.Wpf.SharpDX
 #endif
 {
-    /// <summary>
-    /// 
-    /// </summary>
-    public interface IRenderCore2D
-    {        
-        /// <summary>
-        /// Occurs when [on invalidate renderer].
-        /// </summary>
-        event EventHandler<EventArgs> OnInvalidateRenderer;
-        /// <summary>
-        /// Gets or sets the bound.
-        /// </summary>
-        /// <value>
-        /// The bound.
-        /// </value>
-        RectangleF LayoutBound { set; get; }
-
-        /// <summary>
-        /// Gets or sets the clipping bound.
-        /// </summary>
-        /// <value>
-        /// The clipping bound.
-        /// </value>
-        RectangleF LayoutClippingBound { set; get; }
-        /// <summary>
-        /// 
-        /// </summary>
-        bool IsEmpty { get; }
-
-        /// <summary>
-        /// Transform to render position relative to its parent
-        /// </summary>
-        Matrix3x2 Transform { set; get; }        
-        /// <summary>
-        /// Local render transform
-        /// </summary>
-        Matrix3x2 LocalTransform { set; get; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is rendering.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is rendering; otherwise, <c>false</c>.
-        /// </value>
-        bool IsRendering { set; get; }
-        /// <summary>
-        /// Attaches the specified target.
-        /// </summary>
-        /// <param name="target">The target.</param>
-        void Attach(IRenderHost target);
-        /// <summary>
-        /// Detaches this instance.
-        /// </summary>
-        void Detach();
-        /// <summary>
-        /// Renders the specified context.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        void Render(IRenderContext2D context);
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is mouse over.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is mouse over; otherwise, <c>false</c>.
-        /// </value>
-        bool IsMouseOver { set; get; }
-    }
+    using Core2D;
 
     public interface IRenderable2D : ITransform2D, IGUID
     {
@@ -125,7 +57,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         IList<IRenderable2D> Items { get; }
 
-        IRenderCore2D RenderCore { get; }
+        RenderCore2D RenderCore { get; }
         /// <summary>
         /// Update render related parameters such as model matrix by scene graph and bounding boxes
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderer.cs
@@ -96,7 +96,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context"></param>
         /// <param name="renderables"></param>
         /// <param name="parameter"></param>
-        void RenderPreProc(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter);
+        void RenderPreProc(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter);
 
         /// <summary>
         /// Render post processing, such as bloom effects etc.
@@ -104,7 +104,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context"></param>
         /// <param name="renderables"></param>
         /// <param name="parameter"></param>
-        void RenderPostProc(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter);
+        void RenderPostProc(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter);
 
         /// <summary>
         /// Run actual rendering for render cores.
@@ -112,9 +112,9 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context"></param>
         /// <param name="renderables"></param>
         /// <param name="parameter"></param>
-        void RenderScene(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter);
+        void RenderScene(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter);
         /// <summary>
-        /// Update scene graph not related to rendering. Can be run parallel with the <see cref="RenderScene(IRenderContext, List{IRenderCore}, ref RenderParameter)"/>
+        /// Update scene graph not related to rendering. Can be run parallel with the <see cref="RenderScene(IRenderContext, List{RenderCore}, ref RenderParameter)"/>
         /// <para>Warning: Dependency properties are thread affinity. Do not get/set any dependency property in this function.</para>
         /// </summary>
         /// <param name="renderables"></param>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Element2D/Element2DCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Element2D/Element2DCore.cs
@@ -45,7 +45,7 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
             set
             {
                 if (Set(ref visibilityInternal, value))
-                { InvalidateRender(); }
+                { InvalidateVisual(); }
             }
             get { return visibilityInternal; }
         }
@@ -427,10 +427,14 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
                 return false;
             }
         }
-
+        /// <summary>
+        /// Use InvalidateVisual if render update required.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         private void RenderCore_OnInvalidateRenderer(object sender, EventArgs e)
         {
-            InvalidateRender();
+            InvalidateVisual();
         }
         /// <summary>
         /// Invalidates the render.

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Element2D/Element2DCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Element2D/Element2DCore.cs
@@ -66,14 +66,14 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
         /// </value>
         public bool IsRenderable { private set; get; } = true;
 
-        private IRenderCore2D renderCore;
+        private RenderCore2D renderCore;
         /// <summary>
         /// Gets or sets the render core.
         /// </summary>
         /// <value>
         /// The render core.
         /// </value>
-        public IRenderCore2D RenderCore
+        public RenderCore2D RenderCore
         {
             private set
             {
@@ -220,7 +220,7 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
         /// Creates the render core.
         /// </summary>
         /// <returns></returns>
-        protected virtual IRenderCore2D CreateRenderCore() { return new EmptyRenderCore2D(); }
+        protected virtual RenderCore2D CreateRenderCore() { return new EmptyRenderCore2D(); }
         /// <summary>
         /// <para>Attaches the element to the specified host. To overide Attach, please override <see cref="OnAttach(IRenderHost)"/> function.</para>
         /// <para>Attach Flow: Set RenderHost -> Get Effect ->

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Element2D/Element2DCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Element2D/Element2DCore.cs
@@ -435,7 +435,7 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
         /// <summary>
         /// Invalidates the render.
         /// </summary>
-        protected void InvalidateRender()
+        public void InvalidateRender()
         {
             RenderHost?.InvalidateRender();
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Element3D/Element3DCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Element3D/Element3DCore.cs
@@ -189,14 +189,14 @@ namespace HelixToolkit.Wpf.SharpDX.Core
         public event EventHandler<TransformArgs> OnTransformChanged;
         #endregion
         #region RenderCore
-        private IRenderCore renderCore = null;
+        private RenderCore renderCore = null;
         /// <summary>
         /// Gets or sets the render core.
         /// </summary>
         /// <value>
         /// The render core.
         /// </value>
-        public IRenderCore RenderCore
+        public RenderCore RenderCore
         {
             private set
             {
@@ -257,12 +257,12 @@ namespace HelixToolkit.Wpf.SharpDX.Core
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected virtual IRenderCore OnCreateRenderCore() { return new EmptyRenderCore(); }
+        protected virtual RenderCore OnCreateRenderCore() { return new EmptyRenderCore(); }
         /// <summary>
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected virtual void AssignDefaultValuesToCore(IRenderCore core) { }
+        protected virtual void AssignDefaultValuesToCore(RenderCore core) { }
 
         private void RenderCore_OnInvalidateRenderer(object sender, EventArgs e)
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/PhongMaterialVariables.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/PhongMaterialVariables.cs
@@ -25,7 +25,6 @@ namespace HelixToolkit.UWP.Model
         /// <see cref="IEffectMaterialVariables.OnInvalidateRenderer"/> 
         /// </summary>
         public event EventHandler<EventArgs> OnInvalidateRenderer;
-
         /// <summary>
         ///
         /// </summary>
@@ -273,41 +272,41 @@ namespace HelixToolkit.UWP.Model
             {
                 return;
             }
-            if (e.PropertyName.Equals(nameof(IPhongMaterial.DiffuseMap)))
+            if (e.PropertyName.Equals(nameof(PhongMaterialCore.DiffuseMap)))
             {
-                CreateTextureView((sender as IPhongMaterial).DiffuseMap, TextureResources[DiffuseIdx]);
+                CreateTextureView((sender as PhongMaterialCore).DiffuseMap, TextureResources[DiffuseIdx]);
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.NormalMap)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.NormalMap)))
             {
-                CreateTextureView((sender as IPhongMaterial).NormalMap, TextureResources[NormalIdx]);
+                CreateTextureView((sender as PhongMaterialCore).NormalMap, TextureResources[NormalIdx]);
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DisplacementMap)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DisplacementMap)))
             {
-                CreateTextureView((sender as IPhongMaterial).DisplacementMap, TextureResources[DisplaceIdx]);
+                CreateTextureView((sender as PhongMaterialCore).DisplacementMap, TextureResources[DisplaceIdx]);
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DiffuseAlphaMap)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DiffuseAlphaMap)))
             {
-                CreateTextureView((sender as IPhongMaterial).DiffuseAlphaMap, TextureResources[AlphaIdx]);
+                CreateTextureView((sender as PhongMaterialCore).DiffuseAlphaMap, TextureResources[AlphaIdx]);
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DiffuseMapSampler)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DiffuseMapSampler)))
             {
                 RemoveAndDispose(ref SamplerResources[DiffuseIdx]);
-                SamplerResources[DiffuseIdx] = Collect(statePoolManager.Register((sender as IPhongMaterial).DiffuseMapSampler));
+                SamplerResources[DiffuseIdx] = Collect(statePoolManager.Register((sender as PhongMaterialCore).DiffuseMapSampler));
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DiffuseAlphaMapSampler)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DiffuseAlphaMapSampler)))
             {
                 RemoveAndDispose(ref SamplerResources[AlphaIdx]);
-                SamplerResources[AlphaIdx] = Collect(statePoolManager.Register((sender as IPhongMaterial).DiffuseAlphaMapSampler));
+                SamplerResources[AlphaIdx] = Collect(statePoolManager.Register((sender as PhongMaterialCore).DiffuseAlphaMapSampler));
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DisplacementMapSampler)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DisplacementMapSampler)))
             {
                 RemoveAndDispose(ref SamplerResources[DisplaceIdx]);
-                SamplerResources[DisplaceIdx] = Collect(statePoolManager.Register((sender as IPhongMaterial).DisplacementMapSampler));
+                SamplerResources[DisplaceIdx] = Collect(statePoolManager.Register((sender as PhongMaterialCore).DisplacementMapSampler));
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.NormalMapSampler)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.NormalMapSampler)))
             {
                 RemoveAndDispose(ref SamplerResources[NormalIdx]);
-                SamplerResources[NormalIdx] = Collect(statePoolManager.Register((sender as IPhongMaterial).NormalMapSampler));
+                SamplerResources[NormalIdx] = Collect(statePoolManager.Register((sender as PhongMaterialCore).NormalMapSampler));
             }
             OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/TextureSharedPhongMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/TextureSharedPhongMaterialVariable.cs
@@ -269,41 +269,41 @@ namespace HelixToolkit.UWP.Model
             {
                 return;
             }
-            if (e.PropertyName.Equals(nameof(IPhongMaterial.DiffuseMap)))
+            if (e.PropertyName.Equals(nameof(PhongMaterialCore.DiffuseMap)))
             {
-                CreateTextureView((sender as IPhongMaterial).DiffuseMap, DiffuseIdx);
+                CreateTextureView((sender as PhongMaterialCore).DiffuseMap, DiffuseIdx);
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.NormalMap)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.NormalMap)))
             {
-                CreateTextureView((sender as IPhongMaterial).NormalMap, NormalIdx);
+                CreateTextureView((sender as PhongMaterialCore).NormalMap, NormalIdx);
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DisplacementMap)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DisplacementMap)))
             {
-                CreateTextureView((sender as IPhongMaterial).DisplacementMap, DisplaceIdx);
+                CreateTextureView((sender as PhongMaterialCore).DisplacementMap, DisplaceIdx);
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DiffuseAlphaMap)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DiffuseAlphaMap)))
             {
-                CreateTextureView((sender as IPhongMaterial).DiffuseAlphaMap, AlphaIdx);
+                CreateTextureView((sender as PhongMaterialCore).DiffuseAlphaMap, AlphaIdx);
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DiffuseMapSampler)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DiffuseMapSampler)))
             {
                 RemoveAndDispose(ref SamplerResources[DiffuseIdx]);
-                SamplerResources[DiffuseIdx] = Collect(statePoolManager.Register((sender as IPhongMaterial).DiffuseMapSampler));
+                SamplerResources[DiffuseIdx] = Collect(statePoolManager.Register((sender as PhongMaterialCore).DiffuseMapSampler));
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DiffuseAlphaMapSampler)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DiffuseAlphaMapSampler)))
             {
                 RemoveAndDispose(ref SamplerResources[AlphaIdx]);
-                SamplerResources[AlphaIdx] = Collect(statePoolManager.Register((sender as IPhongMaterial).DiffuseAlphaMapSampler));
+                SamplerResources[AlphaIdx] = Collect(statePoolManager.Register((sender as PhongMaterialCore).DiffuseAlphaMapSampler));
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.DisplacementMapSampler)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.DisplacementMapSampler)))
             {
                 RemoveAndDispose(ref SamplerResources[DisplaceIdx]);
-                SamplerResources[DisplaceIdx] = Collect(statePoolManager.Register((sender as IPhongMaterial).DisplacementMapSampler));
+                SamplerResources[DisplaceIdx] = Collect(statePoolManager.Register((sender as PhongMaterialCore).DisplacementMapSampler));
             }
-            else if (e.PropertyName.Equals(nameof(IPhongMaterial.NormalMapSampler)))
+            else if (e.PropertyName.Equals(nameof(PhongMaterialCore.NormalMapSampler)))
             {
                 RemoveAndDispose(ref SamplerResources[NormalIdx]);
-                SamplerResources[NormalIdx] = Collect(statePoolManager.Register((sender as IPhongMaterial).NormalMapSampler));
+                SamplerResources[NormalIdx] = Collect(statePoolManager.Register((sender as PhongMaterialCore).NormalMapSampler));
             }
             OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderBuffers/DX11Texture2DRenderBufferProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderBuffers/DX11Texture2DRenderBufferProxy.cs
@@ -147,10 +147,10 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <returns></returns>
         public override bool EndDraw()
         {
+            Device.ImmediateContext.Flush();
 #if MSAA
             Device.ImmediateContext.ResolveSubresource(ColorBuffer, 0, renderTargetNMS, 0, Format.B8G8R8A8_UNorm);
-#endif
-
+#endif            
             return true;
         }
         /// <summary>
@@ -158,8 +158,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// </summary>
         /// <returns></returns>
         public override bool Present()
-        {
-            Device.ImmediateContext.Flush();
+        {          
             return true;
         }
     }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -78,7 +78,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             get { return lightRenderables.Select(x=>x as ILight3D); }
         }
         /// <summary>
-        /// Gets the per frame render cores for normal rendering routine. <see cref="RenderType.Normal"/>, <see cref="RenderType.Others"/>, <see cref="RenderType.Particle"/>
+        /// Gets the per frame render cores for normal rendering routine. <see cref="RenderType.Opaque"/>, <see cref="RenderType.Transparent"/>, <see cref="RenderType.Particle"/>
         /// <para>This does not include <see cref="RenderType.PreProc"/>, <see cref="RenderType.PostProc"/>, <see cref="RenderType.Light"/>, <see cref="RenderType.ScreenSpaced"/></para>
         /// </summary>
         public override List<IRenderCore> PerFrameGeneralRenderCores { get { return generalRenderCores; } }
@@ -120,18 +120,11 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             return new DX11Texture2DRenderBufferProxy(EffectsManager);
         }
 
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SeparateRenderables()
         {
-            viewportRenderables.Clear();
-            perFrameRenderables.Clear();
-            generalRenderCores.Clear();
-            lightRenderables.Clear();
-            postProcRenderCores.Clear();
-            preProcRenderCores.Clear();
-            screenSpacedRenderCores.Clear();
-            renderCoresForPostRender.Clear();
-
+            Clear();
             viewportRenderables.AddRange(Viewport.Renderables);
             renderer.UpdateSceneGraph(RenderContext, viewportRenderables, perFrameRenderables);
 
@@ -143,8 +136,8 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                     case RenderType.Light:
                         lightRenderables.Add(renderable);
                         break;
-                    case RenderType.Normal:
-                    case RenderType.Others:
+                    case RenderType.Opaque:
+                    case RenderType.Transparent:
                     case RenderType.Particle:
                         generalRenderCores.Add(renderable.RenderCore);
                         break;
@@ -241,7 +234,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             getPostEffectCoreTask?.Wait();
             getPostEffectCoreTask = null;
             renderer.RenderPostProc(RenderContext, postProcRenderCores, ref renderParameter);
-            renderer.RenderScene(RenderContext, screenSpacedRenderCores, ref renderParameter);
+            renderer.RenderPostProc(RenderContext, screenSpacedRenderCores, ref renderParameter);
         }
 
         /// <summary>
@@ -298,15 +291,29 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             RenderContext2D.PopRenderTarget();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Clear()
+        {
+            viewportRenderables.Clear();
+            perFrameRenderables.Clear();
+            generalRenderCores.Clear();
+            lightRenderables.Clear();
+            postProcRenderCores.Clear();
+            preProcRenderCores.Clear();
+            screenSpacedRenderCores.Clear();
+            renderCoresForPostRender.Clear();
+        }
+
         /// <summary>
         /// Called when [ending d3 d].
         /// </summary>
         protected override void OnEndingD3D()
         {
-            Logger.Log(LogLevel.Information, "", nameof(DefaultRenderHost));
+            Logger.Log(LogLevel.Information, "", nameof(DefaultRenderHost));            
             asyncTask?.Wait();
             getTriangleCountTask?.Wait();
             getPostEffectCoreTask?.Wait();
+            Clear();
             base.OnEndingD3D();
         }
     }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -37,23 +37,23 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <summary>
         /// The pending render cores
         /// </summary>
-        protected readonly List<IRenderCore> generalRenderCores = new List<IRenderCore>();
+        protected readonly List<RenderCore> generalRenderCores = new List<RenderCore>();
         /// <summary>
         /// The pending render cores
         /// </summary>
-        protected readonly List<IRenderCore> preProcRenderCores = new List<IRenderCore>();
+        protected readonly List<RenderCore> preProcRenderCores = new List<RenderCore>();
         /// <summary>
         /// The pending render cores
         /// </summary>
-        protected readonly List<IRenderCore> postProcRenderCores = new List<IRenderCore>();
+        protected readonly List<RenderCore> postProcRenderCores = new List<RenderCore>();
         /// <summary>
         /// The render cores for post render
         /// </summary>
-        protected readonly List<IRenderCore> renderCoresForPostRender = new List<IRenderCore>();
+        protected readonly List<RenderCore> renderCoresForPostRender = new List<RenderCore>();
         /// <summary>
         /// The pending render cores
         /// </summary>
-        protected readonly List<IRenderCore> screenSpacedRenderCores = new List<IRenderCore>();
+        protected readonly List<RenderCore> screenSpacedRenderCores = new List<RenderCore>();
 
         /// <summary>
         /// The viewport renderable2D
@@ -81,14 +81,14 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// Gets the per frame render cores for normal rendering routine. <see cref="RenderType.Opaque"/>, <see cref="RenderType.Transparent"/>, <see cref="RenderType.Particle"/>
         /// <para>This does not include <see cref="RenderType.PreProc"/>, <see cref="RenderType.PostProc"/>, <see cref="RenderType.Light"/>, <see cref="RenderType.ScreenSpaced"/></para>
         /// </summary>
-        public override List<IRenderCore> PerFrameGeneralRenderCores { get { return generalRenderCores; } }
+        public override List<RenderCore> PerFrameGeneralRenderCores { get { return generalRenderCores; } }
         /// <summary>
         /// Gets the per frame post effects cores. It is the subset of <see cref="PerFrameGeneralRenderCores"/>
         /// </summary>
         /// <value>
         /// The per frame post effects cores.
         /// </value>
-        public override List<IRenderCore> PerFrameGeneralCoresWithPostEffect
+        public override List<RenderCore> PerFrameGeneralCoresWithPostEffect
         {
             get { return renderCoresForPostRender; }
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -519,7 +519,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                 var t0 = TimeSpan.FromSeconds((double)Stopwatch.GetTimestamp()/Stopwatch.Frequency);
                 RenderStatistics.FPSStatistics.Push((t0 - lastRenderTime).TotalMilliseconds);
                 lastRenderTime = t0;
-                //UpdateRequested = false;
+                UpdateRequested = false;
                 if (RenderConfiguration.UpdatePerFrameData)
                 {
                     viewport.Update(t0);

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -519,7 +519,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                 var t0 = TimeSpan.FromSeconds((double)Stopwatch.GetTimestamp()/Stopwatch.Frequency);
                 RenderStatistics.FPSStatistics.Push((t0 - lastRenderTime).TotalMilliseconds);
                 lastRenderTime = t0;
-                UpdateRequested = false;
+                //UpdateRequested = false;
                 if (RenderConfiguration.UpdatePerFrameData)
                 {
                     viewport.Update(t0);

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -409,14 +409,14 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <value>
         /// The post effects render cores.
         /// </value>
-        public abstract List<IRenderCore> PerFrameGeneralCoresWithPostEffect { get; }
+        public abstract List<RenderCore> PerFrameGeneralCoresWithPostEffect { get; }
         /// <summary>
         /// Gets the per frame render cores.
         /// </summary>
         /// <value>
         /// The per frame render cores.
         /// </value>
-        public abstract List<IRenderCore> PerFrameGeneralRenderCores { get; }
+        public abstract List<RenderCore> PerFrameGeneralRenderCores { get; }
 
         #region Configuration
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
@@ -13,6 +13,9 @@ namespace HelixToolkit.Wpf.SharpDX.Render
 #endif
 {
     using Core;
+    using System;
+    using System.Threading.Tasks;
+
     /// <summary>
     /// 
     /// </summary>
@@ -21,6 +24,8 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         private IDeviceContextPool deferredContextPool;
         private readonly IRenderTaskScheduler scheduler;
         private readonly List<KeyValuePair<int, CommandList>> commandList = new List<KeyValuePair<int, CommandList>>();
+        private readonly CommandList[] postCommandList = new CommandList[2];
+        private Task renderOthersTask;
         /// <summary>
         /// Initializes a new instance of the <see cref="DeferredContextRenderer"/> class.
         /// </summary>
@@ -39,15 +44,30 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="renderables">The renderables.</param>
         /// <param name="parameter">The parameter.</param>
         public override void RenderScene(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
-        {
-            if(scheduler.ScheduleAndRun(renderables, deferredContextPool, context, parameter, commandList))
+        {          
+            if (scheduler.ScheduleAndRun(renderables, deferredContextPool, context, parameter, RenderType.Opaque, commandList))
             {
+                RenderParameter param = parameter;
+                renderOthersTask = Task.Run(()=>
+                {
+                    RenderOthers(renderables, RenderType.Particle, context, deferredContextPool, ref param, postCommandList, 0);
+                    RenderOthers(renderables, RenderType.Transparent, context, deferredContextPool, ref param, postCommandList, 1);
+                });
+
                 foreach(var command in commandList.OrderBy(x=>x.Key))
                 {
                     ImmediateContext.DeviceContext.ExecuteCommandList(command.Value, false);
                     command.Value.Dispose();
                 }
+
                 commandList.Clear();
+                renderOthersTask.Wait();
+                renderOthersTask = null;
+                for (int i = 0; i < postCommandList.Length; ++ i)
+                {
+                    ImmediateContext.DeviceContext.ExecuteCommandList(postCommandList[i], false);
+                    postCommandList[i].Dispose();
+                }
             }
             else
             {
@@ -55,14 +75,39 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             }
         }
 
-        public override void RenderPreProc(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
+
+
+        private void RenderOthers(List<IRenderCore> list, RenderType filter, IRenderContext context, IDeviceContextPool deviceContextPool,
+            ref RenderParameter parameter,
+            CommandList[] commandsArray,int idx)
         {
-            base.RenderScene(context, renderables, ref parameter);
+            var deviceContext = deviceContextPool.Get();
+            SetRenderTargets(deviceContext, ref parameter);
+            for(int i = 0; i < list.Count; ++i)
+            {
+                if(list[i].RenderType == filter)
+                {
+                    list[i].Render(context, deviceContext);
+                }
+            }
+            commandsArray[idx] = deviceContext.DeviceContext.FinishCommandList(false);
+            deviceContextPool.Put(deviceContext);
         }
 
-        public override void RenderPostProc(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
+
+        private void SetRenderTargets(DeviceContext context, ref RenderParameter parameter)
         {
-            base.RenderScene(context, renderables, ref parameter);
+            context.OutputMerger.SetTargets(parameter.DepthStencilView, parameter.RenderTargetView);
+            context.Rasterizer.SetViewport(parameter.ViewportRegion);
+            context.Rasterizer.SetScissorRectangle(parameter.ScissorRegion.Left, parameter.ScissorRegion.Top,
+                parameter.ScissorRegion.Right, parameter.ScissorRegion.Bottom);
+        }
+
+        protected override void OnDispose(bool disposeManagedResources)
+        {
+            commandList.Clear();
+            renderOthersTask?.Wait();
+            base.OnDispose(disposeManagedResources);
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
@@ -43,7 +43,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context">The context.</param>
         /// <param name="renderables">The renderables.</param>
         /// <param name="parameter">The parameter.</param>
-        public override void RenderScene(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
+        public override void RenderScene(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter)
         {          
             if (scheduler.ScheduleAndRun(renderables, deferredContextPool, context, parameter, RenderType.Opaque, commandList))
             {
@@ -77,7 +77,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
 
 
 
-        private void RenderOthers(List<IRenderCore> list, RenderType filter, IRenderContext context, IDeviceContextPool deviceContextPool,
+        private void RenderOthers(List<RenderCore> list, RenderType filter, IRenderContext context, IDeviceContextPool deviceContextPool,
             ref RenderParameter parameter,
             CommandList[] commandsArray,int idx)
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -23,7 +23,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
     {
         private readonly Stack<KeyValuePair<int, IList<IRenderable>>> stackCache1 = new Stack<KeyValuePair<int, IList<IRenderable>>>(20);
         private readonly Stack<KeyValuePair<int, IList<IRenderable2D>>> stack2DCache1 = new Stack<KeyValuePair<int, IList<IRenderable2D>>>(20);
-        protected readonly List<IRenderCore> filters = new List<IRenderCore>();
+        protected readonly List<RenderCore> filters = new List<RenderCore>();
         /// <summary>
         /// Gets or sets the immediate context.
         /// </summary>
@@ -101,7 +101,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context">The context.</param>
         /// <param name="renderables">The renderables.</param>
         /// <param name="parameter">The parameter.</param>
-        public virtual void RenderScene(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
+        public virtual void RenderScene(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter)
         {
             int count = renderables.Count;
             filters.Clear();
@@ -178,7 +178,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context">The context.</param>
         /// <param name="renderables">The renderables.</param>
         /// <param name="parameter">The parameter.</param>
-        public virtual void RenderPreProc(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
+        public virtual void RenderPreProc(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter)
         {
             int count = renderables.Count;
             for (int i = 0; i < count; ++i)
@@ -193,7 +193,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context">The context.</param>
         /// <param name="renderables">The renderables.</param>
         /// <param name="parameter">The parameter.</param>
-        public virtual void RenderPostProc(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
+        public virtual void RenderPostProc(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter)
         {
             int count = renderables.Count;
             for (int i = 0; i < count; ++i)

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -23,6 +23,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
     {
         private readonly Stack<KeyValuePair<int, IList<IRenderable>>> stackCache1 = new Stack<KeyValuePair<int, IList<IRenderable>>>(20);
         private readonly Stack<KeyValuePair<int, IList<IRenderable2D>>> stack2DCache1 = new Stack<KeyValuePair<int, IList<IRenderable2D>>>(20);
+        protected readonly List<IRenderCore> filters = new List<IRenderCore>();
         /// <summary>
         /// Gets or sets the immediate context.
         /// </summary>
@@ -103,9 +104,32 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         public virtual void RenderScene(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
         {
             int count = renderables.Count;
+            filters.Clear();
             for (int i = 0; i < count; ++i)
             {
-                renderables[i].Render(context, ImmediateContext);
+                if (renderables[i].RenderType == RenderType.Opaque)
+                {
+                    renderables[i].Render(context, ImmediateContext);
+                }
+                else
+                {
+                    filters.Add(renderables[i]);
+                }
+            }
+            count = filters.Count;
+            for (int i = 0; i < count; ++i)
+            {
+                if (filters[i].RenderType == RenderType.Particle)
+                {
+                    filters[i].Render(context, ImmediateContext);
+                }
+            }
+            for (int i = 0; i < count; ++i)
+            {
+                if (filters[i].RenderType == RenderType.Transparent)
+                {
+                    filters[i].Render(context, ImmediateContext);
+                }
             }
         }
         /// <summary>
@@ -156,7 +180,11 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="parameter">The parameter.</param>
         public virtual void RenderPreProc(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
         {
-            RenderScene(context, renderables, ref parameter);
+            int count = renderables.Count;
+            for (int i = 0; i < count; ++i)
+            {
+                renderables[i].Render(context, ImmediateContext);
+            }
         }
 
         /// <summary>
@@ -167,7 +195,19 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="parameter">The parameter.</param>
         public virtual void RenderPostProc(IRenderContext context, List<IRenderCore> renderables, ref RenderParameter parameter)
         {
-            RenderScene(context, renderables, ref parameter);
+            int count = renderables.Count;
+            for (int i = 0; i < count; ++i)
+            {
+                renderables[i].Render(context, ImmediateContext);
+            }
+        }
+
+        protected override void OnDispose(bool disposeManagedResources)
+        {
+            filters.Clear();
+            stackCache1.Clear();
+            stack2DCache1.Clear();
+            base.OnDispose(disposeManagedResources);
         }
     }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/RenderTaskScheduler.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/RenderTaskScheduler.cs
@@ -33,7 +33,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="outputCommands">The output commands.</param>
         /// <param name="filterType"></param>
         /// <returns></returns>
-        bool ScheduleAndRun(List<IRenderCore> items, IDeviceContextPool pool,
+        bool ScheduleAndRun(List<RenderCore> items, IDeviceContextPool pool,
             IRenderContext context, RenderParameter parameter, RenderType filterType, List<KeyValuePair<int, CommandList>> outputCommands);
     }
     /// <summary>
@@ -109,7 +109,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="filterType"></param>
         /// <param name="outputCommands"></param>
         /// <returns></returns>
-        public bool ScheduleAndRun(List<IRenderCore> items, IDeviceContextPool pool,
+        public bool ScheduleAndRun(List<RenderCore> items, IDeviceContextPool pool,
             IRenderContext context, RenderParameter parameter, RenderType filterType, List<KeyValuePair<int, CommandList>> outputCommands)
         {
             outputCommands.Clear();

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/RenderTaskScheduler.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/RenderTaskScheduler.cs
@@ -31,9 +31,10 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context">The context.</param>
         /// <param name="parameter">The parameter.</param>
         /// <param name="outputCommands">The output commands.</param>
+        /// <param name="filterType"></param>
         /// <returns></returns>
         bool ScheduleAndRun(List<IRenderCore> items, IDeviceContextPool pool,
-            IRenderContext context, RenderParameter parameter, List<KeyValuePair<int, CommandList>> outputCommands);
+            IRenderContext context, RenderParameter parameter, RenderType filterType, List<KeyValuePair<int, CommandList>> outputCommands);
     }
     /// <summary>
     /// 
@@ -56,7 +57,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <value>
         /// The minimum item per task.
         /// </value>
-        public int MinimumDrawCalls { set; get; } = 1000;
+        public int MinimumDrawCalls { set; get; } = 600;
 
         /// <summary>
         /// Gets or sets the maximum number of tasks.
@@ -99,16 +100,17 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         }
 
         /// <summary>
-        /// <see cref="IRenderTaskScheduler.ScheduleAndRun(List{IRenderCore}, IDeviceContextPool, IRenderContext, RenderParameter, List{KeyValuePair{int, CommandList}})"/>
+        /// 
         /// </summary>
-        /// <param name="items">The items.</param>
-        /// <param name="pool">The pool.</param>
-        /// <param name="context">The context.</param>
-        /// <param name="parameter">The parameter.</param>
-        /// <param name="outputCommands">The output commands.</param>
+        /// <param name="items"></param>
+        /// <param name="pool"></param>
+        /// <param name="context"></param>
+        /// <param name="parameter"></param>
+        /// <param name="filterType"></param>
+        /// <param name="outputCommands"></param>
         /// <returns></returns>
         public bool ScheduleAndRun(List<IRenderCore> items, IDeviceContextPool pool,
-            IRenderContext context, RenderParameter parameter, List<KeyValuePair<int, CommandList>> outputCommands)
+            IRenderContext context, RenderParameter parameter, RenderType filterType, List<KeyValuePair<int, CommandList>> outputCommands)
         {
             outputCommands.Clear();
             if(items.Count > schedulerParams.MinimumDrawCalls)
@@ -117,10 +119,13 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                 Parallel.ForEach(partitionParams, (range, state) =>
                 {
                     var deferred = pool.Get();
-                    SetRenderTargets(deferred, parameter);
+                    SetRenderTargets(deferred, ref parameter);
                     for(int i=range.Item1; i<range.Item2; ++i)
                     {
-                        items[i].Render(context, deferred);
+                        if (items[i].RenderType == filterType)
+                        {
+                            items[i].Render(context, deferred);
+                        }
                     }
                     var command = deferred.DeviceContext.FinishCommandList(false);
                     pool.Put(deferred);
@@ -139,7 +144,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="parameter">The parameter.</param>
-        protected void SetRenderTargets(DeviceContext context, RenderParameter parameter)
+        private void SetRenderTargets(DeviceContext context, ref RenderParameter parameter)
         {
             context.OutputMerger.SetTargets(parameter.DepthStencilView, parameter.RenderTargetView);
             context.Rasterizer.SetViewport(parameter.ViewportRegion);

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/TreeTraverser.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/TreeTraverser.cs
@@ -10,6 +10,8 @@ namespace HelixToolkit.UWP
 #endif
 {
     using Core;
+    using Core2D;
+
     public static class TreeTraverser
     {
         /// <summary>
@@ -162,7 +164,7 @@ namespace HelixToolkit.UWP
         /// <param name="condition"></param>
         /// <param name="stackCache"></param>
         /// <returns></returns>
-        public static IEnumerable<IRenderCore2D> PreorderDFTGetCores(this IEnumerable<IRenderable2D> nodes, Func<IRenderable2D, bool> condition,
+        public static IEnumerable<RenderCore2D> PreorderDFTGetCores(this IEnumerable<IRenderable2D> nodes, Func<IRenderable2D, bool> condition,
             Stack<IEnumerator<IRenderable2D>> stackCache = null)
         {
             var stack = stackCache == null ? new Stack<IEnumerator<IRenderable2D>>(20) : stackCache;

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/TreeTraverser.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/TreeTraverser.cs
@@ -94,7 +94,7 @@ namespace HelixToolkit.UWP
         /// <param name="condition"></param>
         /// <param name="stackCache"></param>
         /// <returns></returns>
-        public static IEnumerable<IRenderCore> PreorderDFTGetCores(this IEnumerable<IRenderable> nodes, Func<IRenderable, bool> condition,
+        public static IEnumerable<RenderCore> PreorderDFTGetCores(this IEnumerable<IRenderable> nodes, Func<IRenderable, bool> condition,
             Stack<IEnumerator<IRenderable>> stackCache = null)
         {
             var stack = stackCache == null ? new Stack<IEnumerator<IRenderable>>(20) : stackCache;

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/MultiViewports/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/MultiViewports/ModelContainer3DX.cs
@@ -141,14 +141,14 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <value>
         /// The per frame post effect cores.
         /// </value>
-        public List<IRenderCore> PerFrameGeneralCoresWithPostEffect { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameGeneralCoresWithPostEffect : Constants.EmptyCore; } }
+        public List<RenderCore> PerFrameGeneralCoresWithPostEffect { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameGeneralCoresWithPostEffect : Constants.EmptyCore; } }
         /// <summary>
         /// Gets the per frame general render cores.
         /// </summary>
         /// <value>
         /// The per frame general render cores.
         /// </value>
-        public List<IRenderCore> PerFrameGeneralRenderCores { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameGeneralRenderCores : Constants.EmptyCore; } }
+        public List<RenderCore> PerFrameGeneralRenderCores { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameGeneralRenderCores : Constants.EmptyCore; } }
 
         /// <summary>
         /// Handles the change of the effects manager.

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/ScreenDuplicationViewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/ScreenDuplicationViewport3DX.cs
@@ -22,8 +22,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The EffectsManager property.
         /// </summary>
         public static readonly DependencyProperty EffectsManagerProperty = DependencyProperty.Register(
-            "EffectsManager", typeof(IEffectsManager), typeof(ScreenDuplicationViewport3DX), new FrameworkPropertyMetadata(
-                null, FrameworkPropertyMetadataOptions.AffectsRender,
+            "EffectsManager", typeof(IEffectsManager), typeof(ScreenDuplicationViewport3DX), new PropertyMetadata(
+                null,
                 (s, e) => ((ScreenDuplicationViewport3DX)s).EffectsManagerPropertyChanged()));
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -224,8 +224,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The EffectsManager property.
         /// </summary>
         public static readonly DependencyProperty EffectsManagerProperty = DependencyProperty.Register(
-            "EffectsManager", typeof(IEffectsManager), typeof(Viewport3DX), new FrameworkPropertyMetadata(
-                null, FrameworkPropertyMetadataOptions.AffectsRender,
+            "EffectsManager", typeof(IEffectsManager), typeof(Viewport3DX), new PropertyMetadata(
+                null,
                 (s, e) => ((Viewport3DX)s).EffectsManagerPropertyChanged()));
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Abstract/ContentElement2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Abstract/ContentElement2D.cs
@@ -17,7 +17,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
     public abstract class ContentElement2D : Element2D
     {
         public static readonly DependencyProperty Content2DProperty = DependencyProperty.Register("Content2D", typeof(object), typeof(ContentElement2D), 
-            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsMeasure,
+            new PropertyMetadata(null, 
                 (d,e)=>
             {
                 var model = d as ContentElement2D;
@@ -64,6 +64,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
                         model.contentInternal.Attach(model.RenderHost);
                     }
                 }
+                model.InvalidateMeasure();
             }));
 
         [Bindable(true)]
@@ -81,7 +82,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 
         public static readonly DependencyProperty ForegroundProperty
             = DependencyProperty.Register("Foreground", typeof(Brush), typeof(ContentElement2D),
-                new FrameworkPropertyMetadata(new SolidColorBrush(Colors.Black), FrameworkPropertyMetadataOptions.AffectsRender));
+                new PropertyMetadata(new SolidColorBrush(Colors.Black), (d,e)=> { (d as Element2DCore).InvalidateRender(); }));
 
         public Brush Foreground
         {
@@ -97,10 +98,12 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 
         public static readonly DependencyProperty BackgroundProperty
             = DependencyProperty.Register("Background", typeof(Brush), typeof(ContentElement2D),
-                new FrameworkPropertyMetadata(new SolidColorBrush(Colors.Transparent), FrameworkPropertyMetadataOptions.AffectsRender,
+                new PropertyMetadata(new SolidColorBrush(Colors.Transparent), 
                 (d,e)=>
                 {
-                    (d as ContentElement2D).backgroundChanged = true;
+                    var m = d as ContentElement2D;
+                    m.backgroundChanged = true;
+                    m.InvalidateRender();
                 }));
 
         public Brush Background
@@ -124,7 +127,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 
         public static readonly DependencyProperty HorizontalContentAlignmentProperty =
             DependencyProperty.Register("HorizontalContentAlignment", typeof(HorizontalAlignment), typeof(ContentElement2D), 
-                new FrameworkPropertyMetadata(HorizontalAlignment.Center, FrameworkPropertyMetadataOptions.AffectsMeasure));
+                new PropertyMetadata(HorizontalAlignment.Center, (d,e)=> { (d as Element2DCore).InvalidateMeasure(); }));
 
 
         public VerticalAlignment VerticalContentAlignment
@@ -135,7 +138,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 
         public static readonly DependencyProperty VerticalContentAlignmentProperty =
             DependencyProperty.Register("VerticalContentAlignment", typeof(VerticalAlignment), typeof(ContentElement2D), 
-                new FrameworkPropertyMetadata(VerticalAlignment.Center, FrameworkPropertyMetadataOptions.AffectsMeasure));
+                new PropertyMetadata(VerticalAlignment.Center, (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
 
         protected Element2D contentInternal { private set; get; }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Abstract/ContentElement2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Abstract/ContentElement2D.cs
@@ -160,7 +160,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 
         protected BorderRenderCore2D borderCore { private set; get; }
 
-        protected override IRenderCore2D CreateRenderCore()
+        protected override RenderCore2D CreateRenderCore()
         {
             borderCore = new BorderRenderCore2D();
             return borderCore;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Abstract/Element2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Abstract/Element2D.cs
@@ -19,8 +19,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// 
         /// </summary>
         public static readonly DependencyProperty VisibilityProperty =
-            DependencyProperty.Register("Visibility", typeof(Visibility), typeof(Element2D), new FrameworkPropertyMetadata(Visibility.Visible, 
-                FrameworkPropertyMetadataOptions.AffectsRender,
+            DependencyProperty.Register("Visibility", typeof(Visibility), typeof(Element2D), new PropertyMetadata(Visibility.Visible, 
                 (d, e) =>
                 {
                     (d as Element2DCore).VisibilityInternal = (Visibility)e.NewValue;
@@ -64,11 +63,12 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// </summary>
         public new static readonly DependencyProperty IsMouseOverProperty =
             DependencyProperty.Register("IsMouseOver", typeof(bool), typeof(Element2D),
-                new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.AffectsRender, (d, e) =>
+                new PropertyMetadata(false, (d, e) =>
             {
                 var model = d as Element2D;
                 model.RenderCore.IsMouseOver = (bool)e.NewValue;
                 model.OnMouseOverChanged((bool)e.NewValue, (bool)e.OldValue);
+                model.InvalidateRender();
             }));
         /// <summary>
         /// Gets or sets a value indicating whether this instance is mouse over2 d.
@@ -373,26 +373,26 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 #endif
         }
 
-        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
-        {
-            var pm = e.Property.GetMetadata(this);
-            if(pm is FrameworkPropertyMetadata fm)
-            {
-                if (fm.AffectsMeasure)
-                {
-                    InvalidateMeasure();
-                }
-                else if (fm.AffectsArrange)
-                {
-                    InvalidateArrange();
-                }
-                if (fm.AffectsRender)
-                {
-                    InvalidateVisual();
-                }
-            }
-            base.OnPropertyChanged(e);
-        }
+        //protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+        //{
+        //    var pm = e.Property.GetMetadata(this);
+        //    if(pm is FrameworkPropertyMetadata fm)
+        //    {
+        //        if (fm.AffectsMeasure)
+        //        {
+        //            InvalidateMeasure();
+        //        }
+        //        else if (fm.AffectsArrange)
+        //        {
+        //            InvalidateArrange();
+        //        }
+        //        if (fm.AffectsRender)
+        //        {
+        //            InvalidateVisual();
+        //        }
+        //    }
+        //    base.OnPropertyChanged(e);
+        //}
     }
 
     public class Mouse2DEventArgs : RoutedEventArgs

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Abstract/ShapeModel2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Abstract/ShapeModel2D.cs
@@ -231,7 +231,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         protected ShapeRenderCore2DBase shapeRenderable;
 
 
-        protected override IRenderCore2D CreateRenderCore()
+        protected override RenderCore2D CreateRenderCore()
         {
             shapeRenderable = CreateShapeRenderCore();
             AssignProperties();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Border2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Border2D.cs
@@ -9,7 +9,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 {
     using Extensions;
     using SharpDX;
-
+    using Core2D;
     public class Border2D : ContentElement2D
     {
         public double CornerRadius
@@ -35,7 +35,8 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         }
 
         public static readonly DependencyProperty PaddingProperty =
-            DependencyProperty.Register("Padding", typeof(Thickness), typeof(Border2D), new FrameworkPropertyMetadata(new Thickness(0,0,0,0), FrameworkPropertyMetadataOptions.AffectsMeasure));
+            DependencyProperty.Register("Padding", typeof(Thickness), typeof(Border2D), new PropertyMetadata(new Thickness(0,0,0,0), 
+                (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
 
         #region Stroke properties
         public static DependencyProperty BorderBrushProperty
@@ -193,12 +194,14 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 
         public static DependencyProperty BorderThicknessProperty
             = DependencyProperty.Register("BorderThickness", typeof(Thickness), typeof(Border2D), 
-                new FrameworkPropertyMetadata(new Thickness(0,0,0,0), FrameworkPropertyMetadataOptions.AffectsMeasure, (d, e) =>
+                new PropertyMetadata(new Thickness(0,0,0,0), (d, e) =>
                 {
-                    if ((d as Border2D).borderCore == null)
+                    var m = d as Border2D;
+                    if (m.borderCore == null)
                     { return; }
                     var thick = (Thickness)e.NewValue;
-                    (d as Border2D).borderCore.BorderThickness = new Vector4((float)thick.Left, (float)thick.Top, (float)thick.Right, (float)thick.Bottom);
+                    m.borderCore.BorderThickness = new Vector4((float)thick.Left, (float)thick.Top, (float)thick.Right, (float)thick.Bottom);
+                    m.InvalidateMeasure();
                 }));
 
         public Thickness BorderThickness

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Canvas2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/Canvas2D.cs
@@ -20,7 +20,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// The left property
         /// </summary>
         public static readonly DependencyProperty LeftProperty = DependencyProperty.RegisterAttached("Left", typeof(double), typeof(Canvas2D),
-            new FrameworkPropertyMetadata(double.PositiveInfinity, FrameworkPropertyMetadataOptions.AffectsMeasure));
+            new PropertyMetadata(double.PositiveInfinity, (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
         /// <summary>
         /// Sets the left.
         /// </summary>
@@ -43,7 +43,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// The top property
         /// </summary>
         public static readonly DependencyProperty TopProperty = DependencyProperty.RegisterAttached("Top", typeof(double), typeof(Canvas2D),
-            new FrameworkPropertyMetadata(double.PositiveInfinity, FrameworkPropertyMetadataOptions.AffectsMeasure));
+            new PropertyMetadata(double.PositiveInfinity, (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
         /// <summary>
         /// Sets the top.
         /// </summary>
@@ -66,7 +66,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// The right property
         /// </summary>
         public static readonly DependencyProperty RightProperty = DependencyProperty.RegisterAttached("Right", typeof(double), typeof(Canvas2D),
-            new FrameworkPropertyMetadata(double.PositiveInfinity, FrameworkPropertyMetadataOptions.AffectsMeasure));
+            new PropertyMetadata(double.PositiveInfinity, (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
         /// <summary>
         /// Sets the right.
         /// </summary>
@@ -89,7 +89,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// The bottom property
         /// </summary>
         public static readonly DependencyProperty BottomProperty = DependencyProperty.RegisterAttached("Bottom", typeof(double), typeof(Canvas2D),
-            new FrameworkPropertyMetadata(double.PositiveInfinity, FrameworkPropertyMetadataOptions.AffectsMeasure));
+            new PropertyMetadata(double.PositiveInfinity, (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
         /// <summary>
         /// Sets the bottom.
         /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/ContentPresenter2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/ContentPresenter2D.cs
@@ -13,27 +13,28 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
     {
         public static readonly DependencyProperty Content2DProperty = DependencyProperty.Register("Content", typeof(Element2DCore), 
             typeof(ContentPresenter2D),
-            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsMeasure,
-        (d, e) =>
-        {
-            var model = d as ContentPresenter2D;
-
-            if (model.contentInternal != null)
+            new PropertyMetadata(null, 
+            (d, e) =>
             {
-                model.RemoveLogicalChild(model.contentInternal);
-                model.contentInternal.Detach();
-            }
-            model.contentInternal = (Element2DCore)e.NewValue;
+                var model = d as ContentPresenter2D;
 
-            if (model.contentInternal != null)
-            {
-                model.AddLogicalChild(model.contentInternal);
-                if (model.IsAttached)
+                if (model.contentInternal != null)
                 {
-                    model.contentInternal.Attach(model.RenderHost);
+                    model.RemoveLogicalChild(model.contentInternal);
+                    model.contentInternal.Detach();
                 }
-            }
-        }));
+                model.contentInternal = (Element2DCore)e.NewValue;
+
+                if (model.contentInternal != null)
+                {
+                    model.AddLogicalChild(model.contentInternal);
+                    if (model.IsAttached)
+                    {
+                        model.contentInternal.Attach(model.RenderHost);
+                    }
+                }
+                model.InvalidateMeasure();
+            }));
 
         [Bindable(true)]
         public Element2DCore Content2D

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/FrameStatisticsModel2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/FrameStatisticsModel2D.cs
@@ -65,7 +65,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
             return base.OnAttach(host);
         }
 
-        protected override IRenderCore2D CreateRenderCore()
+        protected override RenderCore2D CreateRenderCore()
         {
             return new FrameStatisticsRenderCore();
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/ImageModel2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/ImageModel2D.cs
@@ -35,11 +35,12 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// The image stream property
         /// </summary>
         public static readonly DependencyProperty ImageStreamProperty =
-            DependencyProperty.Register("ImageStream", typeof(Stream), typeof(ImageModel2D), new FrameworkPropertyMetadata(null,
-                FrameworkPropertyMetadataOptions.AffectsRender,
+            DependencyProperty.Register("ImageStream", typeof(Stream), typeof(ImageModel2D), new PropertyMetadata(null,
                 (d,e)=> 
                 {
-                    (d as ImageModel2D).bitmapChanged = true;
+                    var m = d as ImageModel2D;
+                    m.bitmapChanged = true;
+                    m.InvalidateRender();
                 }));
 
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/ImageModel2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/ImageModel2D.cs
@@ -69,7 +69,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
 
         protected bool bitmapChanged { private set; get; } = true;
 
-        protected override IRenderCore2D CreateRenderCore()
+        protected override RenderCore2D CreateRenderCore()
         {
             return new ImageRenderCore2D();
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/RelativePositionCanvas2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/RelativePositionCanvas2D.cs
@@ -21,7 +21,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// The relative x property
         /// </summary>
         public static readonly DependencyProperty RelativeXProperty = DependencyProperty.RegisterAttached("RelativeX", typeof(double), typeof(RelativePositionCanvas2D),
-            new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.AffectsMeasure));
+            new PropertyMetadata(0.0, (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
 
         /// <summary>
         /// Sets the relative x.
@@ -45,7 +45,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// The relative y property
         /// </summary>
         public static readonly DependencyProperty RelativeYProperty = DependencyProperty.RegisterAttached("RelativeY", typeof(double), typeof(RelativePositionCanvas2D),
-            new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.AffectsMeasure));
+            new PropertyMetadata(0.0, (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
         /// <summary>
         /// Sets the relative y.
         /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/StackPanel2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/StackPanel2D.cs
@@ -25,7 +25,8 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         /// The orientation property
         /// </summary>
         public static readonly DependencyProperty OrientationProperty =
-            DependencyProperty.Register("Orientation", typeof(Orientation), typeof(StackPanel2D), new FrameworkPropertyMetadata(Orientation.Horizontal, FrameworkPropertyMetadataOptions.AffectsMeasure));
+            DependencyProperty.Register("Orientation", typeof(Orientation), typeof(StackPanel2D), new PropertyMetadata(Orientation.Horizontal, 
+                (d, e) => { (d as Element2DCore).InvalidateMeasure(); }));
 
         public StackPanel2D()
         {

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/TextModel2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements2D/TextModel2D.cs
@@ -219,7 +219,7 @@ namespace HelixToolkit.Wpf.SharpDX.Elements2D
         private bool foregroundChanged = true;
         private bool backgroundChanged = true;
 
-        protected override IRenderCore2D CreateRenderCore()
+        protected override RenderCore2D CreateRenderCore()
         {
             textRenderable = new TextRenderCore2D();
             AssignProperties();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -72,10 +72,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty TransformProperty =
-            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(Element3D), new PropertyMetadata(Transform3D.Identity, (d,e)=>
-            {
-                (d as IRenderable).ModelMatrix = e.NewValue != null ? (e.NewValue as Transform3D).Value.ToMatrix() : Matrix.Identity;
-            }));
+            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(Element3D), new FrameworkPropertyMetadata(Transform3D.Identity,
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                (d,e)=>
+                {
+                    (d as IRenderable).ModelMatrix = e.NewValue != null ? (e.NewValue as Transform3D).Value.ToMatrix() : Matrix.Identity;
+                }));
         /// <summary>
         /// 
         /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -72,8 +72,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty TransformProperty =
-            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(Element3D), new FrameworkPropertyMetadata(Transform3D.Identity,
-                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+            DependencyProperty.Register("Transform", typeof(Transform3D), typeof(Element3D), new PropertyMetadata(Transform3D.Identity,
                 (d,e)=>
                 {
                     (d as IRenderable).ModelMatrix = e.NewValue != null ? (e.NewValue as Transform3D).Value.ToMatrix() : Matrix.Identity;
@@ -224,18 +223,18 @@ namespace HelixToolkit.Wpf.SharpDX
             return null;
         }
 
-        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
-        {
-            var pm = e.Property.GetMetadata(this);
-            if (pm is FrameworkPropertyMetadata fm)
-            {
-                if (fm.AffectsRender)
-                {
-                    InvalidateRender();
-                }
-            }
-            base.OnPropertyChanged(e);
-        }
+        //protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+        //{
+        //    var pm = e.Property.GetMetadata(this);
+        //    if (pm is FrameworkPropertyMetadata fm)
+        //    {
+        //        if (fm.AffectsRender)
+        //        {
+        //            InvalidateRender();
+        //        }
+        //    }
+        //    base.OnPropertyChanged(e);
+        //}
     }
 
     public abstract class Mouse3DEventArgs : RoutedEventArgs

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/MaterialGeometryModel3D.cs
@@ -99,6 +99,21 @@ namespace HelixToolkit.Wpf.SharpDX
             DependencyProperty.Register("Material", typeof(Material), typeof(MaterialGeometryModel3D), new PropertyMetadata(null, MaterialChanged));
 
         /// <summary>
+        /// Specifiy if model material is transparent. 
+        /// During rendering, transparent objects are rendered after opaque objects. Transparent objects' order in scene graph are preserved.
+        /// </summary>
+        public static readonly DependencyProperty IsTransparentProperty =
+            DependencyProperty.Register("IsTransparent", typeof(bool), typeof(MaterialGeometryModel3D), new PropertyMetadata(false, (d, e) =>
+            {
+                var model = d as Element3DCore;
+                if (model.RenderCore.RenderType == RenderType.Opaque || model.RenderCore.RenderType == RenderType.Transparent)
+                {
+                    model.RenderCore.RenderType = (bool)e.NewValue ? RenderType.Transparent : RenderType.Opaque;
+                }
+            }));
+
+
+        /// <summary>
         /// 
         /// </summary>
         public bool RenderDiffuseMap
@@ -162,6 +177,16 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             get { return (Material)this.GetValue(MaterialProperty); }
             set { this.SetValue(MaterialProperty, value); }
+        }
+
+        /// <summary>
+        /// Specifiy if model material is transparent. 
+        /// During rendering, transparent objects are rendered after opaque objects. Transparent objects' order in scene graph are preserved.
+        /// </summary>
+        public bool IsTransparent
+        {
+            get { return (bool)GetValue(IsTransparentProperty); }
+            set { SetValue(IsTransparentProperty, value); }
         }
         #endregion
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/ScreenSpaceMeshGeometry3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/ScreenSpaceMeshGeometry3D.cs
@@ -168,7 +168,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         protected abstract void UpdateModel(Vector3 upDirection);
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             InitializeMover();
             return new ScreenSpacedMeshRenderCore();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -55,7 +55,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new BillboardRenderCore();
         }
@@ -63,7 +63,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as IBillboardRenderParams).FixedSize = FixedSize;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BillboardTextModel3D.cs
@@ -44,6 +44,30 @@ namespace HelixToolkit.Wpf.SharpDX
                 return (bool)GetValue(FixedSizeProperty);
             }
         }
+
+        /// <summary>
+        /// Specifiy if billboard texture is transparent. 
+        /// During rendering, transparent objects are rendered after opaque objects. Transparent objects' order in scene graph are preserved.
+        /// </summary>
+        public static readonly DependencyProperty IsTransparentProperty =
+            DependencyProperty.Register("IsTransparent", typeof(bool), typeof(BillboardTextModel3D), new PropertyMetadata(false, (d, e) =>
+            {
+                var model = d as Element3DCore;
+                if (model.RenderCore.RenderType == RenderType.Opaque || model.RenderCore.RenderType == RenderType.Transparent)
+                {
+                    model.RenderCore.RenderType = (bool)e.NewValue ? RenderType.Transparent : RenderType.Opaque;
+                }
+            }));
+
+        /// <summary>
+        /// Specifiy if  billboard texture is transparent. 
+        /// During rendering, transparent objects are rendered after opaque objects. Transparent objects' order in scene graph are preserved.
+        /// </summary>
+        public bool IsTransparent
+        {
+            get { return (bool)GetValue(IsTransparentProperty); }
+            set { SetValue(IsTransparentProperty, value); }
+        }
         #endregion
 
         #region Overridable Methods        

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
@@ -55,12 +55,12 @@ namespace HelixToolkit.Wpf.SharpDX
             return host.EffectsManager[DefaultRenderTechniqueNames.BoneSkinBlinn];
         }
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {         
             return new BoneSkinRenderCore();
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             boneSkinRenderCore.BoneMatrices = BoneMatrices;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CrossSectionMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CrossSectionMeshGeometryModel3D.cs
@@ -267,7 +267,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new CrossSectionMeshRenderCore();
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMap3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/EnvironmentMap3D.cs
@@ -28,12 +28,12 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new SkyBoxRenderCore();
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (RenderCore as ISkyboxRenderParams).CubeTexture = Texture;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingBillboardModel3D.cs
@@ -47,7 +47,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new InstancingBillboardRenderCore() { ParameterBuffer = this.instanceParamBuffer };
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/InstancingMeshGeometryModel3D.cs
@@ -95,7 +95,7 @@ namespace HelixToolkit.Wpf.SharpDX
             return host.EffectsManager[DefaultRenderTechniqueNames.InstancingBlinn];
         }
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new InstancingMeshRenderCore() { ParameterBuffer = this.instanceParamBuffer };
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/LineGeometryModel3D.cs
@@ -90,7 +90,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new LineRenderCore();
         }
@@ -98,7 +98,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             var c = core as ILineRenderParams;
             c.LineColor = Color.ToColor4();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/MeshGeometryModel3D.cs
@@ -264,7 +264,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new PatchMeshRenderCore();
         }
@@ -272,7 +272,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             var c = core as IMeshRenderParams;
             c.InvertNormal = this.InvertNormal;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/OutLineMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/OutLineMeshGeometryModel3D.cs
@@ -81,12 +81,12 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new MeshOutlineRenderCore();
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             var c = core as IMeshOutlineParams;
             c.Color = this.OutlineColor.ToColor4();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ParticleStormModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ParticleStormModel3D.cs
@@ -575,7 +575,7 @@ namespace HelixToolkit.Wpf.SharpDX
             blendChanged = true;
         }
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new ParticleRenderCore();
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PatchGeometryModel3D.cs
@@ -16,7 +16,7 @@ namespace HelixToolkit.Wpf.SharpDX
     {
 
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new PatchMeshRenderCore() { EnableTessellation = true };
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PointGeometryModel3D.cs
@@ -112,7 +112,7 @@
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new PointRenderCore();
         }
@@ -120,7 +120,7 @@
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             var c = core as IPointRenderParams;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PostEffects/PostEffectBoom.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PostEffects/PostEffectBoom.cs
@@ -194,7 +194,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new PostEffectBloomCore();
         }
@@ -202,7 +202,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             var c = core as IPostEffectBloom;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PostEffects/PostEffectMeshOutlineBlur.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PostEffects/PostEffectMeshOutlineBlur.cs
@@ -126,7 +126,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new PostEffectMeshOutlineBlurCore();
         }
@@ -144,7 +144,7 @@ namespace HelixToolkit.Wpf.SharpDX
             return host.EffectsManager[DefaultRenderTechniqueNames.PostEffectMeshOutlineBlur];
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as IPostEffectOutlineBlur).EffectName = EffectName;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PostEffects/PostEffectMeshXRay.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/PostEffects/PostEffectMeshXRay.cs
@@ -118,7 +118,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new PostEffectMeshXRayCore();
         }
@@ -126,7 +126,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as IPostEffectMeshXRay).EffectName = EffectName;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ScreenDuplicationModel.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/ScreenDuplicationModel.cs
@@ -116,7 +116,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new ScreenCloneRenderCore();
         }
@@ -124,7 +124,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as IScreenClone).Output = this.DisplayIndex;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UICompositeManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UICompositeManipulator3D.cs
@@ -14,7 +14,7 @@ namespace HelixToolkit.Wpf.SharpDX
     using System.Windows.Data;
 
     using global::SharpDX;
-
+    using Core;
     using Transform3D = System.Windows.Media.Media3D.Transform3D;
 
     public class UICompositeManipulator3D : CompositeModel3D
@@ -87,7 +87,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public static readonly DependencyProperty TargetTransformProperty = DependencyProperty.Register(
             "TargetTransform", typeof(Transform3D), typeof(UICompositeManipulator3D), 
-            new FrameworkPropertyMetadata(Transform3D.Identity, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.AffectsRender));
+            new FrameworkPropertyMetadata(Transform3D.Identity, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                (d,e)=> { (d as Element3DCore).InvalidateRender(); }));
 
         /// <summary>
         ///   Gets or sets TargetTransform.

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/UIManipulator3D.cs
@@ -18,7 +18,7 @@ namespace HelixToolkit.Wpf.SharpDX
     using HelixToolkit.Wpf.SharpDX.Utilities;
 
     using Transform3D = System.Windows.Media.Media3D.Transform3D;
-
+    using Core;
     /// <summary>
     ///   An abstract base class for manipulators.
     /// </summary>
@@ -33,7 +33,8 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   Bind the Tranform of the Target to this Property
         /// </summary>
         public static readonly DependencyProperty TargetTransformProperty = DependencyProperty.Register(
-            "TargetTransform", typeof(Transform3D), typeof(UIManipulator3D), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.AffectsRender));
+            "TargetTransform", typeof(Transform3D), typeof(UIManipulator3D), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                (d,e)=> { (d as Element3DCore).InvalidateRender(); }));
 
         /// <summary>
         ///   The offset property.
@@ -45,7 +46,7 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   The value property.
         /// </summary>
         public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
-            "Value", typeof(double), typeof(UIManipulator3D), new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault | FrameworkPropertyMetadataOptions.AffectsRender, ValueChanged));
+            "Value", typeof(double), typeof(UIManipulator3D), new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, ValueChanged));
 
 
         //public static readonly DependencyProperty PositionProperty =
@@ -69,7 +70,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         private static void ValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ((UIManipulator3D)d).OnValueChanged(e);
+            var m = d as UIManipulator3D;
+            m.OnValueChanged(e);
+            m.InvalidateRender();
         }
 
         /// <summary>
@@ -79,7 +82,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="e"></param>
         private static void OffsetChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ((UIManipulator3D)d).OnOffetChanged(e);
+            var m = d as UIManipulator3D;
+            m.OnOffetChanged(e);
+            m.InvalidateRender();
         }
 
 
@@ -241,9 +246,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         protected static void ModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            if (((UIManipulator3D)d).IsAttached)
+            var m = d as UIManipulator3D;
+            if (m.IsAttached)
             {
-                ((UIManipulator3D)d).OnModelChanged();
+                m.OnModelChanged();
+                m.InvalidateRender();
             }
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/AmbientLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/AmbientLight3D.cs
@@ -10,7 +10,7 @@ namespace HelixToolkit.Wpf.SharpDX
 {
     public sealed class AmbientLight3D : Light3D
     {
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new AmbientLightCore();
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/DirectionalLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/DirectionalLight3D.cs
@@ -28,12 +28,12 @@ namespace HelixToolkit.Wpf.SharpDX
             set { this.SetValue(DirectionProperty, value); }
         }
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new DirectionalLightCore();
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as DirectionalLightCore).Direction = Direction.ToVector3();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/Light3D.cs
@@ -78,7 +78,7 @@ namespace HelixToolkit.Wpf.SharpDX
             get { return (RenderCore as ILight3D).LightType; }
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as LightCoreBase).Color = Color.ToColor4();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/PointLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/PointLight3D.cs
@@ -63,12 +63,12 @@ namespace HelixToolkit.Wpf.SharpDX
             set { this.SetValue(RangeProperty, value); }
         }
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new PointLightCore();
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as PointLightCore).Attenuation = Attenuation.ToVector3();

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ShadowMap3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/ShadowMap3D.cs
@@ -98,7 +98,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new ShadowMapCore();
         }
@@ -113,7 +113,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Assigns the default values to core.
         /// </summary>
         /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             var c = core as ShadowMapCore;

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Lights3D/SpotLight3D.cs
@@ -85,12 +85,12 @@ namespace HelixToolkit.Wpf.SharpDX
         }   
 
 
-        protected override IRenderCore OnCreateRenderCore()
+        protected override RenderCore OnCreateRenderCore()
         {
             return new SpotLightCore();
         }
 
-        protected override void AssignDefaultValuesToCore(IRenderCore core)
+        protected override void AssignDefaultValuesToCore(RenderCore core)
         {
             base.AssignDefaultValuesToCore(core);
             (core as SpotLightCore).Direction = Direction.ToVector3();


### PR DESCRIPTION
Remove OnPropertyChanged. Use explicit property changed call back to invalidate render or invalidate measure.
Add IsTransparency property for material geometry and billboard. Will render any mesh if its IsTransparency=true after rendering opaque meshes and particle system.
Change IRenderCore interface to RenderCore abstract class.
Change IRenderCore2D interface to RenderCore2D  abstract class.
Only render opaque mesh in shadow map.