### PR TITLE
Improve RenderHost. Implement dynamic cube map

### DIFF
--- a/Source/Examples/UWP/SimpleDemo/MainPage.xaml
+++ b/Source/Examples/UWP/SimpleDemo/MainPage.xaml
@@ -34,13 +34,15 @@
             <hx:DirectionalLight3D Direction="{Binding DirectionalLightDirection}" Color="White" />
             <hx:EnvironmentMap3D Texture="{Binding EnvironmentMap}" />
             <hx:GroupModel3D IsThrowingShadow="True">
-                <hx:MeshGeometryModel3D
+                <hx:DynamicReflectionMap3D>
+                    <hx:MeshGeometryModel3D
                     CullMode="Back"
                     Geometry="{Binding Geometry}"
                     IsThrowingShadow="True"
                     Material="{Binding Material1}"
                     RenderEnvironmentMap="True"
                     RenderShadowMap="True" />
+                </hx:DynamicReflectionMap3D>
                 <hx:LineGeometryModel3D
                     Geometry="{Binding LineGeometry}"
                     IsThrowingShadow="True"
@@ -80,12 +82,11 @@
                     Color="#00D13E" />
             </hx:GroupModel3D>
             <hx:MeshGeometryModel3D
-                x:Name="floor"
-                CullMode="Back"
-                Geometry="{Binding FloorModel}"
-                Material="{Binding FloorMaterial}"
-                RenderEnvironmentMap="True"
-                RenderShadowMap="True" />
+                    x:Name="floor"
+                    CullMode="Back"
+                    Geometry="{Binding FloorModel}"
+                    Material="{Binding FloorMaterial}"
+                    RenderShadowMap="True" />
             <hx:PostEffectMeshBorderHighlight EffectName="border" NumberOfBlurPass="2" />
         </hx:Viewport3DX>
         <TextBlock

--- a/Source/Examples/UWP/SimpleDemo/MainPage.xaml
+++ b/Source/Examples/UWP/SimpleDemo/MainPage.xaml
@@ -37,8 +37,9 @@
                 <hx:DynamicReflectionMap3D>
                     <hx:MeshGeometryModel3D
                     CullMode="Back"
-                    Geometry="{Binding Geometry}"
-                    IsThrowingShadow="True"
+                    Geometry="{Binding Sphere}"
+                    IsThrowingShadow="True" 
+                    RenderNormalMap="False"
                     Material="{Binding Material1}"
                     RenderEnvironmentMap="True"
                     RenderShadowMap="True" />

--- a/Source/Examples/UWP/SimpleDemo/MainPageViewModel.cs
+++ b/Source/Examples/UWP/SimpleDemo/MainPageViewModel.cs
@@ -15,7 +15,7 @@ namespace SimpleDemoW10
 {
     public class MainPageViewModel : ObservableObject
     {
-
+        public Geometry3D Sphere { private set; get; }
         public Geometry3D Geometry { private set; get; }
 
         public Geometry3D LineGeometry { private set; get; }
@@ -101,6 +101,10 @@ namespace SimpleDemoW10
             builder.AddBox(new SharpDX.Vector3(0, 0, 0), 2, 2, 2);
             builder.AddSphere(new Vector3(0, 2, 0), 1.5);
             Geometry = builder.ToMesh();
+            builder = new MeshBuilder();
+            builder.AddSphere(new Vector3(0, 2, 0), 2);
+            Sphere = builder.ToMesh();
+
             Material = new PhongMaterial()
             {
                 AmbientColor = Color.Gray,

--- a/Source/Examples/UWP/SimpleDemo/MainPageViewModel.cs
+++ b/Source/Examples/UWP/SimpleDemo/MainPageViewModel.cs
@@ -136,6 +136,7 @@ namespace SimpleDemoW10
             FloorModel = builder.ToMesh();
 
             FloorMaterial = PhongMaterials.Obsidian;
+            FloorMaterial.ReflectiveColor = Color.Silver;
 
             EnvironmentMap = LoadTexture("Cubemap_Grandcanyon.dds");
 

--- a/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/EnvironmentMapDemo.csproj
+++ b/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/EnvironmentMapDemo.csproj
@@ -119,6 +119,10 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Content Include="..\..\..\..\Models\obj\teapot_quads_tex\teapot_quads_tex.obj">
+      <Link>teapot_quads_tex.obj</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="FodyWeavers.xml" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/MainViewModel.cs
@@ -10,6 +10,7 @@ namespace EnvironmentMapDemo
     using HelixToolkit.Wpf;
     using HelixToolkit.Wpf.SharpDX;
     using SharpDX;
+    using System.Collections.Generic;
     using System.IO;
     using Media3D = System.Windows.Media.Media3D;
     using Point3D = System.Windows.Media.Media3D.Point3D;
@@ -18,12 +19,19 @@ namespace EnvironmentMapDemo
     public class MainViewModel : BaseViewModel
     {        
         public MeshGeometry3D Model { get; private set; }
+        public MeshGeometry3D Model1 { get; private set; }
         public PhongMaterial ModelMaterial { get; set; }
         public Media3D.Transform3D ModelTransform { get; private set; }
         public Vector3 DirectionalLightDirection { get; private set; }
         public Color4 DirectionalLightColor { get; private set; }
         public Color4 AmbientLightColor { get; private set; }
 
+        public List<Matrix> Instances1 { private set; get; } = new List<Matrix>();
+        public List<Matrix> Instances2 { private set; get; } = new List<Matrix>();
+        public List<Matrix> Instances3 { private set; get; } = new List<Matrix>();
+        public PhongMaterial ModelMaterial1 { get; set; }
+        public PhongMaterial ModelMaterial2 { get; set; }
+        public PhongMaterial ModelMaterial3 { get; set; }
         public Stream SkyboxTexture { private set; get; }
 
         public MainViewModel()
@@ -41,21 +49,64 @@ namespace EnvironmentMapDemo
             this.DirectionalLightDirection = new Vector3(-2, -1, 1);
 
             // scene model3d
+            LoadModel("teapot_quads_tex.obj", MeshFaces.Default);
+            this.ModelTransform = new Media3D.TranslateTransform3D();
+            this.ModelMaterial = PhongMaterials.PolishedSilver;
+            this.ModelMaterial.ReflectiveColor = Color.Silver;
+
             var b1 = new MeshBuilder(true);
             b1.AddSphere(new Vector3(0, 0, 0), 1.0, 64, 64);
             b1.AddBox(new Vector3(0, 0, 0), 1, 0.5, 3, BoxFaces.All);
-
-            this.Model = b1.ToMeshGeometry3D();
-            this.ModelTransform = new Media3D.TranslateTransform3D();
-            this.ModelMaterial = PhongMaterials.Copper;
+            this.Model1 = b1.ToMeshGeometry3D();
 
             EffectsManager = new DefaultEffectsManager();
             RenderTechnique = EffectsManager[DefaultRenderTechniqueNames.Blinn];
 
             SkyboxTexture = LoadFileToMemory("Cubemap_Grandcanyon.dds");
+            int t = 5;
+            for (int i = 0; i < 10; ++i)
+            {
+                Instances1.Add(Matrix.Translation(new Vector3(t, t, (i - 5) * t)));
+            }
+            for (int i = 0; i < 10; ++i)
+            {
+                Instances2.Add(Matrix.Translation(new Vector3(t, (i - 5) * t, t)));
+            }
+            for (int i = 0; i < 10; ++i)
+            {
+                Instances3.Add(Matrix.Translation(new Vector3(-(i - 5) * t, t, (i - 5) * t)));
+            }
+            //int t = 5;
+            //Instances.Add(Matrix.Translation(new Vector3(t, t, t)));
+            //Instances.Add(Matrix.Translation(new Vector3(-t, t, t)));
+            //Instances.Add(Matrix.Translation(new Vector3(-t, -t, t)));
+            //Instances.Add(Matrix.Translation(new Vector3(-t, -t, -t)));
+            //Instances.Add(Matrix.Translation(new Vector3(t, -t, t)));
+            //Instances.Add(Matrix.Translation(new Vector3(t, -t, -t)));
+            //Instances.Add(Matrix.Translation(new Vector3(-t, t, -t)));
+            //Instances.Add(Matrix.Translation(new Vector3(t, t, -t)));
+            this.ModelMaterial1 = PhongMaterials.Red;
+            this.ModelMaterial1.AmbientColor = Color.Red;
+
+            this.ModelMaterial2 = PhongMaterials.Green;
+            this.ModelMaterial2.AmbientColor = Color.Green;
+
+            this.ModelMaterial3 = PhongMaterials.Blue;
+            this.ModelMaterial3.AmbientColor = Color.Blue;
+        }
+
+        /// <summary>
+        /// load the model from obj-file
+        /// </summary>
+        /// <param name="filename">filename</param>
+        /// <param name="faces">Determines if facades should be treated as triangles (Default) or as quads (Quads)</param>
+        private void LoadModel(string filename, MeshFaces faces)
+        {
+            // load model
+            var reader = new ObjReader();
+            var objModel = reader.Read(filename, new ModelInfo() { Faces = faces });
+            var model = objModel[0].Geometry as MeshGeometry3D;
+            Model = model;
         }
     }
-
-
-
 }

--- a/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/MainWindow.xaml
@@ -36,7 +36,7 @@
             BackgroundColor="Black"
             EffectsManager="{Binding EffectsManager}"
             RenderTechnique="{Binding RenderTechnique}"
-            ShowCoordinateSystem="True" EnableSwapChainRendering="True" EnableD2DRendering="False"
+            ShowCoordinateSystem="True"
             SubTitle="{Binding SubTitle}"
             TextBrush="Black"
             UseDefaultGestures="False">
@@ -57,7 +57,7 @@
             <!--<hx:DirectionalLight3D Direction="1, -1, -1" Color="{Binding DirectionalLightColor}" />
             <hx:DirectionalLight3D Direction="1,1,1" Color="{Binding DirectionalLightColor}" />-->
             <hx:EnvironmentMap3D x:Name="envMap" Texture="{Binding SkyboxTexture}" />
-            <hx:DynamicReflectionMap3D>
+            <hx:DynamicReflectionMap3D x:Name="dynReflector">
                 <hx:MeshGeometryModel3D
                     x:Name="model"
                     Geometry="{Binding Model}"
@@ -121,39 +121,28 @@
                 <Expander.Background>
                     <SolidColorBrush Opacity="0.25" Color="WhiteSmoke" />
                 </Expander.Background>
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
+                <StackPanel Orientation="Vertical">
                     <CheckBox
-                        Grid.Row="0"
                         Margin="{StaticResource MarginSmall}"
                         IsChecked="{Binding RenderEnvironmentMap, ElementName=model}">
                         Reflect Environment Map
                     </CheckBox>
                     <CheckBox
-                        Grid.Row="1"
                         Margin="{StaticResource MarginSmall}"
                         IsChecked="{Binding IsRendering, ElementName=envMap}">
                         Render Environment Map
                     </CheckBox>
-                    <TextBlock Grid.Row="2" Margin="{StaticResource MarginSmall}">Material:</TextBlock>
+                    <CheckBox IsChecked="{Binding ElementName=dynReflector, Path=EnableReflector}">Render Dynamic CubeMap</CheckBox>                    
+                    <TextBlock Margin="{StaticResource MarginSmall}">Material:</TextBlock>
                     <ComboBox
-                        Grid.Row="3"
                         Margin="{StaticResource MarginSmall}"
                         DisplayMemberPath="Name"
                         ItemsSource="{Binding Source={StaticResource PhongMaterials}}"
                         SelectedItem="{Binding ModelMaterial}" />
                     <local:MaterialControl
-                        Grid.Row="4"
                         Margin="{StaticResource MarginSmall}"
                         DataContext="{Binding ModelMaterial}" />
-                </Grid>
+                </StackPanel>
             </Expander>
         </StackPanel>
 

--- a/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/EnvironmentMapDemo/MainWindow.xaml
@@ -33,9 +33,10 @@
             Grid.Row="0"
             Camera="{Binding Camera}"
             CoordinateSystemLabelForeground="White"
+            BackgroundColor="Black"
             EffectsManager="{Binding EffectsManager}"
             RenderTechnique="{Binding RenderTechnique}"
-            ShowCoordinateSystem="True"
+            ShowCoordinateSystem="True" EnableSwapChainRendering="True" EnableD2DRendering="False"
             SubTitle="{Binding SubTitle}"
             TextBrush="Black"
             UseDefaultGestures="False">
@@ -51,15 +52,35 @@
                 <MouseBinding Command="hx:ViewportCommands.Zoom" Gesture="MiddleClick" />
                 <MouseBinding Command="hx:ViewportCommands.Pan" Gesture="LeftClick" />
             </hx:Viewport3DX.InputBindings>
-            <hx:AmbientLight3D Color="{Binding AmbientLightColor}" />
-            <hx:DirectionalLight3D Direction="{Binding Camera.LookDirection}" Color="{Binding DirectionalLightColor}" />
+            <hx:AmbientLight3D Color="#A5A5A5" />
+            <hx:DirectionalLight3D Direction="0,-1, -0.5" Color="{Binding DirectionalLightColor}" />
+            <!--<hx:DirectionalLight3D Direction="1, -1, -1" Color="{Binding DirectionalLightColor}" />
+            <hx:DirectionalLight3D Direction="1,1,1" Color="{Binding DirectionalLightColor}" />-->
             <hx:EnvironmentMap3D x:Name="envMap" Texture="{Binding SkyboxTexture}" />
+            <hx:DynamicReflectionMap3D>
+                <hx:MeshGeometryModel3D
+                    x:Name="model"
+                    Geometry="{Binding Model}"
+                    Material="{Binding ModelMaterial}"
+                    RenderEnvironmentMap="True"
+                    Transform="{Binding ModelTransform}" />                
+            </hx:DynamicReflectionMap3D>
+
             <hx:MeshGeometryModel3D
-                x:Name="model"
-                Geometry="{Binding Model}"
-                Material="{Binding ModelMaterial}"
+                Geometry="{Binding Model1}" CullMode="Back"
+                Material="{Binding ModelMaterial1}"
                 RenderEnvironmentMap="True"
-                Transform="{Binding ModelTransform}" />
+                Instances="{Binding Instances1}"/>
+            <hx:MeshGeometryModel3D
+                Geometry="{Binding Model1}" CullMode="Back"
+                Material="{Binding ModelMaterial2}"
+                RenderEnvironmentMap="True"
+                Instances="{Binding Instances2}"/>
+            <hx:MeshGeometryModel3D
+                Geometry="{Binding Model1}" CullMode="Back"
+                Material="{Binding ModelMaterial3}"
+                RenderEnvironmentMap="True"
+                Instances="{Binding Instances3}"/>
         </hx:Viewport3DX>
 
         <StackPanel>

--- a/Source/Examples/WPF.SharpDX/GroupElementTester/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/GroupElementTester/MainWindow.xaml
@@ -51,7 +51,7 @@
                 <MouseBinding Command="hx:ViewportCommands.Pan" Gesture="LeftClick" />
             </hx:Viewport3DX.InputBindings>
             <hx:DirectionalLight3D Direction="{Binding Camera.LookDirection}" Color="White" />
-            <hx:GroupModel3D ItemsSource="{Binding GroupModelSource}" Transform="{Binding GroupModel3DTransform}">
+            <hx:GroupModel3D x:Name="group1" ItemsSource="{Binding GroupModelSource}" Transform="{Binding GroupModel3DTransform}">
                 <hx:MeshGeometryModel3D
                     Geometry="{Binding SphereModel}"
                     Material="{Binding RedMaterial}"
@@ -69,7 +69,7 @@
                     Material="{Binding RedMaterial}"
                     Transform="{Binding Transform4}" />
             </hx:GroupModel3D>
-            <hx:ItemsModel3D ItemsSource="{Binding ItemsSource}" Transform="{Binding ItemsModel3DTransform}">
+            <hx:ItemsModel3D x:Name="itemsModel1" ItemsSource="{Binding ItemsSource}" Transform="{Binding ItemsModel3DTransform}">
                 <hx:ItemsModel3D.ItemTemplate>
                     <DataTemplate>
                         <hx:MeshGeometryModel3D
@@ -83,7 +83,7 @@
                 <hx:LineGeometryModel3D Geometry="{Binding AxisModel}" Color="White" />
                 <hx:BillboardTextModel3D x:Name="text" Geometry="{Binding AxisLabel}" />
             </hx:CompositeModel3D>
-            <hx:SortingGroupModel3D ItemsSource="{Binding TransparentGroupModelSource}"/>
+            <hx:SortingGroupModel3D x:Name="sortingGroup1" ItemsSource="{Binding TransparentGroupModelSource}"/>
         </hx:Viewport3DX>
         <StackPanel
             Grid.Column="1"
@@ -101,6 +101,10 @@
             <Separator />
             <Button Command="{Binding AddTransparentGroupModelCommand}">Add Transparent Model</Button>
             <Button Command="{Binding RemoveTransparentGroupModelCommand}">Remove Transparent Model</Button>
+            <Separator/>
+            <CheckBox IsChecked="{Binding ElementName=group1, Path=IsRendering}">Visibility Group1</CheckBox>
+            <CheckBox IsChecked="{Binding ElementName=itemsModel1, Path=IsRendering}">Visibility ItemsGroup1</CheckBox>
+            <CheckBox IsChecked="{Binding ElementName=sortingGroup1, Path=IsRendering}">Sorting Group1</CheckBox>
         </StackPanel>
     </Grid>
 </Window>

--- a/Source/Examples/WPF.SharpDX/LightingDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/LightingDemo/MainViewModel.cs
@@ -34,6 +34,7 @@ namespace LightingDemo
         public MeshGeometry3D FlyingObject { get; private set; }
         public LineGeometry3D CubeEdges { get; private set; }
         public Transform3D ModelTransform { get; private set; }
+        public Transform3D Model1Transform { get; private set; }
         public Transform3D FloorTransform { get; private set; }
         public Transform3D Light1Transform { get; private set; }
         public Transform3D Light2Transform { get; private set; }
@@ -53,6 +54,7 @@ namespace LightingDemo
         public Transform3D Object8Transform { get; private set; }
 
         public PhongMaterial ModelMaterial { get; set; }
+        public PhongMaterial ReflectMaterial { get; set; }
         public PhongMaterial FloorMaterial { get; set; }
         public PhongMaterial LightModelMaterial { get; set; }
         public PhongMaterial ObjectMaterial { set; get; } = PhongMaterials.Red;
@@ -206,6 +208,10 @@ namespace LightingDemo
             this.Light4Transform = CreateAnimatedTransform2(-Light4Direction * 2, new Vector3D(0,1,0), 24);
             this.Light4DirectionTransform = CreateAnimatedTransform2(-Light4Direction, new Vector3D(1, 0, 0), 12);
 
+            var transformGroup = new Media3D.Transform3DGroup();
+            transformGroup.Children.Add(new Media3D.ScaleTransform3D(10, 10, 10));
+            transformGroup.Children.Add(new Media3D.TranslateTransform3D(2, -4, 2));
+            Model1Transform = transformGroup;
             // ----------------------------------------------
             // light model3d
             var sphere = new MeshBuilder();
@@ -257,7 +263,9 @@ namespace LightingDemo
             };
             ModelMaterial.DiffuseMap = FloorMaterial.DiffuseMap;
 
-            
+            ReflectMaterial = PhongMaterials.PolishedSilver;
+            ReflectMaterial.ReflectiveColor = global::SharpDX.Color.Silver;
+
             InitialObjectTransforms();
         }
 

--- a/Source/Examples/WPF.SharpDX/LightingDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/LightingDemo/MainWindow.xaml
@@ -118,6 +118,18 @@
                     RenderNormalMap="{Binding RenderNormalMap}"
                     RenderShadowMap="True"
                     Transform="{Binding ModelTransform}" />
+                <hx:DynamicReflectionMap3D>
+                    <hx:MeshGeometryModel3D
+                        x:Name="model1"
+                        Geometry="{Binding Sphere}" 
+                        CullMode="Back"
+                        IsThrowingShadow="{Binding ElementName=view1, Path=IsShadowMappingEnabled}"
+                        Material="{Binding ReflectMaterial}"
+                        RenderShadowMap="True"
+                        RenderEnvironmentMap="True"
+                        Transform="{Binding Model1Transform}" />                    
+                </hx:DynamicReflectionMap3D>
+
                 <hx:GroupModel3D IsThrowingShadow="{Binding ElementName=view1, Path=IsShadowMappingEnabled}">
                     <hx:MeshGeometryModel3D
                         CullMode="Back"

--- a/Source/HelixToolkit.SharpDX.ShaderBuilder/PS/psMeshBlinnPhong.hlsl
+++ b/Source/HelixToolkit.SharpDX.ShaderBuilder/PS/psMeshBlinnPhong.hlsl
@@ -52,9 +52,12 @@ float4 calcBlinnPhongLighting(float4 LColor, float4 vMaterialTexture, float3 N, 
 //--------------------------------------------------------------------------------------
 float4 cubeMapReflection(PSInput input, float4 I)
 {
+    float a = I.a;
     float3 v = normalize((float3) input.wp - vEyePos);
     float3 r = reflect(v, input.n);
-    return (1.0f - vMaterialReflect) * I + vMaterialReflect * texCubeMap.Sample(samplerCube, r);
+    I = (1.0f - vMaterialReflect) * I + vMaterialReflect * texCubeMap.Sample(samplerCube, r);
+    I.a = a;
+    return I;
 }
 
 //--------------------------------------------------------------------------------------

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
@@ -26,6 +26,9 @@ namespace HelixToolkit.UWP.Core
         /// </summary>
         public RasterizerStateProxy RasterState { get { return rasterState; } }
 
+        private RasterizerStateProxy invertCullModeState = null;
+        public RasterizerStateProxy InvertCullModeState { get { return invertCullModeState; } }
+
         /// <summary>
         /// 
         /// </summary>
@@ -200,10 +203,17 @@ namespace HelixToolkit.UWP.Core
         protected virtual bool CreateRasterState(RasterizerStateDescription description, bool force)
         {
             RemoveAndDispose(ref rasterState);
+            RemoveAndDispose(ref invertCullModeState);
             rasterDescription = description;
             if (!IsAttached && !force)
             { return false; }
             rasterState = Collect(EffectTechnique.EffectsManager.StateManager.Register(description));
+            if(description.CullMode != CullMode.None)
+            {
+                var invCull = description;
+                invCull.CullMode = description.CullMode == CullMode.Back ? CullMode.Front : CullMode.Back;
+                invertCullModeState = Collect(EffectTechnique.EffectsManager.StateManager.Register(invCull));
+            }
             return true;
         }
         /// <summary>
@@ -224,6 +234,13 @@ namespace HelixToolkit.UWP.Core
             return false;
         }
 
+        protected override void OnDetach()
+        {
+            rasterState = null;
+            invertCullModeState = null;
+            base.OnDetach();
+        }
+
         /// <summary>
         /// 
         /// </summary>
@@ -238,9 +255,17 @@ namespace HelixToolkit.UWP.Core
         /// Set all necessary states and buffers
         /// </summary>
         /// <param name="context"></param>
-        protected override void OnBindRasterState(DeviceContextProxy context)
+        /// <param name="isInvertCullMode"></param>
+        protected override void OnBindRasterState(DeviceContextProxy context, bool isInvertCullMode)
         {
-            context.SetRasterState(rasterState);
+            if (isInvertCullMode && invertCullModeState != null)
+            {
+                context.SetRasterState(invertCullModeState);
+            }
+            else
+            {
+                context.SetRasterState(rasterState);
+            }
         }
         /// <summary>
         /// Attach vertex buffer routine

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
@@ -25,6 +25,7 @@ namespace HelixToolkit.UWP.Core
         /// 
         /// </summary>
         public RasterizerStateProxy RasterState { get { return rasterState; } }
+
         /// <summary>
         /// 
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
@@ -66,6 +66,7 @@ namespace HelixToolkit.UWP.Core
             }
             get { return isThrowingShadow; }
         }
+
         /// <summary>
         /// Gets or sets the default state binding.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
@@ -7,7 +7,9 @@ using SharpDX.Direct3D11;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-
+#if DX11_1
+using Device = SharpDX.Direct3D11.Device1;
+#endif
 #if !NETFX_CORE
 namespace HelixToolkit.Wpf.SharpDX.Core
 #else

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
@@ -105,32 +105,6 @@ namespace HelixToolkit.UWP.Core
         /// Is render core has been attached
         /// </summary>
         public bool IsAttached { private set; get; } = false;
-
-        /// <summary>
-        /// Gets or sets the post effects.
-        /// </summary>
-        /// <value>
-        /// The post effects.
-        /// </value>
-        private readonly Dictionary<string, IEffectAttributes> postEffectNames = new Dictionary<string, IEffectAttributes>();
-
-        /// <summary>
-        /// Gets the post effect names.
-        /// </summary>
-        /// <value>
-        /// The post effect names.
-        /// </value>
-        public IEnumerable<string> PostEffectNames
-        {
-            get { return postEffectNames.Keys; }
-        }
-        /// <summary>
-        /// Gets a value indicating whether this instance has any post effect.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance has any post effect; otherwise, <c>false</c>.
-        /// </value>
-        public bool HasAnyPostEffect { get { return postEffectNames.Count > 0; } }
         #endregion
 
         /// <summary>
@@ -208,7 +182,6 @@ namespace HelixToolkit.UWP.Core
             OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
         }
 
-
         /// <summary>
         /// 
         /// </summary>
@@ -229,62 +202,5 @@ namespace HelixToolkit.UWP.Core
             InvalidateRenderer();
             return true;
         }
-
-        #region POST EFFECT        
-
-        /// <summary>
-        /// Adds the post effect.
-        /// </summary>
-        /// <param name="effect">The effect.</param>
-        public void AddPostEffect(IEffectAttributes effect)
-        {
-            if (postEffectNames.ContainsKey(effect.EffectName))
-            {
-                return;
-            }
-            postEffectNames.Add(effect.EffectName, effect);
-            InvalidateRenderer();
-        }
-        /// <summary>
-        /// Removes the post effect.
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        public void RemovePostEffect(string effectName)
-        {
-            if (postEffectNames.Remove(effectName))
-            {
-                InvalidateRenderer();
-            }
-        }
-        /// <summary>
-        /// Determines whether [has post effect] [the specified effect name].
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        /// <returns>
-        ///   <c>true</c> if [has post effect] [the specified effect name]; otherwise, <c>false</c>.
-        /// </returns>
-        public bool HasPostEffect(string effectName)
-        {
-            return postEffectNames.ContainsKey(effectName);
-        }
-        /// <summary>
-        /// Tries the get post effect.
-        /// </summary>
-        /// <param name="effectName">Name of the effect.</param>
-        /// <param name="effect">The effect.</param>
-        /// <returns></returns>
-        public bool TryGetPostEffect(string effectName, out IEffectAttributes effect)
-        {
-            return postEffectNames.TryGetValue(effectName, out effect);
-        }
-        /// <summary>
-        /// Clears the post effect.
-        /// </summary>
-        public void ClearPostEffect()
-        {
-            postEffectNames.Clear();
-            InvalidateRenderer();
-        }
-        #endregion
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
@@ -72,7 +72,7 @@ namespace HelixToolkit.UWP.Core
                 int vertStartSlot = 0;
                 OnAttachBuffers(deviceContext, ref vertStartSlot);
                 OnUploadPerModelConstantBuffers(deviceContext);
-                OnBindRasterState(deviceContext);
+                OnBindRasterState(deviceContext, context.IsInvertCullMode);
                 switch (context.IsShadowPass)
                 {
                     case true:
@@ -131,7 +131,8 @@ namespace HelixToolkit.UWP.Core
         /// Set model default raster state
         /// </summary>
         /// <param name="context"></param>
-        protected virtual void OnBindRasterState(DeviceContextProxy context)
+        /// <param name="isInvertCullMode"></param>
+        protected virtual void OnBindRasterState(DeviceContextProxy context, bool isInvertCullMode)
         { }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DepthPrepassCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DepthPrepassCore.cs
@@ -41,9 +41,9 @@ namespace HelixToolkit.UWP.Core
         {
             context.IsCustomPass = true;
             context.CustomPassName = DefaultPassNames.DepthPrepass;
-            for (int i = 0; i < context.RenderHost.PerFrameGeneralRenderCores.Count; ++i)
+            for (int i = 0; i < context.RenderHost.PerFrameGeneralNodes.Count; ++i)
             {
-                var core = context.RenderHost.PerFrameGeneralRenderCores[i];
+                var core = context.RenderHost.PerFrameGeneralNodes[i];
                 if (core.RenderType == RenderType.Opaque)
                 {
                     var pass = core.EffectTechnique[DefaultPassNames.DepthPrepass];

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -220,7 +220,7 @@ namespace HelixToolkit.UWP.Core
 
         private int cubeTextureSlot;
         private int textureSamplerSlot;
-        private SamplerState textureSampler;
+        private SamplerStateProxy textureSampler;
 
         private IDeviceContextPool contextPool;
 
@@ -361,7 +361,7 @@ namespace HelixToolkit.UWP.Core
 #endif
             {
                 var ctx = contextPool.Get();
-                ctx.DeviceContext.ClearRenderTargetView(cubeRTVs[index], Color.White);
+                ctx.DeviceContext.ClearRenderTargetView(cubeRTVs[index], context.RenderHost.ClearColor);
                 ctx.DeviceContext.ClearDepthStencilView(cubeDSVs[index], DepthStencilClearFlags.Depth, 1, 0);
                 ctx.DeviceContext.OutputMerger.SetRenderTargets(cubeDSVs[index], cubeRTVs[index]);
                 ctx.DeviceContext.Rasterizer.SetViewport(viewport);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -359,8 +359,7 @@ namespace HelixToolkit.UWP.Core
                         context.RenderHost.PerFrameGeneralNodes[i].Render(context, ctx);
                     }
                 }
-                commands[index] = ctx.DeviceContext.FinishCommandList(true);
-                ctx.DeviceContext.OutputMerger.ResetTargets();
+                commands[index] = ctx.DeviceContext.FinishCommandList(false);
                 contextPool.Put(ctx);
             }
 #if !TEST

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -40,10 +40,23 @@ namespace HelixToolkit.UWP.Core
         // The DSVs, one for each face of cubemap
         private DepthStencilView[] cubeDSVs = new DepthStencilView[6];
 
+        private int faceSize = 256;
         public int FaceSize
         {
-            set; get;
-        } = 256;
+            set
+            {
+                if(Set(ref faceSize, value) && IsAttached)
+                {
+                    var effect = this.EffectTechnique;
+                    Detach();
+                    Attach(effect);
+                }
+            }
+            get
+            {
+                return faceSize;
+            }
+        }
 
         private string defaultPassName = DefaultPassNames.Default;
         /// <summary>
@@ -169,6 +182,7 @@ namespace HelixToolkit.UWP.Core
         {
             set; get;
         }
+
         /// <summary>
         /// Gets or sets the name of the shader cube texture.
         /// </summary>
@@ -366,7 +380,7 @@ namespace HelixToolkit.UWP.Core
             for (int i = 0; i < 6; ++i)
             {
                 cubeFaceCameras.Cameras[i].View = (LeftHanded ? Matrix.LookAtLH(camPos, targets[i], upVectors[i]) : Matrix.LookAtRH(camPos, targets[i], upVectors[i])) * Matrix.Scaling(-1, 1, 1);
-                cubeFaceCameras.Cameras[i].Projection = LeftHanded ? Matrix.PerspectiveFovLH((float)Math.PI * 0.5f, 1, NearField, FarField) 
+                cubeFaceCameras.Cameras[i].Projection = LeftHanded ? Matrix.PerspectiveFovLH((float)Math.PI * 0.5f, 1, NearField, FarField)
                     : Matrix.PerspectiveFovRH((float)Math.PI * 0.5f, 1, NearField, FarField);
             }
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -162,7 +162,7 @@ namespace HelixToolkit.UWP.Core
         private Viewport viewport;
 
 
-        public DynamicCubeMapCore() : base(RenderType.PreProc)
+        public DynamicCubeMapCore() : base(RenderType.Opaque)
         {
         }
 
@@ -258,11 +258,11 @@ namespace HelixToolkit.UWP.Core
                 transforms.ViewProjection = transforms.View * transforms.ViewProjection;
                 ModelConstBuffer.UploadDataToBuffer(ctx, ref transforms);
 
-                for(int i =0; i< context.RenderHost.PerFrameGeneralRenderCores.Count; ++i)
+                for(int i =0; i< context.RenderHost.PerFrameGeneralNodes.Count; ++i)
                 {
-                    if (!IgnoredGuid.Contains(context.RenderHost.PerFrameGeneralRenderCores[i].GUID))
+                    if (!IgnoredGuid.Contains(context.RenderHost.PerFrameGeneralNodes[i].GUID))
                     {
-                        context.RenderHost.PerFrameGeneralRenderCores[i].Render(context, ctx);
+                        context.RenderHost.PerFrameGeneralNodes[i].Render(context, ctx);
                     }
                 }
                 commands[index] = ctx.DeviceContext.FinishCommandList(true);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -343,6 +343,7 @@ namespace HelixToolkit.UWP.Core
 
         protected override void OnRender(IRenderContext context, DeviceContextProxy deviceContext)
         {
+            context.IsInvertCullMode = true;
 #if TEST
             for (int index = 0; index < 6; ++index)
 #else
@@ -380,6 +381,7 @@ namespace HelixToolkit.UWP.Core
 #if !TEST
             );
 #endif
+            context.IsInvertCullMode = false;
             for (int i = 0; i < commands.Length; ++i)
             {
                 Device.ImmediateContext.ExecuteCommandList(commands[i], true);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -40,13 +40,24 @@ namespace HelixToolkit.UWP.Core
             }
         }
 
-        private ShaderResourceViewProxy cubeDSV;
-
-        // The RTVs, one for each face of cubemap
-        private RenderTargetView[] cubeRTVs = new RenderTargetView[6];
-
-        // The DSVs, one for each face of cubemap
-        private DepthStencilView[] cubeDSVs = new DepthStencilView[6];
+        private bool enableReflector = true;
+        /// <summary>
+        /// Gets or sets a value indicating whether [enable reflector].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable reflector]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableReflector
+        {
+            set
+            {
+                SetAffectsRender(ref enableReflector, value);
+            }
+            get
+            {
+                return enableReflector;
+            }
+        }
 
         private int faceSize = 256;
 
@@ -217,7 +228,13 @@ namespace HelixToolkit.UWP.Core
         public string ShaderCubeTextureSamplerName { set; get; } = DefaultSamplerStateNames.CubeMapSampler;
 
         #endregion Properties
+        private ShaderResourceViewProxy cubeDSV;
 
+        // The RTVs, one for each face of cubemap
+        private RenderTargetView[] cubeRTVs = new RenderTargetView[6];
+
+        // The DSVs, one for each face of cubemap
+        private DepthStencilView[] cubeDSVs = new DepthStencilView[6];
         private int cubeTextureSlot;
         private int textureSamplerSlot;
         private SamplerStateProxy textureSampler;
@@ -350,6 +367,11 @@ namespace HelixToolkit.UWP.Core
             base.OnDetach();
         }
 
+        protected override bool CanRender(IRenderContext context)
+        {
+            return base.CanRender(context) && EnableReflector;
+        }
+
         protected override void OnRender(IRenderContext context, DeviceContextProxy deviceContext)
         {
             CreateCubeMapResources();
@@ -436,8 +458,11 @@ namespace HelixToolkit.UWP.Core
         {
             currSampler = deviceContext.DeviceContext.PixelShader.GetSamplers(cubeTextureSlot, 1);
             currRes = deviceContext.DeviceContext.PixelShader.GetShaderResources(cubeTextureSlot, 1);
-            deviceContext.DeviceContext.PixelShader.SetShaderResource(cubeTextureSlot, CubeMap);
-            deviceContext.DeviceContext.PixelShader.SetSampler(textureSamplerSlot, textureSampler);
+            if (EnableReflector)
+            {
+                deviceContext.DeviceContext.PixelShader.SetShaderResource(cubeTextureSlot, CubeMap);
+                deviceContext.DeviceContext.PixelShader.SetSampler(textureSamplerSlot, textureSampler);
+            }
         }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -24,6 +24,7 @@ namespace HelixToolkit.UWP.Core
     /// </summary>
     public class DynamicCubeMapCore : RenderCoreBase<GlobalTransformStruct>, IDynamicReflector
     {
+        #region Properties
         public HashSet<Guid> IgnoredGuid { get; } = new HashSet<Guid>();
         private ShaderResourceViewProxy cubeMap;
         public ShaderResourceViewProxy CubeMap
@@ -45,7 +46,7 @@ namespace HelixToolkit.UWP.Core
         {
             set
             {
-                if(Set(ref faceSize, value) && IsAttached)
+                if (Set(ref faceSize, value) && IsAttached)
                 {
                     var effect = this.EffectTechnique;
                     Detach();
@@ -122,16 +123,22 @@ namespace HelixToolkit.UWP.Core
             }
         }
 
-        private bool leftHanded = false;
-        public bool LeftHanded
+        private bool isleftHanded = false;
+        /// <summary>
+        /// Gets or sets a value indicating whether this coordinate system is left handed.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this coordinate system is left handed; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsLeftHanded
         {
             set
             {
-                SetAffectsRender(ref leftHanded, value);
+                SetAffectsRender(ref isleftHanded, value);
             }
             get
             {
-                return leftHanded;
+                return isleftHanded;
             }
         }
 
@@ -196,7 +203,8 @@ namespace HelixToolkit.UWP.Core
         /// <value>
         /// The name of the shader cube texture sampler.
         /// </value>
-        public string ShaderCubeTextureSamplerName { set; get; } = DefaultSamplerStateNames.CubeMapSampler;
+        public string ShaderCubeTextureSamplerName { set; get; } = DefaultSamplerStateNames.CubeMapSampler; 
+        #endregion
 
         private int cubeTextureSlot;
         private int textureSamplerSlot;
@@ -379,8 +387,8 @@ namespace HelixToolkit.UWP.Core
 
             for (int i = 0; i < 6; ++i)
             {
-                cubeFaceCameras.Cameras[i].View = (LeftHanded ? Matrix.LookAtLH(camPos, targets[i], upVectors[i]) : Matrix.LookAtRH(camPos, targets[i], upVectors[i])) * Matrix.Scaling(-1, 1, 1);
-                cubeFaceCameras.Cameras[i].Projection = LeftHanded ? Matrix.PerspectiveFovLH((float)Math.PI * 0.5f, 1, NearField, FarField)
+                cubeFaceCameras.Cameras[i].View = (IsLeftHanded ? Matrix.LookAtLH(camPos, targets[i], upVectors[i]) : Matrix.LookAtRH(camPos, targets[i], upVectors[i])) * Matrix.Scaling(-1, 1, 1);
+                cubeFaceCameras.Cameras[i].Projection = IsLeftHanded ? Matrix.PerspectiveFovLH((float)Math.PI * 0.5f, 1, NearField, FarField)
                     : Matrix.PerspectiveFovRH((float)Math.PI * 0.5f, 1, NearField, FarField);
             }
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -1,0 +1,306 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+//#define TEST
+using System;
+using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using SharpDX;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX.Core
+#else
+namespace HelixToolkit.UWP.Core
+#endif
+{
+    using Shaders;
+    using Render;
+    using Utilities;
+
+
+    public class DynamicCubeMapCore : RenderCoreBase<GlobalTransformStruct>
+    {
+        public HashSet<Guid> IgnoredGuid { get; } = new HashSet<Guid>();
+        private ShaderResourceViewProxy cubeMap;
+        public ShaderResourceViewProxy CubeMap
+        {
+            get
+            {
+                return cubeMap;
+            }
+        }
+
+        private ShaderResourceViewProxy cubeDSV;
+        // The RTVs, one for each face of cubemap
+        private RenderTargetView[] cubeRTVs = new RenderTargetView[6];
+        // The DSVs, one for each face of cubemap
+        private DepthStencilView[] cubeDSVs = new DepthStencilView[6];
+
+        public int FaceSize
+        {
+            set; get;
+        } = 256;
+
+        private string defaultPassName = DefaultPassNames.Default;
+        /// <summary>
+        /// Name of the default pass inside a technique.
+        /// <para>Default: <see cref="DefaultPassNames.Default"/></para>
+        /// </summary>
+        public string DefaultShaderPassName
+        {
+            set
+            {
+                if (Set(ref defaultPassName, value) && IsAttached)
+                {
+                    DefaultShaderPass = EffectTechnique[value];
+                }
+            }
+            get
+            {
+                return defaultPassName;
+            }
+        }
+
+        private IShaderPass defaultShaderPass = NullShaderPass.NullPass;
+        /// <summary>
+        /// 
+        /// </summary>
+        protected IShaderPass DefaultShaderPass
+        {
+            private set
+            {
+                if (Set(ref defaultShaderPass, value))
+                {
+                    cubeTextureSlot = value.GetShader(ShaderStage.Pixel).ShaderResourceViewMapping.TryGetBindSlot(ShaderCubeTextureName);
+                    textureSamplerSlot = value.GetShader(ShaderStage.Pixel).SamplerMapping.TryGetBindSlot(ShaderCubeTextureSamplerName);
+                    InvalidateRenderer();
+                }
+            }
+            get
+            {
+                return defaultShaderPass;
+            }
+        }
+
+        private SamplerStateDescription samplerDescription = DefaultSamplers.CubeSampler;
+        /// <summary>
+        /// Gets or sets the sampler description.
+        /// </summary>
+        /// <value>
+        /// The sampler description.
+        /// </value>
+        public SamplerStateDescription SamplerDescription
+        {
+            set
+            {
+                if (SetAffectsRender(ref samplerDescription, value) && IsAttached)
+                {
+                    RemoveAndDispose(ref textureSampler);
+                    textureSampler = Collect(EffectTechnique.EffectsManager.StateManager.Register(value));
+                }
+            }
+            get
+            {
+                return samplerDescription;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the shader cube texture.
+        /// </summary>
+        /// <value>
+        /// The name of the shader cube texture.
+        /// </value>
+        public string ShaderCubeTextureName { set; get; } = DefaultBufferNames.CubeMapTB;
+        /// <summary>
+        /// Gets or sets the name of the shader cube texture sampler.
+        /// </summary>
+        /// <value>
+        /// The name of the shader cube texture sampler.
+        /// </value>
+        public string ShaderCubeTextureSamplerName { set; get; } = DefaultSamplerStateNames.CubeMapSampler;
+
+        private int cubeTextureSlot;
+        private int textureSamplerSlot;
+        private SamplerState textureSampler;
+
+        private DeviceContextPool contextPool;
+
+        private CubeFaceCamerasStruct cubeFaceCameras = new CubeFaceCamerasStruct() { Cameras = new CubeFaceCamera[6] };
+
+        private Vector3[] targets = new Vector3[6];
+        private Vector3[] upVectors = new Vector3[6] { Vector3.UnitY, Vector3.UnitY, -Vector3.UnitZ, +Vector3.UnitZ, Vector3.UnitY, Vector3.UnitY };
+
+        // Create the cube map TextureCube (array of 6 textures)
+        private Texture2DDescription textureDesc = new Texture2DDescription()
+        {
+            Format = Format.R8G8B8A8_UNorm,
+            ArraySize = 6, // 6-sides of the cube
+            BindFlags = BindFlags.ShaderResource | BindFlags.RenderTarget,
+            OptionFlags = ResourceOptionFlags.GenerateMipMaps | ResourceOptionFlags.TextureCube,
+            SampleDescription = new SampleDescription(1, 0),
+            MipLevels = 0,
+            Usage = ResourceUsage.Default,
+            CpuAccessFlags = CpuAccessFlags.None,
+        };
+
+        private Texture2DDescription dsvTextureDesc = new Texture2DDescription()
+        {
+            Format = Format.R32_Float,
+            BindFlags = BindFlags.DepthStencil,
+            Usage = ResourceUsage.Default,
+            SampleDescription = new SampleDescription(1, 0),
+            CpuAccessFlags = CpuAccessFlags.None,
+            MipLevels = 1,
+            OptionFlags = ResourceOptionFlags.TextureCube,
+            ArraySize = 6
+        };
+
+        private Viewport viewport;
+
+
+        public DynamicCubeMapCore() : base(RenderType.PreProc)
+        {
+        }
+
+        protected override ConstantBufferDescription GetModelConstantBufferDescription()
+        {
+            return new ConstantBufferDescription(DefaultBufferNames.GlobalTransformCB, GlobalTransformStruct.SizeInBytes);
+        }
+
+        protected override bool OnAttach(IRenderTechnique technique)
+        {
+            if (base.OnAttach(technique))
+            {
+                DefaultShaderPass = technique[DefaultShaderPassName];
+                textureDesc.Width = textureDesc.Height = dsvTextureDesc.Width = dsvTextureDesc.Height = FaceSize;
+                cubeMap = Collect(new ShaderResourceViewProxy(Device, textureDesc));
+
+                var srvDesc = new ShaderResourceViewDescription()
+                {
+                    Format = textureDesc.Format,
+                    Dimension = global::SharpDX.Direct3D.ShaderResourceViewDimension.TextureCube,
+                    TextureCube = new ShaderResourceViewDescription.TextureCubeResource() { MostDetailedMip = 0, MipLevels = -1 }
+                };
+                cubeMap.CreateView(srvDesc);
+
+                var rtsDesc = new RenderTargetViewDescription()
+                {
+                    Format = textureDesc.Format,
+                    Dimension = RenderTargetViewDimension.Texture2DArray,
+                    Texture2DArray = new RenderTargetViewDescription.Texture2DArrayResource() { MipSlice = 0, FirstArraySlice = 0, ArraySize = 1 }
+                };
+
+                for (int i = 0; i < 6; ++i)
+                {
+                    rtsDesc.Texture2DArray.FirstArraySlice = i;
+                    cubeRTVs[i] = Collect(new RenderTargetView(Device, CubeMap.Resource, rtsDesc));
+                }
+
+                cubeDSV = Collect(new ShaderResourceViewProxy(Device, dsvTextureDesc));
+                var dsvDesc = new DepthStencilViewDescription()
+                {
+                    Format = dsvTextureDesc.Format,
+                    Dimension = DepthStencilViewDimension.Texture2DArray,
+                    Flags = DepthStencilViewFlags.None,
+                    Texture2DArray = new DepthStencilViewDescription.Texture2DArrayResource() { MipSlice = 0, FirstArraySlice = 0, ArraySize = 1 }
+                };
+
+                for (int i = 0; i < 6; ++i)
+                {
+                    dsvDesc.Texture2DArray.FirstArraySlice = i;
+                    cubeDSVs[i] = Collect(new DepthStencilView(Device, cubeDSV.Resource, dsvDesc));
+                }
+
+                viewport = new Viewport(0, 0, FaceSize, FaceSize);
+
+                contextPool = Collect(new DeviceContextPool(Device));
+                textureSampler = Collect(technique.EffectsManager.StateManager.Register(SamplerDescription));
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        protected override void OnDetach()
+        {
+            contextPool = null;
+            cubeMap = null;
+            cubeDSV = null;
+            for (int i = 0; i < 6; ++i)
+            {
+                cubeRTVs[i] = null;
+                cubeDSVs[i] = null;
+            }           
+            base.OnDetach();
+        }
+
+        protected override void OnRender(IRenderContext context, DeviceContextProxy deviceContext)
+        {
+            var commands = new CommandList[6];
+            Parallel.For(0, 6, (index) => 
+            {
+                var ctx = contextPool.Get();
+                ctx.DeviceContext.ClearRenderTargetView(cubeRTVs[index], Color.Black);
+                ctx.DeviceContext.ClearDepthStencilView(cubeDSVs[index], DepthStencilClearFlags.Depth, 1, 0);
+                ctx.DeviceContext.OutputMerger.SetRenderTargets(cubeDSVs[index], cubeRTVs[index]);
+                ctx.DeviceContext.Rasterizer.SetViewport(viewport);
+                ctx.DeviceContext.Rasterizer.SetScissorRectangle(0, 0, FaceSize, FaceSize);
+                var transforms = new GlobalTransformStruct();
+                transforms.Projection = cubeFaceCameras.Cameras[index].Projection;
+                transforms.View = cubeFaceCameras.Cameras[index].View;
+                transforms.Viewport = new Vector4(0, 0, FaceSize, FaceSize);
+                transforms.ViewProjection = transforms.View * transforms.ViewProjection;
+                ModelConstBuffer.UploadDataToBuffer(ctx, ref transforms);
+
+                for(int i =0; i< context.RenderHost.PerFrameGeneralRenderCores.Count; ++i)
+                {
+                    if (!IgnoredGuid.Contains(context.RenderHost.PerFrameGeneralRenderCores[i].GUID))
+                    {
+                        context.RenderHost.PerFrameGeneralRenderCores[i].Render(context, ctx);
+                    }
+                }
+                commands[index] = ctx.DeviceContext.FinishCommandList(true);
+                ctx.DeviceContext.OutputMerger.ResetTargets();
+                contextPool.Put(ctx);
+            });
+           
+            for(int i=0; i < commands.Length; ++i)
+            {
+                Device.ImmediateContext.ExecuteCommandList(commands[i], true);
+                commands[i].Dispose();
+            }
+            deviceContext.DeviceContext.GenerateMips(CubeMap);
+            deviceContext.SetRenderTargets(context.RenderHost.RenderBuffer);
+            deviceContext.DeviceContext.PixelShader.SetShaderResource(cubeTextureSlot, CubeMap);
+            deviceContext.DeviceContext.PixelShader.SetSampler(textureSamplerSlot, textureSampler);
+        }
+
+        protected override void OnUpdatePerModelStruct(ref GlobalTransformStruct model, IRenderContext context)
+        {
+            var camPos = context.Camera.Position;
+            targets[0] = camPos + Vector3.UnitX;
+            targets[1] = camPos - Vector3.UnitX;
+            targets[2] = camPos + Vector3.UnitY;
+            targets[3] = camPos - Vector3.UnitY;
+            targets[4] = camPos + Vector3.UnitZ;
+            targets[5] = camPos - Vector3.UnitZ;
+
+            for (int i = 0; i < 6; ++i)
+            {
+                cubeFaceCameras.Cameras[i].View = Matrix.LookAtRH(camPos, targets[i], upVectors[i]);
+                cubeFaceCameras.Cameras[i].Projection = Matrix.PerspectiveFovRH((float)Math.PI * 0.5f, 1, 0.1f, 100f);
+            }
+        }
+
+        protected override void OnUploadPerModelConstantBuffers(DeviceContext context)
+        {
+            //ModelConstBuffer.UploadDataToBuffer(context, modelStruct.Cameras, modelStruct.Cameras.Length);
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Core/MeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/MeshRenderCore.cs
@@ -13,7 +13,7 @@ namespace HelixToolkit.UWP.Core
     using global::SharpDX.Direct3D11;
     using global::SharpDX;
     using Utilities;
-    public class MeshRenderCore : MaterialGeometryRenderCore, IMeshRenderParams
+    public class MeshRenderCore : MaterialGeometryRenderCore, IMeshRenderParams, IDynamicReflectable
     {
         /// <summary>
         /// 
@@ -64,6 +64,17 @@ namespace HelixToolkit.UWP.Core
         }
 
         private RasterizerStateProxy rasterStateWireframe = null;
+
+        /// <summary>
+        /// Gets or sets the dynamic reflector.
+        /// </summary>
+        /// <value>
+        /// The dynamic reflector.
+        /// </value>
+        public IDynamicReflector DynamicReflector
+        {
+            set; get;
+        }
         /// <summary>
         /// Gets the raster state wireframe.
         /// </summary>
@@ -110,6 +121,12 @@ namespace HelixToolkit.UWP.Core
             }
         }
 
+        protected override void OnDetach()
+        {
+            DynamicReflector = null;
+            base.OnDetach();
+        }
+
         protected override void OnDefaultPassChanged(IShaderPass pass)
         {
             base.OnDefaultPassChanged(pass);
@@ -128,7 +145,9 @@ namespace HelixToolkit.UWP.Core
             {
                 DefaultShaderPass.GetShader(ShaderStage.Pixel).BindTexture(deviceContext, shadowMapSlot, context.SharedResource.ShadowView);
             }
+            DynamicReflector?.BindCubeMap(deviceContext);
             OnDraw(deviceContext, InstanceBuffer);
+            DynamicReflector?.UnBindCubeMap(deviceContext);
             if (RenderWireframe && WireframePass != NullShaderPass.NullPass)
             {
                 WireframePass.BindShader(deviceContext, false);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectBoomCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectBoomCore.cs
@@ -222,6 +222,9 @@ namespace HelixToolkit.UWP.Core
                     h >>= 2;
                     ++count;
                 }
+                //Skip this frame to avoid performance hit due to texture creation
+                InvalidateRenderer();
+                return;
             }
             #endregion
 

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshOutlineBlurCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshOutlineBlurCore.cs
@@ -279,10 +279,10 @@ namespace HelixToolkit.UWP.Core
 
             context.IsCustomPass = true;
             bool hasMesh = false;
-            for (int i = 0; i < context.RenderHost.PerFrameGeneralCoresWithPostEffect.Count; ++i)
+            for (int i = 0; i < context.RenderHost.PerFrameNodesWithPostEffect.Count; ++i)
             {
                 IEffectAttributes effect;
-                var mesh = context.RenderHost.PerFrameGeneralCoresWithPostEffect[i];
+                var mesh = context.RenderHost.PerFrameNodesWithPostEffect[i];
                 if (mesh.TryGetPostEffect(EffectName, out effect))
                 {
                     object attribute;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshOutlineBlurCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshOutlineBlurCore.cs
@@ -267,6 +267,9 @@ namespace HelixToolkit.UWP.Core
                 blurCore.Resize(deviceContext.DeviceContext.Device,
                     renderTargetDesc.Width / downSamplingScale,
                     renderTargetDesc.Height / downSamplingScale);
+                //Skip this frame to avoid performance hit due to texture creation
+                InvalidateRenderer();
+                return;
             }
             #endregion
 

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRay.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRay.cs
@@ -14,6 +14,7 @@ namespace HelixToolkit.UWP.Core
     using Shaders;
     using System.Collections.Generic;
     using Model;
+    using Model.Scene;
     /// <summary>
     /// 
     /// </summary>
@@ -112,7 +113,7 @@ namespace HelixToolkit.UWP.Core
             Color = global::SharpDX.Color.Blue;
         }
 
-        private readonly List<KeyValuePair<RenderCore, IEffectAttributes>> currentCores = new List<KeyValuePair<RenderCore, IEffectAttributes>>();
+        private readonly List<KeyValuePair<SceneNode, IEffectAttributes>> currentCores = new List<KeyValuePair<SceneNode, IEffectAttributes>>();
 
         /// <summary>
         /// Gets the model constant buffer description.
@@ -135,13 +136,13 @@ namespace HelixToolkit.UWP.Core
             {
                 deviceContext.DeviceContext.ClearDepthStencilView(context.RenderHost.DepthStencilBufferView, DepthStencilClearFlags.Stencil, 0, 0);
                 currentCores.Clear();
-                for (int i = 0; i < context.RenderHost.PerFrameGeneralCoresWithPostEffect.Count; ++i)
+                for (int i = 0; i < context.RenderHost.PerFrameNodesWithPostEffect.Count; ++i)
                 {
                     IEffectAttributes effect;
-                    var mesh = context.RenderHost.PerFrameGeneralCoresWithPostEffect[i];
+                    var mesh = context.RenderHost.PerFrameNodesWithPostEffect[i];
                     if (mesh.TryGetPostEffect(EffectName, out effect))
                     {
-                        currentCores.Add(new KeyValuePair<RenderCore, IEffectAttributes>(mesh, effect));
+                        currentCores.Add(new KeyValuePair<SceneNode, IEffectAttributes>(mesh, effect));
                         context.CustomPassName = DefaultPassNames.EffectMeshXRayP1;
                         var pass = mesh.EffectTechnique[DefaultPassNames.EffectMeshXRayP1];
                         if (pass.IsNULL) { continue; }
@@ -179,10 +180,10 @@ namespace HelixToolkit.UWP.Core
             }
             else
             {
-                for (int i =0; i < context.RenderHost.PerFrameGeneralCoresWithPostEffect.Count; ++i)
+                for (int i =0; i < context.RenderHost.PerFrameNodesWithPostEffect.Count; ++i)
                 {
                     IEffectAttributes effect;
-                    var mesh = context.RenderHost.PerFrameGeneralCoresWithPostEffect[i];
+                    var mesh = context.RenderHost.PerFrameNodesWithPostEffect[i];
                     if (mesh.TryGetPostEffect(EffectName, out effect))
                     {
                         object attribute;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
@@ -253,7 +253,8 @@ namespace HelixToolkit.UWP.Core
         /// Called when [bind raster state].
         /// </summary>
         /// <param name="context">The context.</param>
-        protected override void OnBindRasterState(DeviceContextProxy context)
+        /// <param name="isInvertCullMode"></param>
+        protected override void OnBindRasterState(DeviceContextProxy context, bool isInvertCullMode)
         {
             context.SetRasterState(rasterState);
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ShadowMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ShadowMapCore.cs
@@ -232,9 +232,9 @@ namespace HelixToolkit.UWP.Core
             deviceContext.DeviceContext.Rasterizer.SetViewport(0, 0, Width, Height);
 
             deviceContext.DeviceContext.OutputMerger.SetTargets(viewResource.DepthStencilView, new RenderTargetView[0]);
-            for (int i = 0; i < context.RenderHost.PerFrameGeneralRenderCores.Count; ++i)
+            for (int i = 0; i < context.RenderHost.PerFrameGeneralNodes.Count; ++i)
             {
-                var core = context.RenderHost.PerFrameGeneralRenderCores[i];
+                var core = context.RenderHost.PerFrameGeneralNodes[i];
                 if (core.IsThrowingShadow && core.RenderType == RenderType.Opaque)
                 {
                     core.Render(context, deviceContext);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SkyBoxRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SkyBoxRenderCore.cs
@@ -181,10 +181,6 @@ namespace HelixToolkit.UWP.Core
 
         }
 
-        protected override void OnBindRasterState(DeviceContextProxy context)
-        {
-            
-        }
         /// <summary>
         /// Called when [default pass changed].
         /// </summary>
@@ -207,7 +203,7 @@ namespace HelixToolkit.UWP.Core
         protected override void OnRender(IRenderContext context, DeviceContextProxy deviceContext)
         {
             DefaultShaderPass.BindShader(deviceContext);
-            DefaultShaderPass.BindStates(deviceContext, StateType.BlendState | StateType.DepthStencilState | StateType.RasterState);
+            DefaultShaderPass.BindStates(deviceContext, StateType.BlendState | StateType.DepthStencilState);
             DefaultShaderPass.GetShader(ShaderStage.Pixel).BindTexture(deviceContext, cubeTextureSlot, cubeTextureRes);
             DefaultShaderPass.GetShader(ShaderStage.Pixel).BindSampler(deviceContext, textureSamplerSlot, textureSampler);
             deviceContext.DeviceContext.Draw(GeometryBuffer.VertexBuffer[0].ElementCount, 0);

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultBuffers.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultBuffers.cs
@@ -21,6 +21,7 @@ namespace HelixToolkit.UWP.Shaders
         public static string BoneCB = "cbBoneSkinning";
         public static string ClipParamsCB = "cbClipping";
         public static string BorderEffectCB = "cbBorderEffect";
+        public static string DynamicCubeMapCB = "cbDynamicCubeMap";
 #if !NETFX_CORE
         public static string ScreenDuplicationCB = "cbScreenClone";
 #endif

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultSamplers.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultSamplers.cs
@@ -98,9 +98,9 @@ namespace HelixToolkit.UWP.Shaders
         /// </summary>
         public static SamplerStateDescription CubeSampler = new SamplerStateDescription()
         {
-            AddressU = TextureAddressMode.Mirror,
-            AddressV = TextureAddressMode.Mirror,
-            AddressW = TextureAddressMode.Mirror,
+            AddressU = TextureAddressMode.Clamp,
+            AddressV = TextureAddressMode.Clamp,
+            AddressW = TextureAddressMode.Clamp,
             Filter = Filter.MinMagLinearMipPoint,
             MaximumAnisotropy = 2,
             MaximumLod = float.MaxValue

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultStates.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultStates.cs
@@ -375,7 +375,7 @@ namespace HelixToolkit.UWP.Shaders
         public readonly static RasterizerStateDescription RSSkybox = new RasterizerStateDescription()
         {
             FillMode = FillMode.Solid,
-            CullMode = CullMode.None,
+            CullMode = CullMode.Back,
             DepthBias = 0,
             DepthBiasClamp = 0,
             SlopeScaledDepthBias = +0,
@@ -388,7 +388,7 @@ namespace HelixToolkit.UWP.Shaders
         public readonly static RasterizerStateDescription RSSkyDome = new RasterizerStateDescription()
         {
             FillMode = FillMode.Solid,
-            CullMode = CullMode.None,
+            CullMode = CullMode.Back,
             DepthBias = 0,
             DepthBiasClamp = 0,
             SlopeScaledDepthBias = +0,

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultStates.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultStates.cs
@@ -375,7 +375,7 @@ namespace HelixToolkit.UWP.Shaders
         public readonly static RasterizerStateDescription RSSkybox = new RasterizerStateDescription()
         {
             FillMode = FillMode.Solid,
-            CullMode = CullMode.Back,
+            CullMode = CullMode.None,
             DepthBias = 0,
             DepthBiasClamp = 0,
             SlopeScaledDepthBias = +0,
@@ -388,7 +388,7 @@ namespace HelixToolkit.UWP.Shaders
         public readonly static RasterizerStateDescription RSSkyDome = new RasterizerStateDescription()
         {
             FillMode = FillMode.Solid,
-            CullMode = CullMode.Back,
+            CullMode = CullMode.None,
             DepthBias = 0,
             DepthBiasClamp = 0,
             SlopeScaledDepthBias = +0,

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingBoxExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingBoxExtensions.cs
@@ -160,5 +160,10 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             return new RectangleF(rect.Left + translation.X, rect.Top + translation.Y, rect.Width, rect.Height);
         }
+
+        public static Vector3 Center(this BoundingBox box)
+        {
+            return (box.Minimum + box.Maximum) * 0.5f;
+        }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\PointBufferModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\CrossSectionMeshRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\DepthPrepassCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\DynamicCubeMapCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\EmptyRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\InstancingBillboardRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\InstancingMeshRenderCore.cs" />
@@ -166,6 +167,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\CoordinateSystemNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\CrossSectionMeshNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\DepthPrepassNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\DynamicReflectionNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\EnvironmentMapNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\GroupNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\InstancingBillboardNode.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/Constants.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/Constants.cs
@@ -83,7 +83,7 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         public static readonly char[] Separators = { ';', ' ', ',' };
-
+        public static readonly List<KeyValuePair<int, SceneNode>> EmptyRenderablePair = new List<KeyValuePair<int, SceneNode>>();
         public static readonly List<SceneNode> EmptyRenderable = new List<SceneNode>();
         public static readonly List<RenderCore> EmptyCore = new List<RenderCore>();
         public static readonly IList<SceneNode> EmptyRenderableArray = new SceneNode[0];

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IEffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IEffectsManager.cs
@@ -19,6 +19,7 @@ namespace HelixToolkit.Wpf.SharpDX
     using ShaderManager;
     using Shaders;
     using System;
+    using Render;
     /// <summary>
     /// 
     /// </summary>
@@ -99,6 +100,13 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         IConstantBufferPool ConstantBufferPool { get; }
+        /// <summary>
+        /// Gets the device context pool.
+        /// </summary>
+        /// <value>
+        /// The device context pool.
+        /// </value>
+        IDeviceContextPool DeviceContextPool { get; }
     }
 
     /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderContext.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderContext.cs
@@ -166,6 +166,13 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   <c>true</c> if [update octree]; otherwise, <c>false</c>.
         /// </value>
         bool AutoUpdateOctree { get; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is invert cull mode.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is invert cull mode; otherwise, <c>false</c>.
+        /// </value>
+        bool IsInvertCullMode { set; get; }
     }
     /// <summary>
     /// Contains the shared resources across all renderables. 

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderContext.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderContext.cs
@@ -105,6 +105,12 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         void UpdatePerFrameData();
         /// <summary>
+        /// Updates the per frame data.
+        /// </summary>
+        /// <param name="updateGlobalTransform">if set to <c>true</c> [update global transform].</param>
+        /// <param name="updateLights">if set to <c>true</c> [update lights].</param>
+        void UpdatePerFrameData(bool updateGlobalTransform, bool updateLights);
+        /// <summary>
         /// Gets or sets a value indicating whether this instance is shadow pass.
         /// </summary>
         /// <value>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
@@ -14,6 +14,7 @@ namespace HelixToolkit.UWP.Core
 #endif
 {
     using Model;
+    using Render;
     /// <summary>
     /// 
     /// </summary>
@@ -109,6 +110,24 @@ namespace HelixToolkit.UWP.Core
     {
         bool RenderWireframe { set; get; }
         Color4 WireframeColor { set; get; }
+    }
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IDynamicReflector
+    {
+        Vector3 Center { set; get; }
+        void BindCubeMap(DeviceContextProxy deviceContext);
+        void UnBindCubeMap(DeviceContextProxy deviceContext);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IDynamicReflectable
+    {
+        IDynamicReflector DynamicReflector { set; get; }
     }
 
     /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
@@ -118,6 +118,7 @@ namespace HelixToolkit.UWP.Core
     public interface IDynamicReflector
     {
         Vector3 Center { set; get; }
+        int FaceSize { set; get; }
         void BindCubeMap(DeviceContextProxy deviceContext);
         void UnBindCubeMap(DeviceContextProxy deviceContext);
     }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
@@ -117,6 +117,7 @@ namespace HelixToolkit.UWP.Core
     /// </summary>
     public interface IDynamicReflector
     {
+        bool EnableReflector { set; get; }
         Vector3 Center { set; get; }
         int FaceSize { set; get; }
         float NearField { set; get; }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
@@ -119,6 +119,9 @@ namespace HelixToolkit.UWP.Core
     {
         Vector3 Center { set; get; }
         int FaceSize { set; get; }
+        float NearField { set; get; }
+        float FarField { set; get; }
+        bool IsLeftHanded { set; get; }
         void BindCubeMap(DeviceContextProxy deviceContext);
         void UnBindCubeMap(DeviceContextProxy deviceContext);
     }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -203,31 +203,31 @@ namespace HelixToolkit.UWP
         /// </value>
         ID2DTargetProxy D2DTarget { get; }
         /// <summary>
-        /// Gets the current frame renderables for rendering.
+        /// Gets the current frame flattened scene graph
         /// </summary>
         /// <value>
         /// The per frame renderable.
         /// </value>
-        List<SceneNode> PerFrameRenderables { get; }
+        List<KeyValuePair<int, SceneNode>> PerFrameFlattenedScene { get; }
         /// <summary>
-        /// Gets the current frame renderables for rendering.
+        /// Gets the current frame lights
         /// </summary>
         /// <value>
-        /// The per frame renderable.
+        /// The per frame lights.
         /// </value>
-        IEnumerable<LightCoreBase> PerFrameLights { get; }
+        IEnumerable<LightNode> PerFrameLights { get; }
         /// <summary>
-        /// Gets the per frame post effects cores. It is the subset of <see cref="PerFrameGeneralRenderCores"/>
+        /// Gets the per frame nodes with post effects. It is the subset of <see cref="PerFrameGeneralNodes"/>
         /// </summary>
         /// <value>
-        /// The per frame post effects cores.
+        /// Gets the per frame nodes with post effects.
         /// </value>
-        List<RenderCore> PerFrameGeneralCoresWithPostEffect { get; }
+        List<SceneNode> PerFrameNodesWithPostEffect { get; }
         /// <summary>
-        /// Gets the per frame render cores for normal rendering routine. <see cref="RenderType.Opaque"/>, <see cref="RenderType.Transparent"/>, <see cref="RenderType.Particle"/>
+        /// Gets the per frame nodes for normal rendering routine. <see cref="RenderType.Opaque"/>, <see cref="RenderType.Transparent"/>, <see cref="RenderType.Particle"/>
         /// <para>This does not include <see cref="RenderType.PreProc"/>, <see cref="RenderType.PostProc"/>, <see cref="RenderType.Light"/>, <see cref="RenderType.ScreenSpaced"/></para>
         /// </summary>
-        List<RenderCore> PerFrameGeneralRenderCores { get; }
+        List<SceneNode> PerFrameGeneralNodes { get; }
         /// <summary>
         /// Starts the d3 d.
         /// </summary>
@@ -246,6 +246,10 @@ namespace HelixToolkit.UWP
         /// Invalidates the render.
         /// </summary>
         void InvalidateRender();
+        /// <summary>
+        /// Invalidates the scene graph.
+        /// </summary>
+        void InvalidateSceneGraph();
         /// <summary>
         /// Resizes
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderTechnique.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderTechnique.cs
@@ -25,7 +25,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// 
         /// </summary>
+#if DX11_1
+        Device1 Device { get; }
+#else
         Device Device { get; }
+#endif
         /// <summary>
         /// Input layout for all passes
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderable.cs
@@ -97,5 +97,9 @@ namespace HelixToolkit.UWP
         /// Invalidates the render.
         /// </summary>
         void InvalidateRender();
+        /// <summary>
+        /// Invalidates the scene graph.
+        /// </summary>
+        void InvalidateSceneGraph();
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderer.cs
@@ -112,7 +112,8 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context"></param>
         /// <param name="renderables"></param>
         /// <param name="parameter"></param>
-        void RenderScene(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter);
+        /// <returns>Number of node has been rendered</returns>
+        int RenderScene(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter);
         /// <summary>
         /// Update scene graph not related to rendering. Can be run parallel with the <see cref="RenderScene(IRenderContext, List{SceneNode}, ref RenderParameter)"/>
         /// <para>Warning: Dependency properties are thread affinity. Do not get/set any dependency property in this function.</para>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderer.cs
@@ -67,7 +67,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="renderables"></param>
         /// <param name="results"></param>
         /// <returns></returns>
-        void UpdateSceneGraph(IRenderContext context, List<SceneNode> renderables, List<SceneNode> results);
+        void UpdateSceneGraph(IRenderContext context, List<SceneNode> renderables, List<KeyValuePair<int, SceneNode>> results);
 
         /// <summary>
         /// Update scene graph, return the 2D renderables which will be rendered in this frame
@@ -82,7 +82,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context"></param>
         /// <param name="renderables"></param>
         /// <param name="parameter"></param>
-        void UpdateGlobalVariables(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter);
+        void UpdateGlobalVariables(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter);
 
         /// <summary>
         /// 
@@ -96,7 +96,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context"></param>
         /// <param name="renderables"></param>
         /// <param name="parameter"></param>
-        void RenderPreProc(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter);
+        void RenderPreProc(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter);
 
         /// <summary>
         /// Render post processing, such as bloom effects etc.
@@ -104,7 +104,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context"></param>
         /// <param name="renderables"></param>
         /// <param name="parameter"></param>
-        void RenderPostProc(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter);
+        void RenderPostProc(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter);
 
         /// <summary>
         /// Run actual rendering for render cores.
@@ -112,15 +112,15 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context"></param>
         /// <param name="renderables"></param>
         /// <param name="parameter"></param>
-        void RenderScene(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter);
+        void RenderScene(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter);
         /// <summary>
-        /// Update scene graph not related to rendering. Can be run parallel with the <see cref="RenderScene(IRenderContext, List{RenderCore}, ref RenderParameter)"/>
+        /// Update scene graph not related to rendering. Can be run parallel with the <see cref="RenderScene(IRenderContext, List{SceneNode}, ref RenderParameter)"/>
         /// <para>Warning: Dependency properties are thread affinity. Do not get/set any dependency property in this function.</para>
         /// </summary>
         /// <param name="renderables"></param>
         /// <param name="context"></param>
         /// <returns></returns>
-        void UpdateNotRenderParallel(IRenderContext context, List<SceneNode> renderables);
+        void UpdateNotRenderParallel(IRenderContext context, List<KeyValuePair<int, SceneNode>> renderables);
         /// <summary>
         /// 
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Layouts.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Layouts.cs
@@ -359,6 +359,22 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public const int SizeInBytes = 4 * (4 + 4 * 4);
     }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct CubeFaceCamera
+    {
+        public Matrix View;
+        public Matrix Projection;
+        public const int SizeInBytes = 4 * 4 * 4;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct CubeFaceCamerasStruct
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+        public CubeFaceCamera[] Cameras;
+        public const int SizeInBytes = CubeFaceCamera.SizeInBytes * 6;
+    }
 #if !NETFX_CORE
     /// <summary>
     /// 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
@@ -489,8 +489,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <returns></returns>
         protected override bool CanRender(IRenderContext context)
         {
-            if (base.CanRender(context) && GeometryValid && (!(context.EnableBoundingFrustum && EnableViewFrustumCheck)
-                || CheckBoundingFrustum(context.BoundingFrustum)))
+            if (base.CanRender(context) && GeometryValid)
             {
                 return true;
             }
@@ -501,19 +500,19 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         }
 
         /// <summary>
-        /// Checks the bounding frustum.
+        /// Views the frustum test.
         /// </summary>
         /// <param name="viewFrustum">The view frustum.</param>
         /// <returns></returns>
-        protected virtual bool CheckBoundingFrustum(BoundingFrustum viewFrustum)
+        public override bool TestViewFrustum(ref BoundingFrustum viewFrustum)
         {
-            if (!HasBound)
+            if (!HasBound || !EnableViewFrustumCheck)
             {
                 return true;
             }
             var bound = BoundsWithTransform;
             var sphere = BoundsSphereWithTransform;
-            return viewFrustum.Intersects(ref bound) && viewFrustum.Intersects(ref sphere);
+            return viewFrustum.Intersects(ref sphere) && viewFrustum.Intersects(ref bound);
         }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
@@ -353,15 +353,14 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
             {
                 if (Set(ref postEffects, value))
                 {
-                    var core = RenderCore;
-                    core.ClearPostEffect();
+                    ClearPostEffect();
                     if (value is string effects)
                     {
                         if (!string.IsNullOrEmpty(effects))
                         {
                             foreach (var effect in EffectAttributes.Parse(effects))
                             {
-                                core.AddPostEffect(effect);
+                                AddPostEffect(effect);
                             }
                         }
                     }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
@@ -431,6 +431,15 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
             return Visible && IsAttached;
         }
 
+        /// <summary>
+        /// View frustum test.
+        /// </summary>
+        /// <param name="frustum">The frustum.</param>
+        /// <returns></returns>
+        public virtual bool TestViewFrustum(ref BoundingFrustum viewFrustum)
+        {
+            return true;
+        }
         #endregion Rendering
 
         #region Hit Test

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
@@ -439,12 +439,16 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <param name="context">The time since last update.</param>
         public virtual void Update(IRenderContext context)
         {
+            IsRenderable = CanRender(context);
+            if (!IsRenderable)
+            {
+                return;
+            }
             if (needMatrixUpdate || forceUpdateTransform)
             {
                 TotalModelMatrix = modelMatrix * parentMatrix;
                 needMatrixUpdate = false;
-            }
-            IsRenderable = CanRender(context);
+            }           
         }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
@@ -480,7 +480,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <summary>
         /// View frustum test.
         /// </summary>
-        /// <param name="frustum">The frustum.</param>
+        /// <param name="viewFrustum">The frustum.</param>
         /// <returns></returns>
         public virtual bool TestViewFrustum(ref BoundingFrustum viewFrustum)
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
@@ -29,7 +29,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <summary>
         ///
         /// </summary>
-        public Guid GUID { get; } = Guid.NewGuid();
+        public Guid GUID { get { return RenderCore.GUID; } }
 
         private Matrix totalModelMatrix = Matrix.Identity;
         protected bool forceUpdateTransform = false;
@@ -221,7 +221,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <value>
         /// The effects technique.
         /// </value>
-        public IRenderTechnique EffectTechnique { get { return RenderCore.EffectTechnique; } }
+        public IRenderTechnique EffectTechnique { get { return renderTechnique; } }
         #region Handling Transforms
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BillboardNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BillboardNode.cs
@@ -91,12 +91,8 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         {
             return host.EffectsManager[DefaultRenderTechniqueNames.BillboardText];
         }
-        /// <summary>
-        /// Checks the bounding frustum.
-        /// </summary>
-        /// <param name="viewFrustum">The view frustum.</param>
-        /// <returns></returns>
-        protected override bool CheckBoundingFrustum(BoundingFrustum viewFrustum)
+
+        public override bool TestViewFrustum(ref BoundingFrustum viewFrustum)
         {
             if (!HasBound)
             {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
@@ -109,12 +109,13 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
             bonesBufferModel.DisposeAndClear();
             base.OnDetach();
         }
+
         /// <summary>
-        /// Checks the bounding frustum.
+        /// Views the frustum test.
         /// </summary>
-        /// <param name="boundingFrustum">The bounding frustum.</param>
+        /// <param name="viewFrustum">The view frustum.</param>
         /// <returns></returns>
-        protected override bool CheckBoundingFrustum(BoundingFrustum boundingFrustum)
+        public override bool TestViewFrustum(ref BoundingFrustum viewFrustum)
         {
             return true;
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
@@ -52,6 +52,57 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
                 return (RenderCore as IDynamicReflector).FaceSize;
             }
         }
+        /// <summary>
+        /// Gets or sets the near field.
+        /// </summary>
+        /// <value>
+        /// The near field.
+        /// </value>
+        public float NearField
+        {
+            set
+            {
+                (RenderCore as IDynamicReflector).NearField = value;
+            }
+            get
+            {
+                return (RenderCore as IDynamicReflector).NearField;
+            }
+        }
+        /// <summary>
+        /// Gets or sets the far field.
+        /// </summary>
+        /// <value>
+        /// The far field.
+        /// </value>
+        public float FarField
+        {
+            set
+            {
+                (RenderCore as IDynamicReflector).FarField = value;
+            }
+            get
+            {
+                return (RenderCore as IDynamicReflector).FarField;
+            }
+        }
+        /// <summary>
+        /// Gets or sets a value indicating whether this coordinate system is left handed.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this coordinate system is left handed; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsLeftHanded
+        {
+            set
+            {
+                (RenderCore as IDynamicReflector).IsLeftHanded = value;
+            }
+            get
+            {
+                return (RenderCore as IDynamicReflector).IsLeftHanded;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicReflectionNode"/> class.

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
@@ -18,6 +18,23 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
     public class DynamicReflectionNode : GroupNode, IDynamicReflector
     {
         /// <summary>
+        /// Gets or sets a value indicating whether [enable reflector].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable reflector]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableReflector
+        {
+            set
+            {
+                (RenderCore as IDynamicReflector).EnableReflector = value;
+            }
+            get
+            {
+                return (RenderCore as IDynamicReflector).EnableReflector;
+            }
+        }
+        /// <summary>
         /// Gets or sets the center.
         /// </summary>
         /// <value>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
@@ -1,0 +1,54 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+
+using SharpDX;
+using System.Collections.Generic;
+
+#if NETFX_CORE
+namespace HelixToolkit.UWP.Model.Scene
+#else
+namespace HelixToolkit.Wpf.SharpDX.Model.Scene
+#endif
+{
+    using Core;
+    public class DynamicReflectionNode : GroupNode
+    {
+        public DynamicReflectionNode()
+        {
+            this.OnAddChildNode += DynamicReflectionNode_OnAddChildNode;
+            this.OnRemoveChildNode += DynamicReflectionNode_OnRemoveChildNode;
+            this.OnClear += DynamicReflectionNode_OnClear;
+        }
+
+        private void DynamicReflectionNode_OnClear(object sender, OnChildNodeChangedArgs e)
+        {
+            (RenderCore as DynamicCubeMapCore).IgnoredGuid.Clear();
+        }
+
+        private void DynamicReflectionNode_OnRemoveChildNode(object sender, OnChildNodeChangedArgs e)
+        {
+            (RenderCore as DynamicCubeMapCore).IgnoredGuid.Remove(e.Node.RenderCore.GUID);
+        }
+
+        private void DynamicReflectionNode_OnAddChildNode(object sender, OnChildNodeChangedArgs e)
+        {
+            (RenderCore as DynamicCubeMapCore).IgnoredGuid.Add(e.Node.RenderCore.GUID);
+        }
+
+        protected override RenderCore OnCreateRenderCore()
+        {
+            return new DynamicCubeMapCore();
+        }
+
+        protected override bool CanHitTest(IRenderContext context)
+        {
+            return false;
+        }
+        protected override bool OnHitTest(IRenderContext context, Matrix totalModelMatrix, ref Ray ray, ref List<HitTestResult> hits)
+        {
+            return false;
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
@@ -13,8 +13,22 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
 #endif
 {
     using Core;
-    public class DynamicReflectionNode : GroupNode
+    using Render;
+
+    public class DynamicReflectionNode : GroupNode, IDynamicReflector
     {
+        public Vector3 Center
+        {
+            set
+            {
+                (RenderCore as IDynamicReflector).Center = value;
+            }
+            get
+            {
+                return (RenderCore as IDynamicReflector).Center;
+            }
+        }
+
         public DynamicReflectionNode()
         {
             this.OnAddChildNode += DynamicReflectionNode_OnAddChildNode;
@@ -30,16 +44,72 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         private void DynamicReflectionNode_OnRemoveChildNode(object sender, OnChildNodeChangedArgs e)
         {
             (RenderCore as DynamicCubeMapCore).IgnoredGuid.Remove(e.Node.RenderCore.GUID);
+            if (e.Node is IDynamicReflectable dyn)
+            {
+                dyn.DynamicReflector = null;
+            }
         }
 
         private void DynamicReflectionNode_OnAddChildNode(object sender, OnChildNodeChangedArgs e)
         {
             (RenderCore as DynamicCubeMapCore).IgnoredGuid.Add(e.Node.RenderCore.GUID);
+            if(e.Node is IDynamicReflectable dyn)
+            {
+                dyn.DynamicReflector = this;
+            }
         }
 
         protected override RenderCore OnCreateRenderCore()
         {
             return new DynamicCubeMapCore();
+        }
+
+        protected override bool OnAttach(IRenderHost host)
+        {
+            if (base.OnAttach(host))
+            {
+                RenderCore.Attach(this.EffectTechnique);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override void UpdateNotRender(IRenderContext context)
+        {
+            base.UpdateNotRender(context);
+            if(Octree != null)
+            {
+                Center = Octree.Bound.Center();
+            }
+            else
+            {
+                BoundingBox box = new BoundingBox();
+                int i = 0;
+                for(; i < Items.Count; ++i)
+                {
+                    if(Items[i] is IDynamicReflectable)
+                    {
+                        box = Items[i].BoundsWithTransform;
+                        break;
+                    }
+                }
+                for (; i < Items.Count; ++i)
+                {
+                    if (Items[i] is IDynamicReflectable)
+                    {
+                        box = BoundingBox.Merge(box, Items[i].BoundsWithTransform);
+                    }
+                }
+                Center = box.Center();
+            }
+        }
+
+        protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+        {
+            return host.EffectsManager[DefaultRenderTechniqueNames.Skybox];
         }
 
         protected override bool CanHitTest(IRenderContext context)
@@ -49,6 +119,23 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         protected override bool OnHitTest(IRenderContext context, Matrix totalModelMatrix, ref Ray ray, ref List<HitTestResult> hits)
         {
             return false;
+        }
+
+        /// <summary>
+        /// Binds the cube map.
+        /// </summary>
+        /// <param name="deviceContext">The device context.</param>
+        public void BindCubeMap(DeviceContextProxy deviceContext)
+        {
+            (RenderCore as IDynamicReflector).BindCubeMap(deviceContext);
+        }
+        /// <summary>
+        /// Uns the bind cube map.
+        /// </summary>
+        /// <param name="deviceContext">The device context.</param>
+        public void UnBindCubeMap(DeviceContextProxy deviceContext)
+        {
+            (RenderCore as IDynamicReflector).UnBindCubeMap(deviceContext);
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
@@ -17,6 +17,12 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
 
     public class DynamicReflectionNode : GroupNode, IDynamicReflector
     {
+        /// <summary>
+        /// Gets or sets the center.
+        /// </summary>
+        /// <value>
+        /// The center.
+        /// </value>
         public Vector3 Center
         {
             set
@@ -29,6 +35,27 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
             }
         }
 
+        /// <summary>
+        /// Gets or sets the size of the face.
+        /// </summary>
+        /// <value>
+        /// The size of the face.
+        /// </value>
+        public int FaceSize
+        {
+            set
+            {
+                (RenderCore as IDynamicReflector).FaceSize = value;
+            }
+            get
+            {
+                return (RenderCore as IDynamicReflector).FaceSize;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicReflectionNode"/> class.
+        /// </summary>
         public DynamicReflectionNode()
         {
             this.OnAddChildNode += DynamicReflectionNode_OnAddChildNode;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/EnvironmentMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/EnvironmentMapNode.cs
@@ -35,13 +35,36 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
                 return (RenderCore as ISkyboxRenderParams).CubeTexture;
             }
         }
+
+        private readonly bool UseSkyDome = false;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnvironmentMapNode"/> class. Default is using SkyBox. To use SkyDome, pass true into the constructor
+        /// </summary>
+        public EnvironmentMapNode()
+        {
+        }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnvironmentMapNode"/> class. Default is using SkyBox. To use SkyDome, pass true into the constructor
+        /// </summary>
+        /// <param name="useSkyDome">if set to <c>true</c> [use sky dome].</param>
+        public EnvironmentMapNode(bool useSkyDome)
+        {
+            UseSkyDome = useSkyDome;
+        }
         /// <summary>
         /// Called when [create render core].
         /// </summary>
         /// <returns></returns>
         protected override RenderCore OnCreateRenderCore()
         {
-            return new SkyBoxRenderCore();
+            if (UseSkyDome)
+            {
+                return new SkyDomeRenderCore();
+            }
+            else
+            {
+                return new SkyBoxRenderCore();
+            }
         }
         /// <summary>
         /// Called when [create render technique].

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
@@ -125,7 +125,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
                 {
                     if (light.LightType == LightType.Directional)
                     {
-                        var dlight = light as DirectionalLightCore;
+                        var dlight = light.RenderCore as DirectionalLightCore;
                         var dir = Vector4.Transform(dlight.Direction.ToVector4(0), dlight.ModelMatrix).Normalized();
                         var pos = -100 * dir;
                         orthoCamera.LookDirection = new Vector3(dir.X, dir.Y, dir.Z);
@@ -137,7 +137,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
                     }
                     else if (light.LightType == LightType.Spot)
                     {
-                        var splight = light as SpotLightCore;
+                        var splight = light.RenderCore as SpotLightCore;
                         persCamera.Position = (splight.Position + splight.ModelMatrix.Row4.ToVector3());
                         var look = Vector4.Transform(splight.Direction.ToVector4(0), splight.ModelMatrix);
                         persCamera.LookDirection = new Vector3(look.X, look.Y, look.Z);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/MeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/MeshNode.cs
@@ -20,7 +20,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
     /// <summary>
     ///
     /// </summary>
-    public class MeshNode : MaterialGeometryNode
+    public class MeshNode : MaterialGeometryNode, IDynamicReflectable
     {
         #region Properties
         private bool frontCCW = true;
@@ -245,7 +245,25 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         {
             get { return (RenderCore as IMeshRenderParams).RenderWireframe; }
             set { (RenderCore as IMeshRenderParams).RenderWireframe = value; }
-        } 
+        }
+
+        /// <summary>
+        /// Gets or sets the dynamic reflector.
+        /// </summary>
+        /// <value>
+        /// The dynamic reflector.
+        /// </value>
+        public IDynamicReflector DynamicReflector
+        {
+            set
+            {
+                (RenderCore as IDynamicReflectable).DynamicReflector = value;
+            }
+            get
+            {
+                return (RenderCore as IDynamicReflectable).DynamicReflector;
+            }
+        }
         #endregion
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/SortingGroupNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/SortingGroupNode.cs
@@ -172,6 +172,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
             sortingTransparentCache.Clear();
             sortingOpaqueCache.Clear();
             notSorted.Clear();
+            InvalidateSceneGraph();
         }
 
         protected float GetDistance(SceneNode node, ref Vector3 cameraPos)

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextPool.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextPool.cs
@@ -4,6 +4,7 @@ Copyright (c) 2018 Helix Toolkit contributors
 */
 
 using System.Collections.Concurrent;
+using SharpDX.Direct3D11;
 #if DX11_1
 using Device = SharpDX.Direct3D11.Device1;
 #endif

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextPool.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextPool.cs
@@ -69,6 +69,7 @@ namespace HelixToolkit.UWP.Render
         public void Put(DeviceContextProxy context)
         {
             context.DeviceContext.OutputMerger.ResetTargets();
+            context.Reset();
             contextPool.Add(context);
         }
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextPool.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextPool.cs
@@ -68,6 +68,7 @@ namespace HelixToolkit.UWP.Render
         /// <param name="context">The context.</param>
         public void Put(DeviceContextProxy context)
         {
+            context.DeviceContext.OutputMerger.ResetTargets();
             contextPool.Add(context);
         }
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextPool.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextPool.cs
@@ -3,7 +3,6 @@ The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
 
-using SharpDX.Direct3D11;
 using System.Collections.Concurrent;
 #if DX11_1
 using Device = SharpDX.Direct3D11.Device1;

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy.cs
@@ -148,5 +148,12 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         {
             DeviceContext.OutputMerger.SetBlendState(blendState, blendFactor, sampleMask);
         }
+        /// <summary>
+        /// Resets this instance.
+        /// </summary>
+        public void Reset()
+        {
+            LastShaderPass = null;
+        }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
@@ -7,31 +7,32 @@
 //   Optimizations might be possible
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
+using SharpDX;
+using SharpDX.Direct3D11;
+
 #if NETFX_CORE
 namespace HelixToolkit.UWP
 #else
+
 namespace HelixToolkit.Wpf.SharpDX
 #endif
 {
-    using System;
-
-    using global::SharpDX;
-
-    using global::SharpDX.Direct3D11;
-    using Utilities;
-    using Shaders;
-    using Model;
     using Cameras;
+    using Model;
+    using Shaders;
+    using System;
+    using Utilities;
 
     /// <summary>
     /// The render-context is currently generated per frame
     /// Optimizations might be possible
     /// </summary>
     public class RenderContext : DisposeObject, IRenderContext
-    {       
+    {
         private Matrix worldMatrix = Matrix.Identity;
         private Matrix viewMatrix;
         private Matrix projectionMatrix;
+
         /// <summary>
         /// Gets or sets the bounding frustum.
         /// </summary>
@@ -39,9 +40,11 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The bounding frustum.
         /// </value>
         public BoundingFrustum BoundingFrustum { set; get; }
-        private CameraCore camera; 
+
+        private CameraCore camera;
 
         private bool matrixChanged = true;
+
         /// <summary>
         /// Gets the view matrix.
         /// </summary>
@@ -58,6 +61,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 matrixChanged = true;
             }
         }
+
         /// <summary>
         /// Gets or sets the projection matrix.
         /// </summary>
@@ -77,6 +81,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 matrixChanged = true;
             }
         }
+
         /// <summary>
         /// Gets or sets the world matrix.
         /// </summary>
@@ -96,6 +101,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 matrixChanged = true;
             }
         }
+
         /// <summary>
         /// Gets the viewport matrix.
         /// </summary>
@@ -107,13 +113,14 @@ namespace HelixToolkit.Wpf.SharpDX
             get
             {
                 return new Matrix((float)(ActualWidth / 2), 0, 0, 0,
-                    0, (float)(-ActualHeight / 2), 0, 0, 
+                    0, (float)(-ActualHeight / 2), 0, 0,
                     0, 0, 1, 0,
                     (float)((ActualWidth - 1) / 2), (float)((ActualHeight - 1) / 2), 0, 1);
             }
         }
 
         private Matrix screenViewProjectionMatrix = Matrix.Identity;
+
         /// <summary>
         /// Gets the screen view projection matrix.
         /// </summary>
@@ -127,6 +134,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 return GetScreenViewProjectionMatrix();
             }
         }
+
         /// <summary>
         /// Gets or sets a value indicating whether [enable bounding frustum].
         /// </summary>
@@ -134,6 +142,7 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   <c>true</c> if [enable bounding frustum]; otherwise, <c>false</c>.
         /// </value>
         public bool EnableBoundingFrustum { set; get; } = false;
+
         /// <summary>
         /// Gets or sets the device context.
         /// </summary>
@@ -141,6 +150,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The device context.
         /// </value>
         public DeviceContext DeviceContext { private set; get; }
+
         /// <summary>
         /// Gets the actual width.
         /// </summary>
@@ -148,6 +158,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The actual width.
         /// </value>
         public double ActualWidth { get { return RenderHost.ActualWidth; } }
+
         /// <summary>
         /// Gets the actual height.
         /// </summary>
@@ -155,6 +166,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The actual height.
         /// </value>
         public double ActualHeight { get { return RenderHost.ActualHeight; } }
+
         /// <summary>
         /// Gets or sets the camera.
         /// </summary>
@@ -165,25 +177,25 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             get { return this.camera; }
             set
-            {                
+            {
                 this.camera = value;
                 ViewMatrix = this.camera.CreateViewMatrix();
                 var aspectRatio = this.ActualWidth / this.ActualHeight;
                 ProjectionMatrix = this.camera.CreateProjectionMatrix((float)aspectRatio);
                 if (this.camera is ProjectionCameraCore c)
                 {
-                    // viewport: W,H,0,0   
+                    // viewport: W,H,0,0
                     globalTransform.Viewport = new Vector4((float)ActualWidth, (float)ActualHeight, 0, 0);
                     var ar = globalTransform.Viewport.X / globalTransform.Viewport.Y;
-                    
-                    var  pc = c as PerspectiveCameraCore;
+
+                    var pc = c as PerspectiveCameraCore;
                     var fov = (pc != null) ? pc.FieldOfView : 90f;
 
                     var zn = c.NearPlaneDistance > 0 ? c.NearPlaneDistance : 0.1;
                     var zf = c.FarPlaneDistance + 0.0;
                     // frustum: FOV,AR,N,F
                     globalTransform.Frustum = new Vector4((float)fov, (float)ar, (float)zn, (float)zf);
-                    if(EnableBoundingFrustum)
+                    if (EnableBoundingFrustum)
                         BoundingFrustum = new BoundingFrustum(ViewMatrix * ProjectionMatrix);
                     globalTransform.EyePos = this.camera.Position;
                 }
@@ -197,6 +209,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The render host.
         /// </value>
         public IRenderHost RenderHost { get; private set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether is shadow pass.
         /// </summary>
@@ -204,6 +217,7 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   <c>true</c> if is shadow pass; otherwise, <c>false</c>.
         /// </value>
         public bool IsShadowPass { get; set; } = false;
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is deferred pass.
         /// </summary>
@@ -211,6 +225,7 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   <c>true</c> if this instance is deferred pass; otherwise, <c>false</c>.
         /// </value>
         public bool IsDeferredPass { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is custom pass.
         /// </summary>
@@ -218,6 +233,7 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   <c>true</c> if this instance is custom pass; otherwise, <c>false</c>.
         /// </value>
         public bool IsCustomPass { set; get; } = false;
+
         /// <summary>
         /// Gets or sets the name of the custom pass.
         /// </summary>
@@ -225,6 +241,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The name of the custom pass.
         /// </value>
         public string CustomPassName { set; get; } = "";
+
         /// <summary>
         /// Gets or sets the time stamp.
         /// </summary>
@@ -232,6 +249,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The time stamp.
         /// </value>
         public TimeSpan TimeStamp { set; get; }
+
         /// <summary>
         /// Gets or sets the light scene.
         /// </summary>
@@ -241,8 +259,9 @@ namespace HelixToolkit.Wpf.SharpDX
         public Light3DSceneShared LightScene { private set; get; }
 
         private IConstantBufferProxy cbuffer;
-        
+
         private GlobalTransformStruct globalTransform;
+
         /// <summary>
         /// Gets the global transform.
         /// </summary>
@@ -250,6 +269,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The global transform.
         /// </value>
         public GlobalTransformStruct GlobalTransform { get { return globalTransform; } }
+
         /// <summary>
         /// Gets or sets the shared resource.
         /// </summary>
@@ -258,7 +278,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </value>
         public IContextSharedResource SharedResource
         {
-            private set;get;
+            private set; get;
         }
 
         /// <summary>
@@ -268,6 +288,16 @@ namespace HelixToolkit.Wpf.SharpDX
         ///   <c>true</c> if [update octree]; otherwise, <c>false</c>.
         /// </value>
         public bool AutoUpdateOctree { set; get; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this render pass is using inverted cull mode.
+        /// If <see cref="CullMode"/>=<see cref="CullMode.None"/>, default state is used.
+        /// This is usually used when rendering <see cref="Core.DynamicCubeMapCore"/>.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> Set invert cullmode flag; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsInvertCullMode { set; get; } = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RenderContext"/> class.
@@ -284,6 +314,7 @@ namespace HelixToolkit.Wpf.SharpDX
             LightScene = Collect(new Light3DSceneShared(renderHost.EffectsManager.ConstantBufferPool));
             SharedResource = Collect(new ContextSharedResource());
         }
+
         /// <summary>
         /// Gets the screen view projection matrix.
         /// </summary>
@@ -292,6 +323,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             return screenViewProjectionMatrix;
         }
+
         /// <summary>
         /// Call to update constant buffer for per frame
         /// </summary>
@@ -299,6 +331,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             UpdatePerFrameData(true, true);
         }
+
         /// <summary>
         /// Call to update constant buffer for per frame
         /// </summary>
@@ -311,7 +344,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     globalTransform.View = ViewMatrix;
                     globalTransform.Projection = ProjectionMatrix;
                     globalTransform.ViewProjection = globalTransform.View * globalTransform.Projection;
-                    screenViewProjectionMatrix = ViewMatrix * ProjectionMatrix * ViewportMatrix;                        
+                    screenViewProjectionMatrix = ViewMatrix * ProjectionMatrix * ViewportMatrix;
                     matrixChanged = false;
                 }
                 cbuffer.UploadDataToBuffer(DeviceContext, ref globalTransform);

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
@@ -297,16 +297,29 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public void UpdatePerFrameData()
         {
-            if (matrixChanged)
+            UpdatePerFrameData(true, true);
+        }
+        /// <summary>
+        /// Call to update constant buffer for per frame
+        /// </summary>
+        public void UpdatePerFrameData(bool updateGlobalTransform, bool updateLights)
+        {
+            if (updateGlobalTransform)
             {
-                globalTransform.View = ViewMatrix;
-                globalTransform.Projection = ProjectionMatrix;
-                globalTransform.ViewProjection = globalTransform.View * globalTransform.Projection;
-                screenViewProjectionMatrix = ViewMatrix * ProjectionMatrix * ViewportMatrix;                        
-                matrixChanged = false;
+                if (matrixChanged)
+                {
+                    globalTransform.View = ViewMatrix;
+                    globalTransform.Projection = ProjectionMatrix;
+                    globalTransform.ViewProjection = globalTransform.View * globalTransform.Projection;
+                    screenViewProjectionMatrix = ViewMatrix * ProjectionMatrix * ViewportMatrix;                        
+                    matrixChanged = false;
+                }
+                cbuffer.UploadDataToBuffer(DeviceContext, ref globalTransform);
             }
-            cbuffer.UploadDataToBuffer(DeviceContext, ref globalTransform);
-            LightScene.UploadToBuffer(DeviceContext);
+            if (updateLights)
+            {
+                LightScene.UploadToBuffer(DeviceContext);
+            }
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -117,7 +117,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// Initializes a new instance of the <see cref="DefaultRenderHost"/> class.
         /// </summary>
         /// <param name="createRenderer">The create renderer.</param>
-        public DefaultRenderHost(Func<Device, IRenderer> createRenderer) : base(createRenderer)
+        public DefaultRenderHost(Func<IDevice3DResources, IRenderer> createRenderer) : base(createRenderer)
         {
 
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -462,7 +462,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// </summary>
         public event EventHandler OnRendered;
 
-        private readonly Func<Device, IRenderer> createRendererFunction;
+        private readonly Func<IDevice3DResources, IRenderer> createRendererFunction;
         #endregion
 
         #region Private variables
@@ -492,7 +492,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// Initializes a new instance of the <see cref="DX11RenderHostBase"/> class.
         /// </summary>
         /// <param name="createRenderer">The create renderer.</param>
-        public DX11RenderHostBase(Func<Device, IRenderer> createRenderer)
+        public DX11RenderHostBase(Func<IDevice3DResources, IRenderer> createRenderer)
         {
             createRendererFunction = createRenderer;           
         }
@@ -741,11 +741,11 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         {
             if (createRendererFunction != null)
             {
-                return createRendererFunction.Invoke(Device);
+                return createRendererFunction.Invoke(EffectsManager);
             }
             else
             {
-                return new ImmediateContextRenderer(Device);
+                return new ImmediateContextRenderer(EffectsManager);
             }
         }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/SwapChainRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/SwapChainRenderHost.cs
@@ -39,7 +39,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// </summary>
         /// <param name="surface">The surface.</param>
         /// <param name="createRenderer">The create renderer.</param>
-        public SwapChainRenderHost(IntPtr surface, Func<Device, IRenderer> createRenderer) : base(createRenderer)
+        public SwapChainRenderHost(IntPtr surface, Func<IDevice3DResources, IRenderer> createRenderer) : base(createRenderer)
         {
             this.surface = surface;
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
@@ -35,9 +35,9 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// </summary>
         /// <param name="device">The device.</param>
         /// <param name="scheduler"></param>
-        public DeferredContextRenderer(Device device, IRenderTaskScheduler scheduler) : base(device)
+        public DeferredContextRenderer(IDevice3DResources deviceResources, IRenderTaskScheduler scheduler) : base(deviceResources)
         {
-            deferredContextPool = Collect(new DeviceContextPool(device));
+            deferredContextPool = deviceResources.DeviceContextPool;
             this.scheduler = scheduler;
         }
 
@@ -126,6 +126,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         {
             commandList.Clear();
             renderOthersTask?.Wait();
+            deferredContextPool = null;
             base.OnDispose(disposeManagedResources);
         }
     }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
@@ -33,7 +33,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <summary>
         /// Initializes a new instance of the <see cref="DeferredContextRenderer"/> class.
         /// </summary>
-        /// <param name="device">The device.</param>
+        /// <param name="deviceResources">The deviceResources.</param>
         /// <param name="scheduler"></param>
         public DeferredContextRenderer(IDevice3DResources deviceResources, IRenderTaskScheduler scheduler) : base(deviceResources)
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
@@ -19,7 +19,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
     using Core;
     using System;
     using System.Threading.Tasks;
-
+    using Model.Scene;
     /// <summary>
     /// 
     /// </summary>
@@ -47,7 +47,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context">The context.</param>
         /// <param name="renderables">The renderables.</param>
         /// <param name="parameter">The parameter.</param>
-        public override void RenderScene(IRenderContext context, List<RenderCore> renderables, ref RenderParameter parameter)
+        public override void RenderScene(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter)
         {          
             if (scheduler.ScheduleAndRun(renderables, deferredContextPool, context, parameter, RenderType.Opaque, commandList))
             {
@@ -84,7 +84,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
 
 
 
-        private void RenderOthers(List<RenderCore> list, RenderType filter, IRenderContext context, IDeviceContextPool deviceContextPool,
+        private void RenderOthers(List<SceneNode> list, RenderType filter, IRenderContext context, IDeviceContextPool deviceContextPool,
             ref RenderParameter parameter,
             CommandList[] commandsArray,int idx)
         {
@@ -93,9 +93,9 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             bool hasValue = false;
             for(int i = 0; i < list.Count; ++i)
             {
-                if(list[i].RenderType == filter)
+                if(list[i].RenderCore.RenderType == filter)
                 {
-                    list[i].Render(context, deviceContext);
+                    list[i].RenderCore.Render(context, deviceContext);
                     hasValue = true;
                 }
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/DeferredContextRenderer.cs
@@ -47,9 +47,11 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context">The context.</param>
         /// <param name="renderables">The renderables.</param>
         /// <param name="parameter">The parameter.</param>
-        public override void RenderScene(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter)
-        {          
-            if (scheduler.ScheduleAndRun(renderables, deferredContextPool, context, parameter, RenderType.Opaque, commandList))
+        /// <returns>Number of node has been rendered</returns>
+        public override int RenderScene(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter)
+        {
+            int counter = 0;
+            if (scheduler.ScheduleAndRun(renderables, deferredContextPool, context, parameter, RenderType.Opaque, commandList, out counter))
             {
                 RenderParameter param = parameter;
                 renderOthersTask = Task.Run(() =>
@@ -75,10 +77,11 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                         RemoveAndDispose(ref postCommandList[i]);
                     }
                 }
+                return counter;
             }
             else
             {
-                base.RenderScene(context, renderables, ref parameter);
+                return base.RenderScene(context, renderables, ref parameter);
             }
         }
 
@@ -86,7 +89,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
 
         private void RenderOthers(List<SceneNode> list, RenderType filter, IRenderContext context, IDeviceContextPool deviceContextPool,
             ref RenderParameter parameter,
-            CommandList[] commandsArray,int idx)
+            CommandList[] commandsArray, int idx)
         {
             var deviceContext = deviceContextPool.Get();
             SetRenderTargets(deviceContext, ref parameter);

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -108,12 +108,19 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="context">The context.</param>
         /// <param name="renderables">The renderables.</param>
         /// <param name="parameter">The parameter.</param>
-        public virtual void RenderScene(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter)
+        /// <returns>Number of node has been rendered</returns>
+        public virtual int RenderScene(IRenderContext context, List<SceneNode> renderables, ref RenderParameter parameter)
         {
+            int renderedCount = 0;
             int count = renderables.Count;
             filters.Clear();
+            var frustum = context.BoundingFrustum;
             for (int i = 0; i < count; ++i)
             {
+                if (context.EnableBoundingFrustum && !renderables[i].TestViewFrustum(ref frustum))
+                {
+                    continue;
+                }
                 if (renderables[i].RenderCore.RenderType == RenderType.Opaque)
                 {
                     renderables[i].RenderCore.Render(context, ImmediateContext);
@@ -122,6 +129,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                 {
                     filters.Add(renderables[i]);
                 }
+                ++renderedCount;
             }
             count = filters.Count;
             for (int i = 0; i < count; ++i)
@@ -138,6 +146,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                     filters[i].RenderCore.Render(context, ImmediateContext);
                 }
             }
+            return renderedCount;
         }
         /// <summary>
         /// Updates the no render parallel. <see cref="IRenderer.UpdateNotRenderParallel(IRenderContext, List{SceneNode})"/>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -40,12 +40,12 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// Initializes a new instance of the <see cref="ImmediateContextRenderer"/> class.
         /// </summary>
         /// <param name="device">The device.</param>
-        public ImmediateContextRenderer(Device device)
+        public ImmediateContextRenderer(IDevice3DResources deviceResource)
         {
 #if DX11_1
-            ImmediateContext = Collect(new DeviceContextProxy(device.ImmediateContext1));
+            ImmediateContext = Collect(new DeviceContextProxy(deviceResource.Device.ImmediateContext1));
 #else
-            ImmediateContext = Collect(new DeviceContextProxy(device.ImmediateContext));
+            ImmediateContext = Collect(new DeviceContextProxy(deviceResource.Device.ImmediateContext));
 #endif
         }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -87,6 +87,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="parameter">The parameter.</param>
         public virtual void UpdateGlobalVariables(IRenderContext context, List<SceneNode> lights, ref RenderParameter parameter)
         {
+            ImmediateContext.Reset();
             if (parameter.RenderLight)
             {
                 context.LightScene.LightModels.ResetLightCount();

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -39,7 +39,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmediateContextRenderer"/> class.
         /// </summary>
-        /// <param name="device">The device.</param>
+        /// <param name="deviceResource">The deviceResource.</param>
         public ImmediateContextRenderer(IDevice3DResources deviceResource)
         {
 #if DX11_1
@@ -149,7 +149,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             return renderedCount;
         }
         /// <summary>
-        /// Updates the no render parallel. <see cref="IRenderer.UpdateNotRenderParallel(IRenderContext, List{SceneNode})"/>
+        /// Updates the no render parallel. <see cref="IRenderer.UpdateNotRenderParallel(IRenderContext, List{KeyValuePair{int, SceneNode}})"/>
         /// </summary>
         /// <param name="renderables">The renderables.</param>
         /// <param name="context"></param>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/RenderTaskScheduler.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/RenderTaskScheduler.cs
@@ -32,6 +32,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="parameter">The parameter.</param>
         /// <param name="outputCommands">The output commands.</param>
         /// <param name="filterType"></param>
+        /// <param name="numRendered"></param>
         /// <returns></returns>
         bool ScheduleAndRun(List<SceneNode> items, IDeviceContextPool pool,
             IRenderContext context, RenderParameter parameter, RenderType filterType, List<KeyValuePair<int, CommandList>> outputCommands, out int numRendered);
@@ -108,6 +109,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="parameter"></param>
         /// <param name="filterType"></param>
         /// <param name="outputCommands"></param>
+        /// <param name="numRendered"></param>
         /// <returns></returns>
         public bool ScheduleAndRun(List<SceneNode> items, IDeviceContextPool pool,
             IRenderContext context, RenderParameter parameter, RenderType filterType, List<KeyValuePair<int, CommandList>> outputCommands, out int numRendered)

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/RenderTaskScheduler.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/RenderTaskScheduler.cs
@@ -14,7 +14,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
     using global::SharpDX.Direct3D11;
     using System;
     using System.Collections.Concurrent;
-
+    using Model.Scene;
     /// <summary>
     /// 
     /// </summary>
@@ -33,7 +33,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="outputCommands">The output commands.</param>
         /// <param name="filterType"></param>
         /// <returns></returns>
-        bool ScheduleAndRun(List<RenderCore> items, IDeviceContextPool pool,
+        bool ScheduleAndRun(List<SceneNode> items, IDeviceContextPool pool,
             IRenderContext context, RenderParameter parameter, RenderType filterType, List<KeyValuePair<int, CommandList>> outputCommands);
     }
     /// <summary>
@@ -109,7 +109,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <param name="filterType"></param>
         /// <param name="outputCommands"></param>
         /// <returns></returns>
-        public bool ScheduleAndRun(List<RenderCore> items, IDeviceContextPool pool,
+        public bool ScheduleAndRun(List<SceneNode> items, IDeviceContextPool pool,
             IRenderContext context, RenderParameter parameter, RenderType filterType, List<KeyValuePair<int, CommandList>> outputCommands)
         {
             outputCommands.Clear();
@@ -122,9 +122,9 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                     SetRenderTargets(deferred, ref parameter);
                     for(int i=range.Item1; i<range.Item2; ++i)
                     {
-                        if (items[i].RenderType == filterType)
+                        if (items[i].RenderCore.RenderType == filterType)
                         {
-                            items[i].Render(context, deferred);
+                            items[i].RenderCore.Render(context, deferred);
                         }
                     }
                     var command = deferred.DeviceContext.FinishCommandList(true);

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/EffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/EffectsManager.cs
@@ -21,7 +21,7 @@ namespace HelixToolkit.Wpf.SharpDX
 namespace HelixToolkit.UWP
 #endif
 {
-
+    using Render;
     using Shaders;
     using ShaderManager;
     using Core;
@@ -114,6 +114,14 @@ namespace HelixToolkit.UWP
         /// </summary>
         public DriverType DriverType { private set; get; }
 
+        private IDeviceContextPool deviceContextPool;
+        /// <summary>
+        /// Gets the device context pool.
+        /// </summary>
+        /// <value>
+        /// The device context pool.
+        /// </value>
+        public IDeviceContextPool DeviceContextPool { get { return deviceContextPool; } }
         #endregion
         #region 2D Resources
         private global::SharpDX.Direct2D1.Device device2D;
@@ -290,6 +298,9 @@ namespace HelixToolkit.UWP
 
             RemoveAndDispose(ref materialTextureManager);
             materialTextureManager = Collect(new Model.TextureResourceManager(Device));
+
+            RemoveAndDispose(ref deviceContextPool);
+            deviceContextPool = Collect(new DeviceContextPool(Device));
             #endregion
             Log(LogLevel.Information, "Initializing Direct2D resources");
             factory2D = Collect(new global::SharpDX.Direct2D1.Factory1(global::SharpDX.Direct2D1.FactoryType.MultiThreaded));

--- a/Source/HelixToolkit.SharpDX.Shared/Shaders/Technique.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Shaders/Technique.cs
@@ -5,7 +5,9 @@ Copyright (c) 2018 Helix Toolkit contributors
 using SharpDX.Direct3D11;
 using System;
 using System.Collections.Generic;
-using System.Text;
+#if DX11_1
+using Device = SharpDX.Direct3D11.Device1;
+#endif
 
 #if !NETFX_CORE
 namespace HelixToolkit.Wpf.SharpDX.Shaders

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/TreeTraverser.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/TreeTraverser.cs
@@ -60,11 +60,12 @@ namespace HelixToolkit.UWP
         /// <param name="results">The results.</param>
         /// <param name="stackCache">The stack cache.</param>
         public static void PreorderDFT(this List<SceneNode> nodes, IRenderContext context,
-            Func<SceneNode, IRenderContext, bool> condition, List<SceneNode> results,
+            Func<SceneNode, IRenderContext, bool> condition, List<KeyValuePair<int, SceneNode>> results,
             Stack<KeyValuePair<int, IList<SceneNode>>> stackCache = null)
         {
             var stack = stackCache == null ? new Stack<KeyValuePair<int, IList<SceneNode>>>(20) : stackCache;
             int i = -1;
+            int level = 0;
             IList<SceneNode> currNodes = nodes;
             while (true)
             {
@@ -74,12 +75,13 @@ namespace HelixToolkit.UWP
                     var item = currNodes[i];              
                     if (!condition(item, context))
                     { continue; }
-                    results.Add(item);
+                    results.Add(new KeyValuePair<int, SceneNode>(level, item));
                     var elements = item.Items;
                     if(elements == null || elements.Count == 0)
                     { continue; }
                     stack.Push(new KeyValuePair<int, IList<SceneNode>>(i, currNodes));
                     i = -1;
+                    ++level;
                     currNodes = elements;
                     length = currNodes.Count;
                 }
@@ -87,6 +89,7 @@ namespace HelixToolkit.UWP
                 { break; }
                 var prev = stack.Pop();
                 i = prev.Key;
+                --level;
                 currNodes = prev.Value;
             }
         }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/DynamicReflectionMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/DynamicReflectionMap3D.cs
@@ -17,6 +17,28 @@ namespace HelixToolkit.Wpf.SharpDX
     public class DynamicReflectionMap3D : GroupModel3D
     {
         /// <summary>
+        /// Gets or sets a value indicating whether [enable reflector].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable reflector]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableReflector
+        {
+            get { return (bool)GetValue(EnableReflectorProperty); }
+            set { SetValue(EnableReflectorProperty, value); }
+        }
+
+        /// <summary>
+        /// The enable reflector property
+        /// </summary>
+        public static readonly DependencyProperty EnableReflectorProperty =
+            DependencyProperty.Register("EnableReflector", typeof(bool), typeof(DynamicReflectionMap3D), new PropertyMetadata(true, (d, e) =>
+            {
+                ((d as Element3D).SceneNode as IDynamicReflector).EnableReflector = (bool)e.NewValue;
+            }));
+
+
+        /// <summary>
         /// Gets or sets the size.
         /// </summary>
         /// <value>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/DynamicReflectionMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/DynamicReflectionMap3D.cs
@@ -1,4 +1,9 @@
-﻿#if NETFX_CORE
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+
+#if NETFX_CORE
 using Windows.UI.Xaml;
 namespace HelixToolkit.UWP
 #else
@@ -6,10 +11,100 @@ using System.Windows;
 namespace HelixToolkit.Wpf.SharpDX
 #endif
 {
-    using Model;
     using Model.Scene;
+    using Core;
+
     public class DynamicReflectionMap3D : GroupModel3D
     {
+        /// <summary>
+        /// Gets or sets the size.
+        /// </summary>
+        /// <value>
+        /// The size.
+        /// </value>
+        public int Size
+        {
+            get { return (int)GetValue(SizeProperty); }
+            set { SetValue(SizeProperty, value); }
+        }
+
+        /// <summary>
+        /// The size property
+        /// </summary>
+        public static readonly DependencyProperty SizeProperty =
+            DependencyProperty.Register("Size", typeof(int), typeof(DynamicReflectionMap3D), new PropertyMetadata(256, (d, e) =>
+            {
+                ((d as Element3D).SceneNode as IDynamicReflector).FaceSize = (int)e.NewValue;
+            }));
+
+
+        /// <summary>
+        /// Gets or sets the far field.
+        /// </summary>
+        /// <value>
+        /// The far field.
+        /// </value>
+        public double FarField
+        {
+            get { return (double)GetValue(FarFieldProperty); }
+            set { SetValue(FarFieldProperty, value); }
+        }
+
+        /// <summary>
+        /// The far field property
+        /// </summary>
+        public static readonly DependencyProperty FarFieldProperty =
+            DependencyProperty.Register("FarField", typeof(double), typeof(DynamicReflectionMap3D), new PropertyMetadata(100.0, (d, e) =>
+            {
+                ((d as Element3D).SceneNode as IDynamicReflector).FarField = (float)(double)e.NewValue;
+            }));
+
+
+        /// <summary>
+        /// Gets or sets the near field.
+        /// </summary>
+        /// <value>
+        /// The near field.
+        /// </value>
+        public double NearField
+        {
+            get { return (double)GetValue(NearFieldProperty); }
+            set { SetValue(NearFieldProperty, value); }
+        }
+
+        /// <summary>
+        /// The near field property
+        /// </summary>
+        public static readonly DependencyProperty NearFieldProperty =
+            DependencyProperty.Register("NearField", typeof(double), typeof(DynamicReflectionMap3D), new PropertyMetadata(0.1, (d, e) =>
+            {
+                ((d as Element3D).SceneNode as IDynamicReflector).NearField = (float)(double)e.NewValue;
+            }));
+
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is left handed.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is left handed; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsLeftHanded
+        {
+            get { return (bool)GetValue(IsLeftHandedProperty); }
+            set { SetValue(IsLeftHandedProperty, value); }
+        }
+
+        /// <summary>
+        /// The is left handed property
+        /// </summary>
+        public static readonly DependencyProperty IsLeftHandedProperty =
+            DependencyProperty.Register("IsLeftHanded", typeof(bool), typeof(DynamicReflectionMap3D), new PropertyMetadata(false, (d, e) =>
+            {
+                ((d as Element3D).SceneNode as IDynamicReflector).IsLeftHanded = (bool)e.NewValue;
+            }));
+
+
+
         protected override SceneNode OnCreateSceneNode()
         {
             return new DynamicReflectionNode();

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/DynamicReflectionMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/DynamicReflectionMap3D.cs
@@ -1,0 +1,18 @@
+﻿#if NETFX_CORE
+using Windows.UI.Xaml;
+namespace HelixToolkit.UWP
+#else
+using System.Windows;
+namespace HelixToolkit.Wpf.SharpDX
+#endif
+{
+    using Model;
+    using Model.Scene;
+    public class DynamicReflectionMap3D : GroupModel3D
+    {
+        protected override SceneNode OnCreateSceneNode()
+        {
+            return new DynamicReflectionNode();
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.SharedModel/HelixToolkit.SharpDX.SharedModel.projitems
+++ b/Source/HelixToolkit.SharpDX.SharedModel/HelixToolkit.SharpDX.SharedModel.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\CoordinateSystemModel3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\CrossSectionMeshGeometryModel3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\DepthPrepassElement3D.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Element3D\DynamicReflectionMap3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\Element3DCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\EnvironmentMap3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\InstancingBillboardModel3D.cs" />

--- a/Source/HelixToolkit.UWP/CommonDX/SwapChainCompositionRenderHost.cs
+++ b/Source/HelixToolkit.UWP/CommonDX/SwapChainCompositionRenderHost.cs
@@ -29,7 +29,7 @@ namespace HelixToolkit.UWP.CommonDX
         /// Initializes a new instance of the <see cref="SwapChainRenderHost"/> class.
         /// </summary>
         /// <param name="createRenderer">The create renderer.</param>
-        public SwapChainCompositionRenderHost(Func<Device, IRenderer> createRenderer) : base(createRenderer)
+        public SwapChainCompositionRenderHost(Func<IDevice3DResources, IRenderer> createRenderer) : base(createRenderer)
         {
         }
         /// <summary>

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/ZoomHandler.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/ZoomHandler.cs
@@ -115,6 +115,7 @@ namespace HelixToolkit.UWP
         /// <param name="zoomAround">
         /// The zoom around.
         /// </param>
+        /// <param name="isTouch"></param>
         public void Zoom(double delta, Point3D zoomAround, bool isTouch = false)
         {
             if (!this.CameraController.IsZoomEnabled)

--- a/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
@@ -552,6 +552,15 @@ namespace HelixToolkit.UWP
             renderHostInternal?.InvalidateRender();
         }
 
+        /// <summary>
+        /// Invalidates the scene graph.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void InvalidateSceneGraph()
+        {
+            renderHostInternal?.InvalidateSceneGraph();
+        }
+
         public void Update(TimeSpan timeStamp)
         {
             CameraController.OnTimeStep(timeStamp.Ticks);   

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DX11ImageSourceRenderHost.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DX11ImageSourceRenderHost.cs
@@ -28,7 +28,7 @@ namespace HelixToolkit.Wpf.SharpDX.Controls
 
         private DX11ImageSource surfaceD3D;
 
-        public DX11ImageSourceRenderHost(Func<Device, IRenderer> createRenderer) : base(createRenderer)
+        public DX11ImageSourceRenderHost(Func<IDevice3DResources, IRenderer> createRenderer) : base(createRenderer)
         {
             this.OnNewRenderTargetTexture += DX11ImageSourceRenderer_OnNewBufferCreated;
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/MouseHandlers/ZoomHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/MouseHandlers/ZoomHandler.cs
@@ -113,6 +113,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="zoomAround">
         /// The zoom around.
         /// </param>
+        /// <param name="isTouch"></param>
         public void Zoom(double delta, Point3D zoomAround, bool isTouch = false)
         {
             if (!this.Controller.IsZoomEnabled)

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/MultiViewports/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/MultiViewports/ModelContainer3DX.cs
@@ -138,28 +138,28 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <value>
         /// The per frame renderable.
         /// </value>
-        public List<SceneNode> PerFrameRenderables { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameRenderables : Constants.EmptyRenderable; } }
+        public List<KeyValuePair<int, SceneNode>> PerFrameFlattenedScene { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameFlattenedScene : Constants.EmptyRenderablePair; } }
         /// <summary>
         /// Gets the current frame Lights for rendering.
         /// </summary>
         /// <value>
         /// The per frame renderable.
         /// </value>
-        public IEnumerable<LightCoreBase> PerFrameLights { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameLights : Enumerable.Empty<LightCoreBase>(); } }
+        public IEnumerable<LightNode> PerFrameLights { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameLights : Enumerable.Empty<LightNode>(); } }
         /// <summary>
         /// Gets the per frame post effect cores.
         /// </summary>
         /// <value>
         /// The per frame post effect cores.
         /// </value>
-        public List<RenderCore> PerFrameGeneralCoresWithPostEffect { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameGeneralCoresWithPostEffect : Constants.EmptyCore; } }
+        public List<SceneNode> PerFrameNodesWithPostEffect { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameNodesWithPostEffect : Constants.EmptyRenderable; } }
         /// <summary>
         /// Gets the per frame general render cores.
         /// </summary>
         /// <value>
         /// The per frame general render cores.
         /// </value>
-        public List<RenderCore> PerFrameGeneralRenderCores { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameGeneralRenderCores : Constants.EmptyCore; } }
+        public List<SceneNode> PerFrameGeneralNodes { get { return CurrentRenderHost != null ? CurrentRenderHost.PerFrameGeneralNodes : Constants.EmptyRenderable; } }
 
         /// <summary>
         /// Handles the change of the effects manager.
@@ -206,6 +206,17 @@ namespace HelixToolkit.Wpf.SharpDX
             foreach(var v in viewports)
             {
                 v.InvalidateRender();
+            }
+        }
+
+        /// <summary>
+        /// Invalidates the scene graph.
+        /// </summary>
+        public void InvalidateSceneGraph()
+        {
+            foreach (var v in viewports)
+            {
+                v.InvalidateSceneGraph();
             }
         }
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/ScreenDuplicationViewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/ScreenDuplicationViewport3DX.cs
@@ -270,6 +270,11 @@ namespace HelixToolkit.Wpf.SharpDX
             renderHostInternal?.InvalidateRender();
         }
 
+        public void InvalidateSceneGraph()
+        {
+            renderHostInternal?.InvalidateSceneGraph();
+        }
+
         public void Update(TimeSpan timeStamp)
         {
             

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -335,7 +335,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     }
                 }
             }
-            InvalidateRender();
+            InvalidateSceneGraph();
         }
 
         /// <summary>
@@ -518,11 +518,14 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public void InvalidateRender()
         {
-            var rh = this.renderHostInternal;
-            if (rh != null)
-            {
-                rh.InvalidateRender();
-            }
+            renderHostInternal?.InvalidateRender();
+        }
+        /// <summary>
+        /// Invalidates the scene graph.
+        /// </summary>
+        public void InvalidateSceneGraph()
+        {
+            renderHostInternal?.InvalidateSceneGraph();
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -29,6 +29,8 @@ namespace HelixToolkit.Wpf.SharpDX
     using Model;
     using Model.Scene;
     using Model.Scene2D;
+    using System.Runtime.CompilerServices;
+
     /// <summary>
     /// Provides a Viewport control.
     /// </summary>
@@ -335,7 +337,6 @@ namespace HelixToolkit.Wpf.SharpDX
                     }
                 }
             }
-            InvalidateSceneGraph();
         }
 
         /// <summary>
@@ -516,6 +517,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// Tries to invalidate the current render.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void InvalidateRender()
         {
             renderHostInternal?.InvalidateRender();
@@ -523,6 +525,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// Invalidates the scene graph.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void InvalidateSceneGraph()
         {
             renderHostInternal?.InvalidateSceneGraph();


### PR DESCRIPTION
Improve RenderHost. Use lazy scene graph flatten. Only flatten scene graph if scene graph changed, such as model attached/detached.
Implement dynamic cube map. Update Environment demo and lighting demo to show dynamic cube map example.