### PR TITLE
Fix UWP camera binding failed issue.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -543,7 +543,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// </returns>
         protected virtual bool CanRender()
         {
-            return IsInitialized && IsRendering && (UpdateRequested || updateCounter < 2) && viewport != null && ActualWidth > 10 && ActualHeight > 10;
+            return IsInitialized && IsRendering && (UpdateRequested || updateCounter < 2) && viewport != null && viewport.CameraCore != null && ActualWidth > 10 && ActualHeight > 10;
         }
         /// <summary>
         /// Updates the and render.

--- a/Source/HelixToolkit.UWP/Themes/Generic.xaml
+++ b/Source/HelixToolkit.UWP/Themes/Generic.xaml
@@ -65,4 +65,14 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <local:PerspectiveCamera
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="perspectiveCamera" />
+
+    <local:OrthographicCamera
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="orthographicCamera" />
 </ResourceDictionary>


### PR DESCRIPTION
Ref: https://social.msdn.microsoft.com/Forums/en-US/5e42e6a1-740f-48b2-9908-09a474f9d413/error-converter-failed-to-convert-value-of-type-when-type-is-derived?forum=winappswithcsharp

Add camera to Theme.xaml to solve this issue