### PR TITLE
Set mesh name in ObjReader (WPF)

### DIFF
--- a/Source/HelixToolkit.Wpf.Tests/Importers/ObjReaderTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Importers/ObjReaderTests.cs
@@ -431,6 +431,34 @@ Kd 0 0 0
                 File.Delete(tempMtl);
             }
         }
+
+        [Test]
+        public void Name_Valid()
+        {
+            string content = @"
+g group1
+
+v 0 0 0
+v 1 0 0
+v 0 1 0
+
+f 1 2 3
+";
+
+            string expectedName = "group1";
+
+            var buffer = Encoding.UTF8.GetBytes(content);
+
+            using (var stream = new MemoryStream(buffer, false))
+            {
+                var model = new ObjReader().Read(stream);
+                var mesh = model.Children[0];
+
+                string name = mesh.GetName();
+
+                Assert.AreEqual(name, expectedName);
+            }
+        }
     }
 
     public static class Model3DTestExtensions 

--- a/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf/Importers/ObjReader.cs
@@ -690,6 +690,8 @@ namespace HelixToolkit.Wpf
                     {
                         foreach (var gm in g.CreateModels())
                         {
+                            gm.SetName(g.Name);
+
                             if (this.Freeze)
                             {
                                 gm.Freeze();


### PR DESCRIPTION
Fix #815 

Set and test mesh name in ObjReader.