### PR TITLE
Fix #702. Disable mipmap for environment cube map.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultStates.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultStates.cs
@@ -375,11 +375,24 @@ namespace HelixToolkit.UWP.Shaders
         public readonly static RasterizerStateDescription RSSkybox = new RasterizerStateDescription()
         {
             FillMode = FillMode.Solid,
-            CullMode = CullMode.None,
+            CullMode = CullMode.Back,
             DepthBias = 0,
-            DepthBiasClamp = -10,
+            DepthBiasClamp = 0,
             SlopeScaledDepthBias = +0,
             IsFrontCounterClockwise = true,
+            IsMultisampleEnabled = false,
+            IsAntialiasedLineEnabled = false,
+            IsDepthClipEnabled = false
+        };
+
+        public readonly static RasterizerStateDescription RSSkyDome = new RasterizerStateDescription()
+        {
+            FillMode = FillMode.Solid,
+            CullMode = CullMode.Back,
+            DepthBias = 0,
+            DepthBiasClamp = 0,
+            SlopeScaledDepthBias = +0,
+            IsFrontCounterClockwise = false,
             IsMultisampleEnabled = false,
             IsAntialiasedLineEnabled = false,
             IsDepthClipEnabled = false

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\ScreenSpacedMeshRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\ShadowMapCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\SkyBoxRenderCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\SkyDomeRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DefaultShaders\DefaultBuffers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DefaultShaders\DefaultComputeShaders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DefaultShaders\DefaultDomainShaders.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
@@ -94,12 +94,13 @@ namespace HelixToolkit.UWP.Utilities
         /// Creates the view.
         /// </summary>
         /// <param name="stream">The stream.</param>
-        public void CreateView(System.IO.Stream stream)
+        /// <param name="disableAutoGenMipMap">Disable auto mipmaps generation</param>
+        public void CreateView(System.IO.Stream stream, bool disableAutoGenMipMap = false)
         {
             this.DisposeAndClear();
             if (stream != null && device != null)
             {
-                textureView = Collect(TextureLoader.FromMemoryAsShaderResourceView(device, stream));
+                textureView = Collect(TextureLoader.FromMemoryAsShaderResourceView(device, stream, disableAutoGenMipMap));
             }
         }
         /// <summary>


### PR DESCRIPTION
Fix #702. Disable mipmap for environment cube map.
Add a SkyDome render core. Not used for now.