### PR TITLE
Bug fix

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
@@ -47,6 +47,13 @@ namespace HelixToolkit.UWP.Core
             get { return renderType; }
         }
 
+        /// <summary>
+        /// Indicate whether render host should call <see cref="Update(IRenderContext, DeviceContextProxy)"/> before <see cref="Render(IRenderContext, DeviceContextProxy)"/>
+        /// <para><see cref="Update(IRenderContext, DeviceContextProxy)"/> is used to run such as compute shader before rendering. </para>
+        /// <para>Compute shader can be run at the beginning of any other <see cref="Render(IRenderContext, DeviceContextProxy)"/> routine to avoid waiting.</para>
+        /// </summary>
+        public bool NeedUpdate { protected set; get; } = false;
+
         private bool isThrowingShadow = false;
         /// <summary>
         /// <see cref="IThrowingShadow.IsThrowingShadow"/>
@@ -150,11 +157,19 @@ namespace HelixToolkit.UWP.Core
             DisposeAndClear();
         }
         /// <summary>
-        /// Trigger OnRender function delegate if CanRender()==true
+        /// Render routine
         /// </summary>
         /// <param name="context"></param>
         /// <param name="deviceContext"></param>
         public abstract void Render(IRenderContext context, DeviceContextProxy deviceContext);
+
+        /// <summary>
+        /// Update routine. Only used to run update computation such as compute shader in particle system. 
+        /// <para>Compute shader can be run at the beginning of any other <see cref="Render(IRenderContext, DeviceContextProxy)"/> routine to avoid waiting.</para>
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="deviceContext"></param>
+        public virtual void Update(IRenderContext context, DeviceContextProxy deviceContext) { }
 
         /// <summary>
         /// Resets the invalidate handler.

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
@@ -110,6 +110,14 @@ namespace HelixToolkit.UWP.Core
             }
         }
 
+        public override void Update(IRenderContext context, DeviceContextProxy deviceContext)
+        {
+            if (CanRender(context))
+            {
+                OnUpdate(context, deviceContext);
+            }
+        }
+
         /// <summary>
         /// Called when [render shadow].
         /// </summary>
@@ -138,6 +146,13 @@ namespace HelixToolkit.UWP.Core
         /// Actual render function. Used to attach different render states and call the draw call.
         /// </summary>
         protected abstract void OnRender(IRenderContext context, DeviceContextProxy deviceContext);
+
+        /// <summary>
+        /// Only used for running compute shader such as in particle system.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="deviceContext"></param>
+        protected virtual void OnUpdate(IRenderContext context, DeviceContextProxy deviceContext) { }
 
         /// <summary>
         /// Render function for custom shader pass. Used to do special effects

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/BillboardBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/BillboardBufferModel.cs
@@ -79,7 +79,7 @@ namespace HelixToolkit.UWP.Core
             textureView?.Detach(this.GUID);
             textureView = null;
             var billboardGeometry = geometry as IBillboardText;
-            
+            billboardGeometry.DrawTexture(deviceResources);
             if (billboardGeometry != null && billboardGeometry.BillboardVertices != null && billboardGeometry.BillboardVertices.Count > 0)
             {
                 Type = billboardGeometry.Type;              
@@ -151,8 +151,6 @@ namespace HelixToolkit.UWP.Core
         /// <returns></returns>
         protected override BillboardVertex[] OnBuildVertexArray(IBillboardText geometry, IDeviceResources deviceResources)
         {
-            geometry.DrawTexture(deviceResources);
-
             var vertexCount = geometry.BillboardVertices.Count;
             var array = vertexArrayBuffer != null && vertexArrayBuffer.Length >= vertexCount ? vertexArrayBuffer : new BillboardVertex[vertexCount];
 

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/BillboardBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/BillboardBufferModel.cs
@@ -80,7 +80,7 @@ namespace HelixToolkit.UWP.Core
             textureView = null;
             var billboardGeometry = geometry as IBillboardText;
             
-            if (billboardGeometry != null && billboardGeometry.BillboardVertices != null)
+            if (billboardGeometry != null && billboardGeometry.BillboardVertices != null && billboardGeometry.BillboardVertices.Count > 0)
             {
                 Type = billboardGeometry.Type;              
                 var data = OnBuildVertexArray(billboardGeometry, deviceResources);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/LineBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/LineBufferModel.cs
@@ -84,7 +84,7 @@ namespace HelixToolkit.UWP.Core
         protected override void OnCreateVertexBuffer(DeviceContext context, IElementsBufferProxy buffer, int bufferIndex, Geometry3D geometry, IDeviceResources deviceResources)
         {
             // -- set geometry if given
-            if (geometry != null && geometry.Positions != null)
+            if (geometry != null && geometry.Positions != null && geometry.Positions.Count > 0)
             {
                 // --- get geometry
                 var mesh = geometry as LineGeometry3D;
@@ -105,7 +105,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="deviceResources">The device resources.</param>
         protected override void OnCreateIndexBuffer(DeviceContext context, IElementsBufferProxy buffer, Geometry3D geometry, IDeviceResources deviceResources)
         {
-            if (geometry.Indices != null)
+            if (geometry != null && geometry.Indices != null && geometry.Indices.Count > 0)
             {
                 buffer.UploadDataToBuffer(context, geometry.Indices, geometry.Indices.Count);
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/MeshBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/MeshBufferModel.cs
@@ -104,7 +104,7 @@ namespace HelixToolkit.UWP.Core
         protected override void OnCreateVertexBuffer(DeviceContext context, IElementsBufferProxy buffer, int bufferIndex, Geometry3D geometry, IDeviceResources deviceResources)
         {
             // -- set geometry if given
-            if (geometry != null && geometry.Positions != null)
+            if (geometry != null && geometry.Positions != null && geometry.Positions.Count > 0)
             {
                 // --- get geometry
                 var mesh = geometry as MeshGeometry3D;
@@ -125,7 +125,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="deviceResources">The device resources.</param>
         protected override void OnCreateIndexBuffer(DeviceContext context, IElementsBufferProxy buffer, Geometry3D geometry, IDeviceResources deviceResources)
         {
-            if (geometry.Indices != null && geometry.Indices.Count > 0)
+            if (geometry != null && geometry.Indices != null && geometry.Indices.Count > 0)
             {
                 buffer.UploadDataToBuffer(context, geometry.Indices, geometry.Indices.Count);
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/MeshBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/MeshBufferModel.cs
@@ -125,7 +125,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="deviceResources">The device resources.</param>
         protected override void OnCreateIndexBuffer(DeviceContext context, IElementsBufferProxy buffer, Geometry3D geometry, IDeviceResources deviceResources)
         {
-            if (geometry.Indices != null)
+            if (geometry.Indices != null && geometry.Indices.Count > 0)
             {
                 buffer.UploadDataToBuffer(context, geometry.Indices, geometry.Indices.Count);
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/PointBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/PointBufferModel.cs
@@ -64,7 +64,7 @@ namespace HelixToolkit.UWP.Core
         protected override void OnCreateVertexBuffer(DeviceContext context, IElementsBufferProxy buffer, int bufferIndex, Geometry3D geometry, IDeviceResources deviceResources)
         {
             // -- set geometry if given
-            if (geometry != null && geometry.Positions != null)
+            if (geometry != null && geometry.Positions != null && geometry.Positions.Count > 0)
             {
                 // --- get geometry
                 var mesh = geometry as PointGeometry3D;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ParticleRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ParticleRenderCore.cs
@@ -786,7 +786,8 @@ namespace HelixToolkit.UWP.Core
         /// <param name="context">The context.</param>
         /// <param name="deviceContext">The device context.</param>
         protected override void OnRender(IRenderContext context, DeviceContextProxy deviceContext)
-        {            
+        {
+            perFrameCB.UploadDataToBuffer(deviceContext, ref FrameVariables);
             // Clear binding
             updatePass.GetShader(ShaderStage.Compute).BindUAV(deviceContext, currentStateSlot, null);
             updatePass.GetShader(ShaderStage.Compute).BindUAV(deviceContext, newStateSlot, null);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/TextureResourceManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/TextureResourceManager.cs
@@ -133,7 +133,7 @@ namespace HelixToolkit.UWP.Model
         /// </returns>
         public static implicit operator ShaderResourceViewProxy(SharedTextureResourceProxy proxy)
         {
-            return proxy.resource;
+            return proxy == null ? null : proxy.resource;
         }
         /// <summary>
         /// Performs an implicit conversion from <see cref="SharedTextureResourceProxy"/> to <see cref="ShaderResourceView"/>.
@@ -144,7 +144,7 @@ namespace HelixToolkit.UWP.Model
         /// </returns>
         public static implicit operator ShaderResourceView(SharedTextureResourceProxy proxy)
         {
-            return proxy.resource;
+            return proxy == null ? null : proxy.resource;
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -140,6 +140,10 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                     case RenderType.Transparent:
                     case RenderType.Particle:
                         generalRenderCores.Add(renderable.RenderCore);
+                        if(renderable.RenderCore.NeedUpdate) // Run update function at the beginning of actual rendering.
+                        {
+                            renderable.RenderCore.Update(RenderContext, renderer.ImmediateContext);
+                        }
                         break;
                     case RenderType.PreProc:
                         preProcRenderCores.Add(renderable.RenderCore);

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -470,6 +470,8 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         private TimeSpan lastRenderingDuration = TimeSpan.Zero;
 
         private TimeSpan lastRenderTime = TimeSpan.Zero;
+
+        private int updateCounter = 0; // Used to render at least twice. D3DImage sometimes not getting refresh if only render once.
         #endregion
 
         /// <summary>
@@ -497,6 +499,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         public void InvalidateRender()
         {
             UpdateRequested = true;
+            updateCounter = 0;
         }
         /// <summary>
         /// Determines whether this instance can render.
@@ -506,7 +509,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// </returns>
         protected virtual bool CanRender()
         {
-            return IsInitialized && IsRendering && UpdateRequested && viewport != null && ActualWidth > 10 && ActualHeight > 10;
+            return IsInitialized && IsRendering && (UpdateRequested || updateCounter < 2) && viewport != null && ActualWidth > 10 && ActualHeight > 10;
         }
         /// <summary>
         /// Updates the and render.
@@ -520,6 +523,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                 RenderStatistics.FPSStatistics.Push((t0 - lastRenderTime).TotalMilliseconds);
                 lastRenderTime = t0;
                 UpdateRequested = false;
+                ++updateCounter;
                 if (RenderConfiguration.UpdatePerFrameData)
                 {
                     viewport.Update(t0);

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ConstantBufferProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ConstantBufferProxy.cs
@@ -251,7 +251,7 @@ namespace HelixToolkit.UWP.Utilities
 
         public static implicit operator SDX11.Buffer(ConstantBufferProxy proxy)
         {
-            return proxy.buffer;
+            return proxy == null ? null : proxy.buffer;
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
@@ -155,7 +155,7 @@ namespace HelixToolkit.UWP.Utilities
         /// </returns>
         public static implicit operator ShaderResourceView(ShaderResourceViewProxy proxy)
         {
-            return proxy.textureView;
+            return proxy == null ? null : proxy.textureView;
         }
         /// <summary>
         /// Performs an implicit conversion from <see cref="ShaderResourceViewProxy"/> to <see cref="DepthStencilView"/>.
@@ -166,7 +166,7 @@ namespace HelixToolkit.UWP.Utilities
         /// </returns>
         public static implicit operator DepthStencilView(ShaderResourceViewProxy proxy)
         {
-            return proxy.depthStencilView;
+            return proxy == null ? null : proxy.depthStencilView;
         }
         /// <summary>
         /// Performs an implicit conversion from <see cref="ShaderResourceViewProxy"/> to <see cref="RenderTargetView"/>.
@@ -177,7 +177,7 @@ namespace HelixToolkit.UWP.Utilities
         /// </returns>
         public static implicit operator RenderTargetView(ShaderResourceViewProxy proxy)
         {
-            return proxy.renderTargetView;
+            return proxy == null ? null : proxy.renderTargetView;
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/UAVBufferViewProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/UAVBufferViewProxy.cs
@@ -62,12 +62,12 @@ namespace HelixToolkit.UWP.Utilities
 
         public static implicit operator UnorderedAccessView(UAVBufferViewProxy proxy)
         {
-            return proxy.uav;
+            return proxy == null ? null : proxy.uav;
         }
 
         public static implicit operator ShaderResourceView(UAVBufferViewProxy proxy)
         {
-            return proxy.srv;
+            return proxy == null ? null : proxy.srv;
         }
 
         #region IDisposable Support

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -254,6 +254,7 @@ namespace HelixToolkit.Wpf.SharpDX
         private Overlay overlay2D { get; } = new Overlay() { EnableBitmapCache = true };
 
         private bool useSwapChain = false;
+
         /// <summary>
         /// Initializes static members of the <see cref="Viewport3DX" /> class.
         /// </summary>
@@ -595,8 +596,16 @@ namespace HelixToolkit.Wpf.SharpDX
 
             if (EnableSwapChainRendering)
             {
+                double dpiXScale = 1;
+                double dpiYScale = 1;
+                PresentationSource source = PresentationSource.FromVisual(this);
+                if (source != null)
+                {
+                    dpiXScale = 1.0 / source.CompositionTarget.TransformToDevice.M11;
+                    dpiYScale = 1.0 / source.CompositionTarget.TransformToDevice.M22;
+                }
                 useSwapChain = true;
-                hostPresenter.Content = new DPFSurfaceSwapChain(EnableDeferredRendering);
+                hostPresenter.Content = new DPFSurfaceSwapChain(EnableDeferredRendering) { DPIXScale = dpiXScale, DPIYScale = dpiYScale };
             }
             else
             {
@@ -713,7 +722,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 overlay2D.Children.Add(Content2D);
             }
             // update the coordinateview camera
-            this.OnCameraChanged();           
+            this.OnCameraChanged();
         }
 
         /// <summary>
@@ -996,7 +1005,7 @@ namespace HelixToolkit.Wpf.SharpDX
         private void Viewport3DX_FormMouseMove(object sender, WinformHostExtend.FormMouseMoveEventArgs e)
         {
             if (this.touchDownDevice == null)
-            {            
+            {
                 var pt = e.Location;
                 this.MouseMoveHitTest(pt);
                 this.UpdateCurrentPosition(pt);

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/WinformHostExtend.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/WinformHostExtend.cs
@@ -20,6 +20,11 @@ namespace HelixToolkit.Wpf.SharpDX.Controls
         }
 
         protected UIElement ParentControl { set; get; }
+
+        public double DPIXScale { set; get; } = 1;
+
+        public double DPIYScale { set; get; } = 1;
+
         public WinformHostExtend()
         {
             ChildChanged += OnChildChanged;
@@ -46,7 +51,7 @@ namespace HelixToolkit.Wpf.SharpDX.Controls
 
         private void OnMouseMove(object sender, System.Windows.Forms.MouseEventArgs e)
         {
-            RaiseEvent(new FormMouseMoveEventArgs(FormMouseMoveEvent, new Point(e.Location.X, e.Location.Y), e.X, e.Y, e.Delta) { Source = this });
+            RaiseEvent(new FormMouseMoveEventArgs(FormMouseMoveEvent, new Point(e.Location.X * DPIXScale, e.Location.Y * DPIYScale), e.X, e.Y, e.Delta) { Source = this });
         }
 
         private void OnMouseWheel(object sender, System.Windows.Forms.MouseEventArgs e)


### PR DESCRIPTION
Fix #671, D3DImage display is not getting refreshed.
Fix #669, handling empty mesh model.
Fix winform mouse event is wrong under different DPI settings.
Separate particle compute shader routine into its own update function.