### PR TITLE
Improve and bug fix

### DIFF
--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomMeshCore.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomMeshCore.cs
@@ -35,7 +35,7 @@ namespace CustomShaderDemo
         {
             set
             {
-                if (SetAffectsRender(ref colorGradients, value))
+                if (SetAffectsCanRenderFlag(ref colorGradients, value))
                 {
                     colorChanged = true;
                 }
@@ -107,9 +107,9 @@ namespace CustomShaderDemo
             }
         }
 
-        protected override bool CanRender(RenderContext context)
+        protected override bool OnUpdateCanRenderFlag()
         {
-            return base.CanRender(context) && ColorGradients != null;
+            return base.OnUpdateCanRenderFlag() && ColorGradients != null;
         }
 
         protected override void OnRender(RenderContext context, DeviceContextProxy deviceContext)

--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj
@@ -570,6 +570,20 @@ xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(Solut
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
     </FxCompile>
+    <FxCompile Include="PS\psMeshDiffuseMapOIT.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">meshDiffuseOIT</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">meshDiffuseOIT</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">meshDiffuseOIT</EntryPointName>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">meshDiffuseOIT</EntryPointName>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+    </FxCompile>
     <FxCompile Include="PS\psMeshXRay.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>

--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj.filters
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj.filters
@@ -264,5 +264,8 @@
     <FxCompile Include="PS\psEffectMeshDiffuseXRayGrid.hlsl">
       <Filter>PS</Filter>
     </FxCompile>
+    <FxCompile Include="PS\psMeshDiffuseMapOIT.hlsl">
+      <Filter>PS</Filter>
+    </FxCompile>
   </ItemGroup>
 </Project>

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psEffectMeshBorderHighlight.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psEffectMeshBorderHighlight.hlsl
@@ -2,30 +2,25 @@
 #include"..\Common\CommonBuffers.hlsl"
 #pragma pack_matrix( row_major )
 
-static const float offset[4] = { 0.0, 1.0, 2.0, 3.0 };
-static const float weight[4] = { 0.2, 0.2, 0.2, 0.2 };
+static const float offset[2] = { 0, 1 };
 static const float scale = 1;
 
 float4 main(MeshOutlinePS_INPUT input) : SV_Target
 {
     float4 color = texDiffuseMap.Sample(samplerDiffuse, input.Tex);
-    float a = color.a * weight[0];
     float x = vViewport.z * Param._m00;
     float y = vViewport.w * Param._m01;
     [unroll]
-    for (int i = 1; i < 4; ++i)
+    for (int i = 1; i < 2; ++i)
     {
         float off = offset[i];
         float offX = off * x;
         float offY = off * y;
         float4 c = texDiffuseMap.Sample(samplerDiffuse, input.Tex + float2(offX, offY));
-        c += texDiffuseMap.Sample(samplerDiffuse, input.Tex - float2(offX, offY));
-        c += texDiffuseMap.Sample(samplerDiffuse, input.Tex + float2(-offX, offY));
-        c += texDiffuseMap.Sample(samplerDiffuse, input.Tex - float2(-offX, offY));
-        color += c;
-        a = mad(weight[i], c.a, a);
+        c = max(c, texDiffuseMap.Sample(samplerDiffuse, input.Tex - float2(offX, offY)));
+        c = max(c, texDiffuseMap.Sample(samplerDiffuse, input.Tex + float2(-offX, offY)));
+        color = max(c, texDiffuseMap.Sample(samplerDiffuse, input.Tex - float2(-offX, offY)));
     }
-    color.a = a;
     return saturate(color);
 
 }

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshDiffuseMapOIT.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshDiffuseMapOIT.hlsl
@@ -1,0 +1,40 @@
+#ifndef PSMESHDIFFUSEMAPOIT_HLSL
+#define PSMESHDIFFUSEMAPOIT_HLSL
+
+#define CLIPPLANE
+#define MESH
+
+#include"..\Common\Common.hlsl"
+#include"..\Common\DataStructs.hlsl"
+#include"psCommon.hlsl"
+#include"psDiffuseMap.hlsl"
+//--------------------------------------------------------------------------------------
+// PER PIXEL LIGHTING - BLINN-PHONG for Order Independant Transparent A-buffer rendering
+// http://casual-effects.blogspot.com/2014/03/weighted-blended-order-independent.html
+//--------------------------------------------------------------------------------------
+
+PSOITOutput meshDiffuseOIT(PSInput input)
+{
+    float4 color = main(input);
+    if (bRenderOIT)
+    {
+        return calculateOIT(color, input.vEye.w, input.p.z);
+        //// Insert your favorite weighting function here. The color-based factor
+        //// avoids color pollution from the edges of wispy clouds. The z-based
+        //// factor gives precedence to nearer surfaces.
+        //float weight = color.a * clamp(0.03 / (1e-5 + pow((input.p.z/input.p.w), 4.0)), 1e-2, 3e3);
+        //// Blend Func: GL_ONE, GL_ONE
+        //// Switch to premultiplied alpha and weight
+        //output.color = float4(color.rgb * color.a, color.a) * weight;
+ 
+        //// Blend Func: GL_ZERO, GL_ONE_MINUS_SRC_ALPHA
+        //output.alpha.a = color.a;
+    }
+    else
+    {
+        PSOITOutput output = (PSOITOutput) 0;
+        output.color = color;
+        return output;
+    }
+}
+#endif

--- a/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
+++ b/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
@@ -64,6 +64,7 @@
     <None Remove="Resources\psMeshClipPlaneBackface.cso" />
     <None Remove="Resources\psMeshClipPlaneQuad.cso" />
     <None Remove="Resources\psMeshColorStripe.cso" />
+    <None Remove="Resources\psMeshDiffuseMapOIT.cso" />
     <None Remove="Resources\psMeshXRay.cso" />
     <None Remove="Resources\psNormals.cso" />
     <None Remove="Resources\psParticle.cso" />
@@ -133,6 +134,7 @@
     <EmbeddedResource Include="Resources\psMeshClipPlaneBackface.cso" />
     <EmbeddedResource Include="Resources\psMeshClipPlaneQuad.cso" />
     <EmbeddedResource Include="Resources\psMeshColorStripe.cso" />
+    <EmbeddedResource Include="Resources\psMeshDiffuseMapOIT.cso" />
     <EmbeddedResource Include="Resources\psMeshXRay.cso" />
     <EmbeddedResource Include="Resources\psNormals.cso" />
     <EmbeddedResource Include="Resources\psParticle.cso" />

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
@@ -40,16 +40,16 @@ namespace HelixToolkit.UWP.Core
         {
             set
             {
-                if (instanceBuffer != value)
+                var old = instanceBuffer;
+                if(SetAffectsCanRenderFlag(ref instanceBuffer, value))
                 {
-                    if (instanceBuffer != null)
+                    if (old != null)
                     {
-                        instanceBuffer.OnElementChanged -= InvalidateRenderEvent;
+                        old.OnElementChanged -= OnElementChanged;
                     }
-                    instanceBuffer = value;
                     if (instanceBuffer != null)
                     {
-                        instanceBuffer.OnElementChanged += InvalidateRenderEvent;
+                        instanceBuffer.OnElementChanged += OnElementChanged;
                     }
                 }
             }
@@ -67,20 +67,19 @@ namespace HelixToolkit.UWP.Core
         {
             set
             {
-                if(geometryBuffer == value)
+                var old = geometryBuffer;
+                if(SetAffectsCanRenderFlag(ref geometryBuffer, value))
                 {
-                    return;
+                    if(old != null)
+                    {
+                        old.OnInvalidateRender -= OnInvalidateRendererEvent;
+                    }
+                    if (geometryBuffer != null)
+                    {
+                        geometryBuffer.OnInvalidateRender += OnInvalidateRendererEvent;
+                    }
+                    OnGeometryBufferChanged(value);
                 }
-                if(geometryBuffer != null)
-                {
-                    geometryBuffer.OnInvalidateRender -= InvalidateRenderEvent;
-                }
-                geometryBuffer = value;
-                if (geometryBuffer != null)
-                {
-                    geometryBuffer.OnInvalidateRender += InvalidateRenderEvent;
-                }
-                OnGeometryBufferChanged(value);
             }
             get { return geometryBuffer; }
         }
@@ -281,13 +280,12 @@ namespace HelixToolkit.UWP.Core
             return succ;
         }
         /// <summary>
-        /// 
+        /// Called when [update can render flag].
         /// </summary>
-        /// <param name="context"></param>
         /// <returns></returns>
-        protected override bool CanRender(RenderContext context)
+        protected override bool OnUpdateCanRenderFlag()
         {
-            return base.CanRender(context) && GeometryBuffer != null;
+            return base.OnUpdateCanRenderFlag() && GeometryBuffer != null;
         }
 
         /// <summary>
@@ -336,7 +334,13 @@ namespace HelixToolkit.UWP.Core
             OnDraw(deviceContext, InstanceBuffer);
         }
 
-        protected void InvalidateRenderEvent(object sender, EventArgs e)
+        protected void OnElementChanged(object sender, EventArgs e)
+        {
+            UpdateCanRenderFlag();
+            InvalidateRenderer();
+        }
+
+        protected void OnInvalidateRendererEvent(object sender, EventArgs e)
         {
             InvalidateRenderer();
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
@@ -186,7 +186,12 @@ namespace HelixToolkit.UWP.Core
         /// </summary>
         public void UpdateCanRenderFlag()
         {
-            CanRenderFlag = OnUpdateCanRenderFlag();
+            bool flag = OnUpdateCanRenderFlag();
+            if(CanRenderFlag != flag)
+            {
+                CanRenderFlag = flag;
+                InvalidateRenderer();
+            }
         }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCore.cs
@@ -50,6 +50,16 @@ namespace HelixToolkit.UWP.Core
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this instance can be rendered. Update this flag using <see cref="UpdateCanRenderFlag"/>
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance can render; otherwise, <c>false</c>.
+        /// </value>
+        public bool CanRenderFlag
+        {
+            private set; get;
+        } = false;
+        /// <summary>
         /// Indicate whether render host should call <see cref="Update(RenderContext, DeviceContextProxy)"/> before <see cref="Render(RenderContext, DeviceContextProxy)"/>
         /// <para><see cref="Update(RenderContext, DeviceContextProxy)"/> is used to run such as compute shader before rendering. </para>
         /// <para>Compute shader can be run at the beginning of any other <see cref="Render(RenderContext, DeviceContextProxy)"/> routine to avoid waiting.</para>
@@ -103,6 +113,7 @@ namespace HelixToolkit.UWP.Core
         /// 
         /// </summary>
         public Device Device { get { return EffectTechnique?.Device; } }
+
         /// <summary>
         /// Is render core has been attached
         /// </summary>
@@ -129,6 +140,7 @@ namespace HelixToolkit.UWP.Core
             }
             EffectTechnique = technique;
             IsAttached = OnAttach(technique);
+            UpdateCanRenderFlag();
         }
 
         /// <summary>
@@ -145,6 +157,7 @@ namespace HelixToolkit.UWP.Core
         {
             IsAttached = false;
             OnDetach();
+            UpdateCanRenderFlag();
         }
         /// <summary>
         /// On detaching, default is to release all resources
@@ -169,6 +182,22 @@ namespace HelixToolkit.UWP.Core
         public virtual void Update(RenderContext context, DeviceContextProxy deviceContext) { }
 
         /// <summary>
+        /// Updates the can render flag.
+        /// </summary>
+        public void UpdateCanRenderFlag()
+        {
+            CanRenderFlag = OnUpdateCanRenderFlag();
+        }
+
+        /// <summary>
+        /// Called when [update can render flag].
+        /// </summary>
+        /// <returns></returns>
+        protected virtual bool OnUpdateCanRenderFlag()
+        {
+            return IsAttached;
+        }
+        /// <summary>
         /// Resets the invalidate handler.
         /// </summary>
         public void ResetInvalidateHandler()
@@ -179,6 +208,7 @@ namespace HelixToolkit.UWP.Core
         /// <summary>
         /// Invalidates the renderer.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void InvalidateRenderer()
         {
             OnInvalidateRenderer?.Invoke(this, EventArgs.Empty);
@@ -192,6 +222,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="value"></param>
         /// <param name="propertyName"></param>
         /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected bool SetAffectsRender<T>(ref T backingField, T value, [CallerMemberName] string propertyName = "")
         {
             if (EqualityComparer<T>.Default.Equals(backingField, value))
@@ -201,6 +232,29 @@ namespace HelixToolkit.UWP.Core
 
             backingField = value;
             this.RaisePropertyChanged(propertyName);
+            InvalidateRenderer();
+            return true;
+        }
+
+        /// <summary>
+        /// Sets the affects can render flag. This will also invalidate renderer.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="backingField">The backing field.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected bool SetAffectsCanRenderFlag<T>(ref T backingField, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (EqualityComparer<T>.Default.Equals(backingField, value))
+            {
+                return false;
+            }
+
+            backingField = value;
+            this.RaisePropertyChanged(propertyName);
+            UpdateCanRenderFlag();
             InvalidateRenderer();
             return true;
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
@@ -63,7 +63,7 @@ namespace HelixToolkit.UWP.Core
         /// </summary>
         /// <param name="context"></param>
         /// <param name="deviceContext"></param>
-        public override void Render(RenderContext context, DeviceContextProxy deviceContext)
+        public sealed override void Render(RenderContext context, DeviceContextProxy deviceContext)
         {
             if (CanRenderFlag)
             {
@@ -104,7 +104,7 @@ namespace HelixToolkit.UWP.Core
             }
         }
 
-        public override void Update(RenderContext context, DeviceContextProxy deviceContext)
+        public sealed override void Update(RenderContext context, DeviceContextProxy deviceContext)
         {
             if (CanRenderFlag)
             {

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/RenderCoreBase.cs
@@ -65,7 +65,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="deviceContext"></param>
         public override void Render(RenderContext context, DeviceContextProxy deviceContext)
         {
-            if (CanRender(context))
+            if (CanRenderFlag)
             {
                 OnUpdatePerModelStruct(ref modelStruct, context);
                 int vertStartSlot = 0;
@@ -106,7 +106,7 @@ namespace HelixToolkit.UWP.Core
 
         public override void Update(RenderContext context, DeviceContextProxy deviceContext)
         {
-            if (CanRender(context))
+            if (CanRenderFlag)
             {
                 OnUpdate(context, deviceContext);
             }
@@ -178,14 +178,5 @@ namespace HelixToolkit.UWP.Core
         /// <param name="context"></param>
         protected virtual void PostRender(RenderContext context)
         { }
-
-        /// <summary>
-        /// Check if can render
-        /// </summary>
-        /// <returns></returns>
-        protected virtual bool CanRender(RenderContext context)
-        {
-            return IsAttached;
-        }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/BoneSkinRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/BoneSkinRenderCore.cs
@@ -14,7 +14,32 @@ namespace HelixToolkit.UWP.Core
 
     public class BoneSkinRenderCore : MeshRenderCore, IBoneSkinRenderParams
     {
-        public IElementsBufferModel VertexBoneIdBuffer { set; get; }
+        private IElementsBufferModel vertexBoneIdBuffer;
+        /// <summary>
+        /// Gets or sets the vertex bone identifier buffer.
+        /// </summary>
+        /// <value>
+        /// The vertex bone identifier buffer.
+        /// </value>
+        public IElementsBufferModel VertexBoneIdBuffer
+        {
+            set
+            {
+                var old = vertexBoneIdBuffer;
+                if(SetAffectsCanRenderFlag(ref vertexBoneIdBuffer, value))
+                {
+                    if(old != null)
+                    {
+                        old.OnElementChanged -= OnElementChanged;
+                    }
+                    if (vertexBoneIdBuffer != null)
+                    {
+                        vertexBoneIdBuffer.OnElementChanged += OnElementChanged;
+                    }
+                }              
+            }
+            get { return vertexBoneIdBuffer; }
+        }
 
         private BoneMatricesStruct boneMatrices;
         public BoneMatricesStruct BoneMatrices
@@ -41,9 +66,9 @@ namespace HelixToolkit.UWP.Core
             }
         }
 
-        protected override bool CanRender(RenderContext context)
+        protected override bool OnUpdateCanRenderFlag()
         {
-            return base.CanRender(context) && VertexBoneIdBuffer != null && VertexBoneIdBuffer.HasElements;
+            return base.OnUpdateCanRenderFlag() && VertexBoneIdBuffer != null && VertexBoneIdBuffer.HasElements;
         }
 
         protected override bool OnAttachBuffers(DeviceContextProxy context, ref int vertStartSlot)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DynamicCubeMapCore.cs
@@ -92,7 +92,7 @@ namespace HelixToolkit.UWP.Core
         {
             set
             {
-                SetAffectsRender(ref enableReflector, value);
+                SetAffectsCanRenderFlag(ref enableReflector, value);
             }
             get
             {
@@ -367,9 +367,9 @@ namespace HelixToolkit.UWP.Core
             base.OnDetach();
         }
 
-        protected override bool CanRender(RenderContext context)
+        protected override bool OnUpdateCanRenderFlag()
         {
-            return base.CanRender(context) && EnableReflector;
+            return base.OnUpdateCanRenderFlag() && EnableReflector;
         }
 
         protected override void OnRender(RenderContext context, DeviceContextProxy deviceContext)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/InstancingBillboardRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/InstancingBillboardRenderCore.cs
@@ -18,30 +18,25 @@ namespace HelixToolkit.UWP.Core
         {
             set
             {
-                if (parameterBufferModel == value)
+                var old = parameterBufferModel;
+                if(SetAffectsCanRenderFlag(ref parameterBufferModel, value))
                 {
-                    return;
-                }
-                if (parameterBufferModel != null)
-                {
-                    parameterBufferModel.OnElementChanged -= ParameterBufferModel_OnElementChanged;
-                }
-                parameterBufferModel = value;
-                if (parameterBufferModel != null)
-                {
-                    parameterBufferModel.OnElementChanged += ParameterBufferModel_OnElementChanged;
-                }
+                    if (old != null)
+                    {
+                        old.OnElementChanged -= OnElementChanged;
+                    }
+                    if (parameterBufferModel != null)
+                    {
+                        parameterBufferModel.OnElementChanged += OnElementChanged;
+                    }
+                }                
             }
             get { return parameterBufferModel; }
         }
 
-        private void ParameterBufferModel_OnElementChanged(object sender, EventArgs e)
+        protected override bool OnUpdateCanRenderFlag()
         {
-            InvalidateRenderer();
-        }
-        protected override bool CanRender(RenderContext context)
-        {
-            return base.CanRender(context) && InstanceBuffer != null && InstanceBuffer.HasElements;
+            return base.OnUpdateCanRenderFlag() && InstanceBuffer != null && InstanceBuffer.HasElements;
         }
 
         protected override void OnUpdatePerModelStruct(ref PointLineModelStruct model, RenderContext context)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/InstancingMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/InstancingMeshRenderCore.cs
@@ -18,35 +18,29 @@ namespace HelixToolkit.UWP.Core
         {
             set
             {
-                if (parameterBufferModel == value)
+                var old = parameterBufferModel;
+                if(SetAffectsCanRenderFlag(ref parameterBufferModel, value))
                 {
-                    return;
-                }
-                if (parameterBufferModel != null)
-                {
-                    parameterBufferModel.OnElementChanged -= ParameterBufferModel_OnElementChanged;
-                }
-                parameterBufferModel = value;
-                if (parameterBufferModel != null)
-                {
-                    parameterBufferModel.OnElementChanged += ParameterBufferModel_OnElementChanged;
+                    if (old != null)
+                    {
+                        old.OnElementChanged -= OnElementChanged;
+                    }
+                    if (parameterBufferModel != null)
+                    {
+                        parameterBufferModel.OnElementChanged += OnElementChanged;
+                    }
                 }
             }
             get { return parameterBufferModel; }
-        }
-
-        private void ParameterBufferModel_OnElementChanged(object sender, EventArgs e)
-        {
-            InvalidateRenderer();
         }
 
         protected override bool OnAttach(IRenderTechnique technique)
         {
             return base.OnAttach(technique);
         }
-        protected override bool CanRender(RenderContext context)
+        protected override bool OnUpdateCanRenderFlag()
         {
-            return base.CanRender(context) && InstanceBuffer != null && InstanceBuffer.HasElements;
+            return base.OnUpdateCanRenderFlag() && InstanceBuffer != null && InstanceBuffer.HasElements;
         }
 
         protected override void OnUpdatePerModelStruct(ref ModelStruct model, RenderContext context)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Lights/LightCoreBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Lights/LightCoreBase.cs
@@ -63,7 +63,7 @@ namespace HelixToolkit.UWP.Core
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="deviceContext">The device context.</param>
-        public override void Render(RenderContext context, DeviceContextProxy deviceContext)
+        public sealed override void Render(RenderContext context, DeviceContextProxy deviceContext)
         {
             if (CanRender(context.LightScene))
             {

--- a/Source/HelixToolkit.SharpDX.Shared/Core/OrderIndependantTransparentRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/OrderIndependantTransparentRenderCore.cs
@@ -190,15 +190,14 @@ namespace HelixToolkit.UWP.Core
             base.OnDetach();
         }
 
-        protected override bool CanRender(RenderContext context)
-        {
-            return base.CanRender(context) && context.RenderHost.PerFrameTransparentNodes.Count > 0;
-        }
-
         protected override void OnRender(RenderContext context, DeviceContextProxy deviceContext)
         {
             RenderCount = 0;
-            if(CreateTextureResources(context, deviceContext))
+            if(context.RenderHost.PerFrameTransparentNodes.Count == 0)
+            {
+                return;
+            }
+            else if(CreateTextureResources(context, deviceContext))
             {
                 InvalidateRenderer();
                 return; // Skip this frame if texture resized to reduce latency.

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ParticleRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ParticleRenderCore.cs
@@ -673,6 +673,7 @@ namespace HelixToolkit.UWP.Core
             UpdateInsertThrottle();
             isInitialParticleChanged = false;
             isRestart = true;
+            UpdateCanRenderFlag();
         }
 
         private void DisposeBuffers()
@@ -728,16 +729,10 @@ namespace HelixToolkit.UWP.Core
             blendState = Collect(EffectTechnique.EffectsManager.StateManager.Register(blendDesc));
         }
 
-        /// <summary>
-        /// Determines whether this instance can render the specified context.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <returns>
-        ///   <c>true</c> if this instance can render the specified context; otherwise, <c>false</c>.
-        /// </returns>
-        protected override bool CanRender(RenderContext context)
+
+        protected override bool OnUpdateCanRenderFlag()
         {
-            return base.CanRender(context) && BufferProxies != null && !isInitialParticleChanged;
+            return base.OnUpdateCanRenderFlag() && !isInitialParticleChanged;
         }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectBoomCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectBoomCore.cs
@@ -56,7 +56,8 @@ namespace HelixToolkit.UWP.Core
       
         private int width, height;
         #endregion
-        #region Properties        
+        #region Properties   
+        private string effectName = DefaultRenderTechniqueNames.PostEffectBloom;
         /// <summary>
         /// Gets or sets the name of the effect.
         /// </summary>
@@ -65,8 +66,9 @@ namespace HelixToolkit.UWP.Core
         /// </value>
         public string EffectName
         {
-            set; get;
-        } = DefaultRenderTechniqueNames.PostEffectBloom;
+            set { SetAffectsCanRenderFlag(ref effectName, value); }
+            get { return effectName; }
+        }
 
         /// <summary>
         /// Gets or sets the color of the border.
@@ -189,7 +191,7 @@ namespace HelixToolkit.UWP.Core
             }
         }
 
-        protected override bool CanRender(RenderContext context)
+        protected override bool OnUpdateCanRenderFlag()
         {
             return IsAttached && !string.IsNullOrEmpty(EffectName);
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectFXAA.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectFXAA.cs
@@ -17,12 +17,25 @@ namespace HelixToolkit.UWP.Core
 
     public sealed class PostEffectFXAA : RenderCoreBase<BorderEffectStruct>, IPostEffect
     {
-        public string EffectName { set; get; } = DefaultRenderTechniqueNames.PostEffectFXAA;
+        private string effectName = DefaultRenderTechniqueNames.PostEffectFXAA;
+        public string EffectName
+        {
+            set { SetAffectsCanRenderFlag(ref effectName, value); }
+            get { return effectName; }
+        }
 
+        private FXAALevel fxaaLevel = FXAALevel.None;
+        /// <summary>
+        /// Gets or sets the fxaa level.
+        /// </summary>
+        /// <value>
+        /// The fxaa level.
+        /// </value>
         public FXAALevel FXAALevel
         {
-            set; get;
-        } = FXAALevel.Medium;
+            set { SetAffectsCanRenderFlag(ref fxaaLevel, value); }
+            get { return fxaaLevel; }
+        }
 
         private int textureSlot;
         private int samplerSlot;
@@ -60,9 +73,9 @@ namespace HelixToolkit.UWP.Core
             base.OnDetach();
         }
 
-        protected override bool CanRender(RenderContext context)
+        protected override bool OnUpdateCanRenderFlag()
         {
-            return base.CanRender(context) && FXAALevel != FXAALevel.None;
+            return IsAttached && !string.IsNullOrEmpty(EffectName) && FXAALevel != FXAALevel.None;
         }
 
         protected override void OnRender(RenderContext context, DeviceContextProxy deviceContext)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshOutlineBlurCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshOutlineBlurCore.cs
@@ -90,6 +90,7 @@ namespace HelixToolkit.UWP.Core
         };
         #endregion
         #region Properties
+        private string effectName = DefaultRenderTechniqueNames.PostEffectMeshOutlineBlur;
         /// <summary>
         /// Gets or sets the name of the effect.
         /// </summary>
@@ -98,8 +99,15 @@ namespace HelixToolkit.UWP.Core
         /// </value>
         public string EffectName
         {
-            set; get;
-        } = DefaultRenderTechniqueNames.PostEffectMeshOutlineBlur;
+            set
+            {
+                SetAffectsCanRenderFlag(ref effectName, value);
+            }
+            get
+            {
+                return effectName;
+            }
+        }
 
         private Color4 color = global::SharpDX.Color.Red;
         /// <summary>
@@ -200,7 +208,7 @@ namespace HelixToolkit.UWP.Core
             }
         }
 
-        protected override bool CanRender(RenderContext context)
+        protected override bool OnUpdateCanRenderFlag()
         {
             return IsAttached && !string.IsNullOrEmpty(EffectName);
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRay.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRay.cs
@@ -55,6 +55,7 @@ namespace HelixToolkit.UWP.Core
         private DepthPrepassCore depthPrepassCore;
         #endregion
         #region Properties
+        private string effectName = DefaultRenderTechniqueNames.PostEffectMeshXRay;
         /// <summary>
         /// Gets or sets the name of the effect.
         /// </summary>
@@ -63,8 +64,9 @@ namespace HelixToolkit.UWP.Core
         /// </value>
         public string EffectName
         {
-            set; get;
-        } = DefaultRenderTechniqueNames.PostEffectMeshXRay;
+            set { SetAffectsCanRenderFlag(ref effectName, value); }
+            get { return effectName; }
+        }
 
         private Color4 color = global::SharpDX.Color.Red;
         /// <summary>
@@ -248,6 +250,11 @@ namespace HelixToolkit.UWP.Core
                 buffer.FullResDepthStencilPool.Put(Format.D32_Float_S8X24_UInt, depthStencilBuffer);
             }
             context.IsCustomPass = false;
+        }
+
+        protected override bool OnUpdateCanRenderFlag()
+        {
+            return IsAttached && !string.IsNullOrEmpty(EffectName);
         }
 
         protected override void OnUpdatePerModelStruct(ref BorderEffectStruct model, RenderContext context)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRayGrid.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRayGrid.cs
@@ -35,6 +35,7 @@ namespace HelixToolkit.UWP.Core
         private DepthPrepassCore depthPrepassCore;
         #endregion
         #region Properties
+        private string effectName = DefaultRenderTechniqueNames.PostEffectMeshXRayGrid; 
         /// <summary>
         /// Gets or sets the name of the effect.
         /// </summary>
@@ -43,8 +44,9 @@ namespace HelixToolkit.UWP.Core
         /// </value>
         public string EffectName
         {
-            set; get;
-        } = DefaultRenderTechniqueNames.PostEffectMeshXRayGrid;
+            set { SetAffectsCanRenderFlag(ref effectName, value); }
+            get { return effectName; }
+        }
 
         private Color4 color = global::SharpDX.Color.DarkBlue;
         /// <summary>
@@ -150,6 +152,11 @@ namespace HelixToolkit.UWP.Core
             depthPrepassCore.Detach();
             depthPrepassCore = null;
             base.OnDetach();
+        }
+
+        protected override bool OnUpdateCanRenderFlag()
+        {
+            return IsAttached && !string.IsNullOrEmpty(EffectName);
         }
         /// <summary>
         /// Called when [render].

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenCloneRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenCloneRenderCore.cs
@@ -145,7 +145,6 @@ namespace HelixToolkit.Wpf.SharpDX.Core
         {
             set; get;
         } = true;
-
         private DuplicationResource duplicationResource;
         private FrameProcessing frameProcessor;
         private ShaderPass DefaultShaderPass;
@@ -199,16 +198,10 @@ namespace HelixToolkit.Wpf.SharpDX.Core
             frameProcessor = Collect(new FrameProcessing());
             return true;
         }
-        /// <summary>
-        /// Determines whether this instance can render the specified context.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <returns>
-        ///   <c>true</c> if this instance can render the specified context; otherwise, <c>false</c>.
-        /// </returns>
-        protected override bool CanRender(RenderContext context)
+
+        protected override bool OnUpdateCanRenderFlag()
         {
-            return base.CanRender(context) && duplicationResource != null;
+            return base.OnUpdateCanRenderFlag() && duplicationResource != null;
         }
         /// <summary>
         /// Called when [render].

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
@@ -328,17 +328,7 @@ namespace HelixToolkit.UWP.Core
             model.World = Matrix.Identity;
             model.HasInstances = 0;
         }
-        /// <summary>
-        /// Determines whether this instance can render the specified context.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <returns>
-        ///   <c>true</c> if this instance can render the specified context; otherwise, <c>false</c>.
-        /// </returns>
-        protected override bool CanRender(RenderContext context)
-        {
-            return context.ActualWidth > Size && context.ActualHeight > Size;
-        }
+
         /// <summary>
         /// Called when [render].
         /// </summary>
@@ -374,6 +364,10 @@ namespace HelixToolkit.UWP.Core
         /// <param name="clearDepthBuffer">if set to <c>true</c> [clear depth buffer].</param>
         protected virtual void SetScreenSpacedCoordinates(RenderContext context, DeviceContextProxy deviceContext, bool clearDepthBuffer)
         {
+            if(context.ActualWidth < Size || context.ActualHeight < Size)
+            {
+                return;
+            }
             context.WorldMatrix = Matrix.Identity;
             DepthStencilView dsView;
             if (clearDepthBuffer)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ShadowMapCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ShadowMapCore.cs
@@ -194,27 +194,19 @@ namespace HelixToolkit.UWP.Core
             return new ConstantBufferDescription(DefaultBufferNames.ShadowParamCB, ShadowMapParamStruct.SizeInBytes);
         }
 
-        protected override bool CanRender(RenderContext context)
-        {
-#if TEST
-            if (base.CanRender(context))
-#else
-            if(base.CanRender(context) && !context.IsShadowPass)
-#endif
-            {
-                OnUpdateLightSource?.Invoke(this, new UpdateLightSourceEventArgs(context));
-                ++currentFrame;
-                currentFrame %= Math.Max(1, UpdateFrequency);
-                return FoundLightSource && currentFrame == 0;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
         protected override void OnRender(RenderContext context, DeviceContextProxy deviceContext)
         {
+            if (context.IsShadowPass)
+            {
+                return;
+            }
+            OnUpdateLightSource?.Invoke(this, new UpdateLightSourceEventArgs(context));
+            ++currentFrame;
+            currentFrame %= Math.Max(1, UpdateFrequency);
+            if(!FoundLightSource || currentFrame != 0)
+            {
+                return;
+            }
             if (resolutionChanged)
             {
                 RemoveAndDispose(ref viewResource);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SkyBoxRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SkyBoxRenderCore.cs
@@ -203,10 +203,6 @@ namespace HelixToolkit.UWP.Core
             textureSamplerSlot = pass.PixelShader.SamplerMapping.TryGetBindSlot(ShaderCubeTextureSamplerName);
         }
 
-        protected override bool CanRender(RenderContext context)
-        {
-            return base.CanRender(context) && GeometryBuffer.VertexBuffer.Length > 0;
-        }
         /// <summary>
         /// Called when [render].
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SkyDomeRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SkyDomeRenderCore.cs
@@ -165,11 +165,6 @@ namespace HelixToolkit.UWP.Core
             cubeTextureSlot = pass.PixelShader.ShaderResourceViewMapping.TryGetBindSlot(ShaderCubeTextureName);
             textureSamplerSlot = pass.PixelShader.SamplerMapping.TryGetBindSlot(ShaderCubeTextureSamplerName);
         }
-
-        protected override bool CanRender(RenderContext context)
-        {
-            return base.CanRender(context) && GeometryBuffer.VertexBuffer.Length > 0;
-        }
         /// <summary>
         /// Called when [render].
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultPixelShaders.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultPixelShaders.cs
@@ -55,6 +55,19 @@ namespace HelixToolkit.UWP.Shaders
             }
         }
         /// <summary>
+        /// Gets the ps mesh diffuse map oit.
+        /// </summary>
+        /// <value>
+        /// The ps mesh diffuse map oit.
+        /// </value>
+        public static byte[] PSMeshDiffuseMapOIT
+        {
+            get
+            {
+                return UWPShaderBytePool.Read("psMeshDiffuseMapOIT");
+            }
+        }
+        /// <summary>
         /// 
         /// </summary>
         public static byte[] PSMeshVertColor
@@ -528,6 +541,11 @@ namespace HelixToolkit.UWP.Shaders
         /// </summary>
         public static ShaderDescription PSMeshDiffuseMap = new ShaderDescription(nameof(PSMeshDiffuseMap), ShaderStage.Pixel, new ShaderReflector(),
             DefaultPSShaderByteCodes.PSMeshDiffuseMap);
+        /// <summary>
+        /// The ps mesh diffuse map oit
+        /// </summary>
+        public static ShaderDescription PSMeshDiffuseMapOIT = new ShaderDescription(nameof(PSMeshDiffuseMapOIT), ShaderStage.Pixel, new ShaderReflector(),
+            DefaultPSShaderByteCodes.PSMeshDiffuseMapOIT);
         /// <summary>
         /// 
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/DiffuseMaterialCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/DiffuseMaterialCore.cs
@@ -114,7 +114,7 @@ namespace HelixToolkit.UWP.Model
             }
         }
 
-        private string transparentPassName = DefaultPassNames.OITPass;
+        private string transparentPassName = DefaultPassNames.DiffuseOIT;
         /// <summary>
         /// Gets or sets the name of the mesh transparent pass.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
@@ -164,6 +164,16 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
+                    new ShaderPassDescription(DefaultPassNames.DiffuseOIT)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshDefault,
+                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOIT
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
                     new ShaderPassDescription(DefaultPassNames.DepthPrepass)
                     {
                         ShaderList = new[]
@@ -408,6 +418,16 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
+                    new ShaderPassDescription(DefaultPassNames.DiffuseOIT)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshInstancing,
+                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOIT
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
                     new ShaderPassDescription(DefaultPassNames.DepthPrepass)
                     {
                         ShaderList = new[]
@@ -638,6 +658,16 @@ namespace HelixToolkit.UWP
                         {
                             DefaultVSShaderDescriptions.VSMeshBoneSkinning,
                             DefaultPSShaderDescriptions.PSMeshBlinnPhongOIT
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.DiffuseOIT)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
+                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
@@ -1037,6 +1067,16 @@ namespace HelixToolkit.UWP
                         {
                             DefaultVSShaderDescriptions.VSMeshClipPlane,
                             DefaultPSShaderDescriptions.PSMeshBlinnPhongOIT
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.DiffuseOIT)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshClipPlane,
+                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
@@ -139,6 +139,10 @@ namespace HelixToolkit.UWP
         /// </summary>
         public const string Diffuse = "RenderDiffuse";
         /// <summary>
+        /// The diffuse oit
+        /// </summary>
+        public const string DiffuseOIT = "RenderDiffuseOIT";
+        /// <summary>
         /// 
         /// </summary>
         public const string Colors = "RenderColors";

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/PostEffects/PostEffectMeshBorderHighlight.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/PostEffects/PostEffectMeshBorderHighlight.cs
@@ -12,7 +12,7 @@ namespace HelixToolkit.Wpf.SharpDX
     {
         protected override SceneNode OnCreateSceneNode()
         {
-            return new NodePostEffectMeshOutlineBlur();
+            return new NodePostEffectBorderHighlight();
         }
     }
 }

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -445,6 +445,9 @@
     <Content Include="Resources\psEffectMeshDiffuseXRayGrid.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Resources\psMeshDiffuseMapOIT.cso">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup />
   <Import Project="..\HelixToolkit.Shared\HelixToolkit.Shared.projitems" Label="Shared" />

--- a/Source/HelixToolkit.UWP/Themes/Generic.xaml
+++ b/Source/HelixToolkit.UWP/Themes/Generic.xaml
@@ -90,8 +90,43 @@
         xmlns:local="using:HelixToolkit.UWP"
         x:Key="orthographicCamera" />
 
+    <local:MatrixCamera
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="matrixCamera" />
+
     <local:PhongMaterial
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:local="using:HelixToolkit.UWP"
         x:Key="phongMaterial" />
+
+    <local:DiffuseMaterial
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="diffuseMaterial" />
+
+    <local:NormalMaterial
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="normalMaterial" />
+
+    <local:NormalVectorMaterial
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="normalVectorMaterial" />
+
+    <local:VertColorMaterial
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="vertColorMaterial" />
+
+    <local:PositionColorMaterial
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="positionColorMaterial" />
+
+    <local:ColorStripeMaterial
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:local="using:HelixToolkit.UWP"
+        x:Key="colorStripeMaterial" />
 </ResourceDictionary>

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -268,6 +268,7 @@
     <None Include="Resources\psMeshClipPlaneBackface.cso" />
     <None Include="Resources\psMeshClipPlaneQuad.cso" />
     <None Include="Resources\psMeshColorStripe.cso" />
+    <None Include="Resources\psMeshDiffuseMapOIT.cso" />
     <None Include="Resources\psMeshXRay.cso" />
     <None Include="Resources\psNormals.cso" />
     <None Include="Resources\psParticle.cso" />

--- a/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.Designer.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.Designer.cs
@@ -433,6 +433,16 @@ namespace HelixToolkit.Wpf.SharpDX.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
+        internal static byte[] psMeshDiffuseMapOIT {
+            get {
+                object obj = ResourceManager.GetObject("psMeshDiffuseMapOIT", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
         internal static byte[] psMeshXRay {
             get {
                 object obj = ResourceManager.GetObject("psMeshXRay", resourceCulture);

--- a/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.resx
+++ b/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.resx
@@ -334,4 +334,7 @@
   <data name="psEffectMeshDiffuseXRayGrid" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\pseffectmeshdiffusexraygrid.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="psMeshDiffuseMapOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshdiffusemapoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>


### PR DESCRIPTION
1. Support OIT for DiffuseMaterial.
2. Change RenderCoreBase.CanRender to CanRenderFlag.  Use SetAffectsCanRenderFlag or UpdateCanRenderFlag to update the flag during property change.
3. Fix border highlight effects gets the wrong effect node. Improve the border highlight shader.