### PR TITLE
Fix triangulation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@
 
 Aleksey Shubin <alekseysshubin@gmail.com>
 ando23 <andreas@herzig-net.de>
+Beppe Marazzi <beppemarazzi@gmail.com>
 Benglin (Ben) Goh <benglin@outlook.com>
 Brad Phelan <bradphelan@xtargets.com>
 Carl Philipp Bickmeier <c.bickmeier@diomex.de>

--- a/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
+++ b/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
@@ -1957,15 +1957,18 @@ namespace HelixToolkit.Wpf
         public void AddPolygon(IList<Point> points, Vector3D axisX, Vector3D axisY, Point3D origin)
         {
             var indices = SweepLinePolygonTriangulator.Triangulate(points);
-            var index0 = this.positions.Count;
-            foreach (var p in points)
+            if (indices != null)
             {
-                this.positions.Add(origin + (axisX * p.X) + (axisY * p.Y));
-            }
+                var index0 = this.positions.Count;
+                foreach (var p in points)
+                {
+                    this.positions.Add(origin + (axisX * p.X) + (axisY * p.Y));
+                }
 
-            foreach (var i in indices)
-            {
-                this.triangleIndices.Add(index0 + i);
+                foreach (var i in indices)
+                {
+                    this.triangleIndices.Add(index0 + i);
+                }
             }
         }
         /// <summary>
@@ -3333,6 +3336,9 @@ namespace HelixToolkit.Wpf
             {
                 throw new ArgumentNullException("fanTextureCoordinates");
             }
+
+            if (fanPositions.Count < 3)
+                return;
 
             int index0 = this.positions.Count;
             foreach (var p in fanPositions)

--- a/Source/HelixToolkit.Wpf.Tests/Helpers/MeshBuilderTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Helpers/MeshBuilderTests.cs
@@ -6,7 +6,9 @@
 
 namespace HelixToolkit.Wpf.Tests
 {
+    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Windows;
     using System.Windows.Media.Media3D;
 
     using HelixToolkit.Wpf;
@@ -60,5 +62,63 @@ namespace HelixToolkit.Wpf.Tests
                 Assert.AreEqual(new Point3D(0, 0, 1), normal);
             }
         }
+
+        [Test]
+        public void AddInvalidPolygon()
+        {
+            var meshBuilder = new MeshBuilder(false, false);
+            Assert.AreEqual(0, meshBuilder.Positions.Count);
+            Assert.AreEqual(0, meshBuilder.TriangleIndices.Count);
+            var p = new List<Point>
+                {
+                    new Point(0, 0 ),
+                    new Point(1, 1 ),
+                };
+
+            meshBuilder.AddPolygon(p, new Vector3D(0, 1, 0), new Vector3D(1, 0, 0), new Point3D(0, 0, 0));
+            Assert.AreEqual(0, meshBuilder.Positions.Count);
+            Assert.AreEqual(0, meshBuilder.TriangleIndices.Count);
+
+            var p3 = new List<Point3D>
+                {
+                    new Point3D(0, 0, 0),
+                    new Point3D(1, 1, 0),
+                };
+            meshBuilder.AddPolygon(p3);
+            Assert.AreEqual(0, meshBuilder.Positions.Count);
+            Assert.AreEqual(0, meshBuilder.TriangleIndices.Count);
+        }
+
+        [Test]
+        public void AddValidPolygon()
+        {
+            var meshBuilder = new MeshBuilder(false, false);
+            Assert.AreEqual(0, meshBuilder.Positions.Count);
+            Assert.AreEqual(0, meshBuilder.TriangleIndices.Count);
+            var p = new List<Point>
+                {
+                    new Point(0, 0 ),
+                    new Point(1, 1 ),
+                    new Point(2, 2 ),
+                };
+
+            meshBuilder.AddPolygon(p, new Vector3D(0, 1, 0), new Vector3D(1, 0, 0), new Point3D(0, 0, 0));
+            Assert.AreEqual(3, meshBuilder.Positions.Count);
+            Assert.AreEqual(3, meshBuilder.TriangleIndices.Count);
+
+            var p3 = new List<Point3D>
+                {
+                    new Point3D(0, 0, 0),
+                    new Point3D(1, 1, 0),
+                    new Point3D(2, 2, 0),
+                };
+            meshBuilder.AddPolygon(p3);
+            Assert.AreEqual(6, meshBuilder.Positions.Count);
+            Assert.AreEqual(6, meshBuilder.TriangleIndices.Count);
+
+
+
+        }
+
     }
 }


### PR DESCRIPTION
When passing invalid polygon with 2 or less points, AddPolygon overload accepting IList<Point> failed with NullReferenceException because SweepLinePolygonTriangulator.Triangulate returns null.
With my fix the behavior is the same of other overloads (ignore)