### PR TITLE
Visuals Point/Rect selection

### DIFF
--- a/Source/Examples/WPF/ExampleBrowser/Examples/RectSelection/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/RectSelection/MainWindow.xaml
@@ -6,6 +6,8 @@
     <DockPanel>
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="7, 5">
             <ComboBox SelectedValue="{Binding SelectionMode}" ItemsSource="{Binding SelectionModes}"/>
+            <TextBlock Text="SelectedVisuals:"/>
+            <TextBlock Text="{Binding SelectedVisuals}"/>
         </StackPanel>
         <helix:HelixViewport3D x:Name="view1" x:FieldModifier="private">
             <helix:DefaultLights />

--- a/Source/Examples/WPF/ExampleBrowser/Examples/RectSelection/MainWindow.xaml.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/RectSelection/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ namespace RectSelection
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
@@ -31,14 +32,20 @@ namespace RectSelection
         }
     }
 
-    public class MainWindowViewModel
+    public class MainWindowViewModel : INotifyPropertyChanged
     {
         private IList<Model3D> selectedModels;
+        private IList<Visual3D> selectedVisuals;
 
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
         public MainWindowViewModel(Viewport3D viewport)
         {
-            this.RectangleSelectionCommand = new RectangleSelectionCommand(viewport, this.HandleSelectionEvent);
-            this.PointSelectionCommand = new PointSelectionCommand(viewport, this.HandleSelectionEvent);
+            this.RectangleSelectionCommand = new RectangleSelectionCommand(viewport, this.HandleSelectionModelsEvent, this.HandleSelectionVisualsEvent);
+            this.PointSelectionCommand = new PointSelectionCommand(viewport, this.HandleSelectionModelsEvent, this.HandleSelectionVisualsEvent);
         }
 
         public RectangleSelectionCommand RectangleSelectionCommand { get; private set; }
@@ -66,7 +73,20 @@ namespace RectSelection
             }
         }
 
-        private void HandleSelectionEvent(object sender, ModelsSelectedEventArgs args)
+        public string SelectedVisuals
+        {
+            get
+            {
+                return selectedVisuals == null ? "" : string.Join("; ", selectedVisuals.Select(x => x.GetType().Name));
+            }
+        }
+
+        private void HandleSelectionVisualsEvent(object sender, VisualsSelectedEventArgs args)
+        {
+            this.selectedVisuals = args.SelectedVisuals;
+            RaisePropertyChanged(nameof(SelectedVisuals));
+        }
+        private void HandleSelectionModelsEvent(object sender, ModelsSelectedEventArgs args)
         {
             this.ChangeMaterial(this.selectedModels, Materials.Blue);
             this.selectedModels = args.SelectedModels;

--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
@@ -151,6 +151,9 @@
     <Compile Include="SelectionCommands\RectangleSelectionCommand.cs" />
     <Compile Include="SelectionCommands\SelectionCommand.cs" />
     <Compile Include="SelectionCommands\SelectionHitMode.cs" />
+    <Compile Include="SelectionCommands\VisualsSelectedByPointEventArgs.cs" />
+    <Compile Include="SelectionCommands\VisualsSelectedByRectangleEventArgs.cs" />
+    <Compile Include="SelectionCommands\VisualsSelectedEventArgs.cs" />
     <Compile Include="ShaderEffects\InterlacedEffect.cs" />
     <Compile Include="ShaderEffects\AnaglyphMethod.cs" />
     <Compile Include="Visual3Ds\LightSetups\DirectionalHeadLight.cs" />

--- a/Source/HelixToolkit.Wpf/Helpers/Model3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Model3DHelper.cs
@@ -108,6 +108,25 @@ namespace HelixToolkit.Wpf
                 action(gm, childTransform);
             }
         }
+
+        /// <summary>
+        /// Traverses the Model3D tree and invokes the specified action on each Model3D of the specified type.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type.
+        /// </typeparam>
+        /// <param name="model">
+        /// The model.
+        /// </param>
+        /// <param name="visual">
+        /// The visual.
+        /// </param>
+        /// <param name="transform">
+        /// The transform.
+        /// </param>
+        /// <param name="action">
+        /// The action.
+        /// </param>
         public static void Traverse<T>(this Model3D model, Visual3D visual, Transform3D transform, Action<T, Visual3D, Transform3D> action)
             where T : Model3D
         {

--- a/Source/HelixToolkit.Wpf/Helpers/Model3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Model3DHelper.cs
@@ -108,5 +108,25 @@ namespace HelixToolkit.Wpf
                 action(gm, childTransform);
             }
         }
+        public static void Traverse<T>(this Model3D model, Visual3D visual, Transform3D transform, Action<T, Visual3D, Transform3D> action)
+            where T : Model3D
+        {
+            var mg = model as Model3DGroup;
+            if (mg != null)
+            {
+                var childTransform = Transform3DHelper.CombineTransform(model.Transform, transform);
+                foreach (var m in mg.Children)
+                {
+                    Traverse(m, visual, childTransform, action);
+                }
+            }
+
+            var gm = model as T;
+            if (gm != null)
+            {
+                var childTransform = Transform3DHelper.CombineTransform(model.Transform, transform);
+                action(gm, visual, childTransform);
+            }
+        }
     }
 }

--- a/Source/HelixToolkit.Wpf/Helpers/Viewport3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Viewport3DHelper.cs
@@ -215,12 +215,12 @@ namespace HelixToolkit.Wpf
             if (rectangle.Width < Tolerance && rectangle.Height < Tolerance)
             {
                 var hitResults = FindHits(viewport, rectangle.BottomLeft);
-                return hitResults.Select(x => x.Model).Select(model => new RectangleHitResult(model));
+                return hitResults.Select(x => new RectangleHitResult(x.Model, x.Visual));
             }
 
             var results = new List<RectangleHitResult>();
             viewport.Children.Traverse<GeometryModel3D>(
-                (model, transform) =>
+                (model, visual, transform) =>
                 {
                     var geometry = model.Geometry as MeshGeometry3D;
                     if (geometry == null || geometry.Positions == null || geometry.TriangleIndices == null)
@@ -261,7 +261,7 @@ namespace HelixToolkit.Wpf
 
                     if (status)
                     {
-                        results.Add(new RectangleHitResult(model));
+                        results.Add(new RectangleHitResult(model, visual));
                     }
                 });
 
@@ -1231,15 +1231,21 @@ namespace HelixToolkit.Wpf
             /// Initializes a new instance of the <see cref="RectangleHitResult" /> class.
             /// </summary>
             /// <param name="model">The hit model.</param>
-            public RectangleHitResult(Model3D model)
+            public RectangleHitResult(Model3D model, Visual3D visual)
             {
                 this.Model = model;
+                this.Visual = visual;
             }
 
             /// <summary>
             /// Gets the hit model.
             /// </summary>
             public Model3D Model { get; private set; }
+            
+            /// <summary>
+            /// Gets the hit visual.
+            /// </summary>
+            public Visual3D Visual { get; private set; }
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf/Helpers/Viewport3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Viewport3DHelper.cs
@@ -1231,6 +1231,7 @@ namespace HelixToolkit.Wpf
             /// Initializes a new instance of the <see cref="RectangleHitResult" /> class.
             /// </summary>
             /// <param name="model">The hit model.</param>
+            /// <param name="visual">The hit visual.</param>
             public RectangleHitResult(Model3D model, Visual3D visual)
             {
                 this.Model = model;

--- a/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
@@ -281,6 +281,19 @@ namespace HelixToolkit.Wpf
                 Traverse(child, action);
             }
         }
+
+        /// <summary>
+        /// Traverses the Visual3D/Model3D tree and invokes the specified action on each Model3D of the specified type.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type filter.
+        /// </typeparam>
+        /// <param name="visuals">
+        /// The visuals.
+        /// </param>
+        /// <param name="action">
+        /// The action.
+        /// </param>
         public static void Traverse<T>(this Visual3DCollection visuals, Action<T, Visual3D, Transform3D> action) where T : Model3D
         {
             foreach (var child in visuals)
@@ -305,6 +318,19 @@ namespace HelixToolkit.Wpf
         {
             Traverse(visual, Transform3D.Identity, action);
         }
+
+        /// <summary>
+        /// Traverses the Visual3D/Model3D tree and invokes the specified action on each Model3D of the specified type.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type filter.
+        /// </typeparam>
+        /// <param name="visual">
+        /// The visual.
+        /// </param>
+        /// <param name="action">
+        /// The action.
+        /// </param>
         public static void Traverse<T>(this Visual3D visual, Action<T, Visual3D, Transform3D> action) where T : Model3D
         {
             Traverse(visual, Transform3D.Identity, action);

--- a/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
@@ -281,6 +281,13 @@ namespace HelixToolkit.Wpf
                 Traverse(child, action);
             }
         }
+        public static void Traverse<T>(this Visual3DCollection visuals, Action<T, Visual3D, Transform3D> action) where T : Model3D
+        {
+            foreach (var child in visuals)
+            {
+                Traverse(child, action);
+            }
+        }
 
         /// <summary>
         /// Traverses the Visual3D/Model3D tree and invokes the specified action on each Model3D of the specified type.
@@ -295,6 +302,10 @@ namespace HelixToolkit.Wpf
         /// The action.
         /// </param>
         public static void Traverse<T>(this Visual3D visual, Action<T, Transform3D> action) where T : Model3D
+        {
+            Traverse(visual, Transform3D.Identity, action);
+        }
+        public static void Traverse<T>(this Visual3D visual, Action<T, Visual3D, Transform3D> action) where T : Model3D
         {
             Traverse(visual, Transform3D.Identity, action);
         }
@@ -410,6 +421,21 @@ namespace HelixToolkit.Wpf
             if (model != null)
             {
                 model.Traverse(childTransform, action);
+            }
+
+            foreach (var child in GetChildren(visual))
+            {
+                Traverse(child, childTransform, action);
+            }
+        }
+        private static void Traverse<T>(Visual3D visual, Transform3D transform, Action<T, Visual3D, Transform3D> action)
+            where T : Model3D
+        {
+            var childTransform = Transform3DHelper.CombineTransform(visual.Transform, transform);
+            var model = GetModel(visual);
+            if (model != null)
+            {
+                model.Traverse(visual, childTransform, action);
             }
 
             foreach (var child in GetChildren(visual))

--- a/Source/HelixToolkit.Wpf/SelectionCommands/PointSelectionCommand.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/PointSelectionCommand.cs
@@ -30,9 +30,30 @@ namespace HelixToolkit.Wpf
         /// Initializes a new instance of the <see cref="PointSelectionCommand" /> class.
         /// </summary>
         /// <param name="viewport">The viewport.</param>
-        /// <param name="eventHandler">The selection event handler.</param>
-        public PointSelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> eventHandler)
-            : base(viewport, eventHandler)
+        /// <param name="modelsSelectedEventHandler">The selection event handler.</param>
+        public PointSelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> modelsSelectedEventHandler)
+            : base(viewport, modelsSelectedEventHandler, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PointSelectionCommand" /> class.
+        /// </summary>
+        /// <param name="viewport">The viewport.</param>
+        /// <param name="visualsSelectedEventHandler">The selection event handler.</param>
+        public PointSelectionCommand(Viewport3D viewport, EventHandler<VisualsSelectedEventArgs> visualsSelectedEventHandler)
+            : base(viewport, null, visualsSelectedEventHandler)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PointSelectionCommand" /> class.
+        /// </summary>
+        /// <param name="viewport">The viewport.</param>
+        /// <param name="modelsSelectedEventHandler">The selection event handler.</param>
+        /// <param name="visualsSelectedEventHandler">The selection event handler.</param>
+        public PointSelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> modelsSelectedEventHandler, EventHandler<VisualsSelectedEventArgs> visualsSelectedEventHandler)
+            : base(viewport, modelsSelectedEventHandler, visualsSelectedEventHandler)
         {
         }
 
@@ -45,8 +66,11 @@ namespace HelixToolkit.Wpf
             base.Started(e);
             this.position = e.CurrentPosition;
 
-            var selectedModels = this.Viewport.FindHits(this.position).Select(hit => hit.Model).ToList();
+            var res = this.Viewport.FindHits(this.position);
+            var selectedModels = res.Select(hit => hit.Model).ToList();
+            var selectedVisuals = res.Select(hit => hit.Visual).ToList();
             this.OnModelsSelected(new ModelsSelectedByPointEventArgs(selectedModels, this.position));
+            this.OnVisualsSelected(new VisualsSelectedByPointEventArgs(selectedVisuals, this.position));
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf/SelectionCommands/RectangleSelectionCommand.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/RectangleSelectionCommand.cs
@@ -38,9 +38,30 @@ namespace HelixToolkit.Wpf
         /// Initializes a new instance of the <see cref="RectangleSelectionCommand" /> class.
         /// </summary>
         /// <param name="viewport">The viewport.</param>
-        /// <param name="eventHandler">The selection event handler.</param>
-        public RectangleSelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> eventHandler)
-            : base(viewport, eventHandler)
+        /// <param name="modelsSelectedEventHandler">The selection event handler.</param>
+        public RectangleSelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> modelsSelectedEventHandler)
+            : base(viewport, modelsSelectedEventHandler, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RectangleSelectionCommand" /> class.
+        /// </summary>
+        /// <param name="viewport">The viewport.</param>
+        /// <param name="visualsSelectedEventHandler">The selection event handler.</param>
+        public RectangleSelectionCommand(Viewport3D viewport, EventHandler<VisualsSelectedEventArgs> visualsSelectedEventHandler)
+            : base(viewport, null, visualsSelectedEventHandler)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RectangleSelectionCommand" /> class.
+        /// </summary>
+        /// <param name="viewport">The viewport.</param>
+        /// <param name="modelsSelectedEventHandler">The selection event handler.</param>
+        /// <param name="visualsSelectedEventHandler">The selection event handler.</param>
+        public RectangleSelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> modelsSelectedEventHandler, EventHandler<VisualsSelectedEventArgs> visualsSelectedEventHandler)
+            : base(viewport, modelsSelectedEventHandler, visualsSelectedEventHandler)
         {
         }
 
@@ -76,8 +97,9 @@ namespace HelixToolkit.Wpf
         {
             this.HideRectangle();
 
-            var selectedModels =
-                    this.Viewport.FindHits(this.selectionRect, this.SelectionHitMode).Select(hit => hit.Model).ToList();
+            var res = this.Viewport.FindHits(this.selectionRect, this.SelectionHitMode);
+            
+            var selectedModels = res.Select(hit => hit.Model).ToList();
 
             // We do not handle the point selection, unless no models are selected. If no models are selected, we clear the
             // existing selection.
@@ -87,6 +109,8 @@ namespace HelixToolkit.Wpf
             }
 
             this.OnModelsSelected(new ModelsSelectedByRectangleEventArgs(selectedModels, this.selectionRect));
+            var selectedVisuals = res.Select(hit => hit.Visual).ToList();
+            this.OnVisualsSelected(new VisualsSelectedByRectangleEventArgs(selectedVisuals, this.selectionRect));
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf/SelectionCommands/SelectionCommand.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/SelectionCommand.cs
@@ -34,10 +34,11 @@ namespace HelixToolkit.Wpf
         /// </summary>
         /// <param name="viewport">The viewport.</param>
         /// <param name="eventHandler">The selection event handler.</param>
-        protected SelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> eventHandler)
+        protected SelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> eventHandlerModels, EventHandler<VisualsSelectedEventArgs> eventHandlerVisuals)
         {
             this.Viewport = viewport;
-            this.ModelsSelected = eventHandler;
+            this.ModelsSelected = eventHandlerModels;
+            this.VisualsSelected = eventHandlerVisuals;
         }
 
         /// <summary>
@@ -49,6 +50,11 @@ namespace HelixToolkit.Wpf
         /// Occurs when models are selected.
         /// </summary>
         private event EventHandler<ModelsSelectedEventArgs> ModelsSelected;
+
+        /// <summary>
+        /// Occurs when visuals are selected.
+        /// </summary>
+        private event EventHandler<VisualsSelectedEventArgs> VisualsSelected;
 
         /// <summary>
         /// Gets or sets the selection hit mode.
@@ -123,6 +129,19 @@ namespace HelixToolkit.Wpf
         protected virtual void OnModelsSelected(ModelsSelectedEventArgs e)
         {
             var handler = this.ModelsSelected;
+            if (handler != null)
+            {
+                handler(this.Viewport, e);
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="E:VisualsSelected" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="VisualsSelectedEventArgs"/> instance containing the event data.</param>
+        protected virtual void OnVisualsSelected(VisualsSelectedEventArgs e)
+        {
+            var handler = this.VisualsSelected;
             if (handler != null)
             {
                 handler(this.Viewport, e);

--- a/Source/HelixToolkit.Wpf/SelectionCommands/SelectionCommand.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/SelectionCommand.cs
@@ -33,7 +33,8 @@ namespace HelixToolkit.Wpf
         /// Initializes a new instance of the <see cref="SelectionCommand"/> class.
         /// </summary>
         /// <param name="viewport">The viewport.</param>
-        /// <param name="eventHandler">The selection event handler.</param>
+        /// <param name="eventHandlerModels">The selection event handler for models.</param>
+        /// <param name="eventHandlerVisuals">The selection event handler for visuals.</param>
         protected SelectionCommand(Viewport3D viewport, EventHandler<ModelsSelectedEventArgs> eventHandlerModels, EventHandler<VisualsSelectedEventArgs> eventHandlerVisuals)
         {
             this.Viewport = viewport;

--- a/Source/HelixToolkit.Wpf/SelectionCommands/SelectionHitMode.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/SelectionHitMode.cs
@@ -23,5 +23,6 @@ namespace HelixToolkit.Wpf
         /// Selects models completely inside selection range.
         /// </summary>
         Inside,
+
     }
 }

--- a/Source/HelixToolkit.Wpf/SelectionCommands/VisualsSelectedByPointEventArgs.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/VisualsSelectedByPointEventArgs.cs
@@ -1,0 +1,40 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="VisualsSelectedByPointEventArgs.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// <summary>
+//   Provides event data for the VisualsSelected event of the PointSelectionCommand.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace HelixToolkit.Wpf
+{
+    using System.Collections.Generic;
+    using System.Windows;
+    using System.Windows.Media.Media3D;
+
+    /// <summary>
+    /// Provides event data for the VisualsSelected event of the <see cref="PointSelectionCommand" />.
+    /// </summary>
+    public class VisualsSelectedByPointEventArgs : VisualsSelectedEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisualsSelectedByPointEventArgs"/> class.
+        /// </summary>
+        /// <param name="selectedVisuals">The selected visuals.</param>
+        /// <param name="position">The position.</param>
+        /// <remarks>
+        /// For the visuals selected by point, they are sorted by distance in ascending order.
+        /// </remarks>
+        public VisualsSelectedByPointEventArgs(IList<Visual3D> selectedVisuals, Point position)
+            : base(selectedVisuals, true)
+        {
+            this.Position = position;
+        }
+
+        /// <summary>
+        /// Gets the rectangle of selection.
+        /// </summary>
+        public Point Position { get; private set; }
+    }
+}

--- a/Source/HelixToolkit.Wpf/SelectionCommands/VisualsSelectedByRectangleEventArgs.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/VisualsSelectedByRectangleEventArgs.cs
@@ -1,0 +1,40 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="VisualsSelectedByRectangleEventArgs.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// <summary>
+//   Provides event data for the VisualsSelected event of the RectangleSelectionCommand.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace HelixToolkit.Wpf
+{
+    using System.Collections.Generic;
+    using System.Windows;
+    using System.Windows.Media.Media3D;
+
+    /// <summary>
+    /// Provides event data for the VisualsSelected event of the <see cref="RectangleSelectionCommand" />.
+    /// </summary>
+    public class VisualsSelectedByRectangleEventArgs : VisualsSelectedEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisualsSelectedByRectangleEventArgs"/> class.
+        /// </summary>
+        /// <param name="selectedVisuals">The selected visuals.</param>
+        /// <param name="rectangle">The selection rectangle.</param>
+        /// <remarks>
+        /// For the visuals selected by rectangle, they are not sorted by distance in ascending order.
+        /// </remarks>
+        public VisualsSelectedByRectangleEventArgs(IList<Visual3D> selectedVisuals, Rect rectangle)
+            : base(selectedVisuals, false)
+        {
+            this.Rectangle = rectangle;
+        }
+
+        /// <summary>
+        /// Gets the rectangle of selection.
+        /// </summary>
+        public Rect Rectangle { get; private set; }
+    }
+}

--- a/Source/HelixToolkit.Wpf/SelectionCommands/VisualsSelectedEventArgs.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/VisualsSelectedEventArgs.cs
@@ -1,0 +1,45 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="VisualsSelectedEventArgs.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// <summary>
+//   Provides event data for the VisualsSelected event of the SelectionCommand.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace HelixToolkit.Wpf
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Windows.Media.Media3D;
+
+    /// <summary>
+    /// Provides event data for the VisualsSelected event of the <see cref="SelectionCommand" />.
+    /// </summary>
+    public class VisualsSelectedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VisualsSelectedEventArgs" /> class.
+        /// </summary>
+        /// <param name="selected">The selected.</param>
+        /// <param name="areSortedByDistanceAscending">if set to <c>true</c> the selected visuals are sorted by distance in ascending order.</param>
+        public VisualsSelectedEventArgs(IList<Visual3D> selected, bool areSortedByDistanceAscending)
+        {
+            this.SelectedVisuals = selected;
+            this.AreSortedByDistanceAscending = areSortedByDistanceAscending;
+        }
+
+        /// <summary>
+        /// Gets the selected visuals.
+        /// </summary>
+        public IList<Visual3D> SelectedVisuals { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the selected visuals are sorted by distance in ascending order.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the selected visuals are sorted by distance in ascending order; otherwise, <c>false</c>.
+        /// </value>
+        public bool AreSortedByDistanceAscending { get; private set; }
+    }
+}


### PR DESCRIPTION
Ability to select not only Models but also Visuals with RectangleSelectionCommand and PointSelectionCommand.
In XXXSelectionCommand ctor you can specify an handler for SelectionModelsEvent (as before) or an handler for SelectionVisualsEvent or both.
Extended all Traverse<> funcions to pass the visual all around.
Updated the example "RectSelection".
If ok can close #841
