### PR TITLE
 Obsolete the Viewport3DX.WorldMatrix

### DIFF
--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
@@ -144,13 +144,25 @@ namespace HelixToolkit.SharpDX.Core.Controls
 
         private SceneNode2D root2D = new OverlayNode2D() { EnableBitmapCache = false };
 
-        public ViewportCore(IntPtr nativeWindowPointer)
+        public ViewportCore(IntPtr nativeWindowPointer, bool deferred = false)
         {
-            RenderHost = new SwapChainRenderHost(nativeWindowPointer)
+            if (deferred)
             {
-                ShowRenderDetail = RenderDetail.Statistics | RenderDetail.FPS,
-                Viewport = this,
-            };
+                RenderHost = new SwapChainRenderHost(nativeWindowPointer,
+                    (device) => { return new DeferredContextRenderer(device, new AutoRenderTaskScheduler()); })
+                {
+                    ShowRenderDetail = RenderDetail.Statistics | RenderDetail.FPS,
+                    Viewport = this,
+                };
+            }
+            else
+            {
+                RenderHost = new SwapChainRenderHost(nativeWindowPointer)
+                {
+                    ShowRenderDetail = RenderDetail.Statistics | RenderDetail.FPS,
+                    Viewport = this,
+                };
+            }
             BackgroundColor = Color.Black;
             RenderHost.StartRenderLoop += RenderHost_StartRenderLoop;
             RenderHost.StopRenderLoop += RenderHost_StopRenderLoop;

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
@@ -60,8 +60,6 @@ namespace HelixToolkit.SharpDX.Core.Controls
             set;
         }
 
-        public Matrix WorldMatrix { set; get; } = Matrix.Identity;
-
         public IEnumerable<SceneNode> Renderables => Items;
 
         public IEnumerable<SceneNode2D> D2DRenderables => Items2D;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/MaterialGeometryRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/MaterialGeometryRenderCore.cs
@@ -145,7 +145,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="context"></param>
         protected override void OnUpdatePerModelStruct(ref ModelStruct model, RenderContext context)
         {
-            model.World = ModelMatrix * context.WorldMatrix;
+            model.World = ModelMatrix;// * context.WorldMatrix;
             model.HasInstances = InstanceBuffer == null ? 0 : InstanceBuffer.HasElements ? 1 : 0;
             MaterialVariables.UpdateMaterialVariables(ref model);
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/BillboardRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/BillboardRenderCore.cs
@@ -167,7 +167,7 @@ namespace HelixToolkit.UWP.Core
 
         protected override void OnUpdatePerModelStruct(ref PointLineModelStruct model, RenderContext context)
         {
-            model.World = ModelMatrix * context.WorldMatrix;
+            model.World = ModelMatrix;
             model.HasInstances = InstanceBuffer == null ? 0 : InstanceBuffer.HasElements ? 1 : 0;
             model.BoolParams.X = FixedSize;
             var type = billboardBuffer.Type;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/LineRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/LineRenderCore.cs
@@ -68,7 +68,7 @@ namespace HelixToolkit.UWP.Core
 
         protected override void OnUpdatePerModelStruct(ref PointLineModelStruct model, RenderContext context)
         {
-            model.World = ModelMatrix * context.WorldMatrix;
+            model.World = ModelMatrix;
             model.HasInstances = InstanceBuffer == null ? 0 : InstanceBuffer.HasElements ? 1 : 0;
         }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ParticleRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ParticleRenderCore.cs
@@ -587,7 +587,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="context">The context.</param>
         protected override void OnUpdatePerModelStruct(ref PointLineModelStruct model, RenderContext context)
         {
-            model.World = ModelMatrix * context.WorldMatrix;
+            model.World = ModelMatrix;
             model.HasInstances = InstanceBuffer == null ? 0 : InstanceBuffer.HasElements ? 1 : 0;
             model.BoolParams.X = HasTexture;
             FrameVariables.RandomVector = VectorGenerator.RandomVector3;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PointRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PointRenderCore.cs
@@ -105,7 +105,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="context">The context.</param>
         protected override void OnUpdatePerModelStruct(ref PointLineModelStruct model, RenderContext context)
         {
-            model.World = ModelMatrix * context.WorldMatrix;
+            model.World = ModelMatrix;
             model.HasInstances = InstanceBuffer == null ? 0 : InstanceBuffer.HasElements ? 1 : 0;
             modelStruct.Color = PointColor;
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
@@ -368,7 +368,6 @@ namespace HelixToolkit.UWP.Core
             {
                 return;
             }
-            context.WorldMatrix = Matrix.Identity;
             DepthStencilView dsView;
             if (clearDepthBuffer)
             {

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderable.cs
@@ -72,13 +72,7 @@ namespace HelixToolkit.UWP
         /// <param name="timeStamp"></param>
         //DeferredRenderer DeferredRenderer { get; set; }
         void Update(TimeSpan timeStamp);
-        /// <summary>
-        /// Gets the world matrix.
-        /// </summary>
-        /// <value>
-        /// The world matrix.
-        /// </value>
-        Matrix WorldMatrix { get; }
+
         /// <summary>
         /// Gets the renderables.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy/DeviceContextProxy_InputAssembler.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy/DeviceContextProxy_InputAssembler.cs
@@ -15,6 +15,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
 {
     public partial class DeviceContextProxy
     {
+        private PrimitiveTopology currPrimitiveTopology = PrimitiveTopology.Undefined;
         /// <summary>
         /// Gets or sets the primitive topology.
         /// </summary>
@@ -25,14 +26,20 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         {
             set
             {
+                if(currPrimitiveTopology == value)
+                {
+                    return;
+                }
+                currPrimitiveTopology = value;
                 deviceContext.InputAssembler.PrimitiveTopology = value;
             }
             get
             {
-                return deviceContext.InputAssembler.PrimitiveTopology;
+                return currPrimitiveTopology;
             }
         }
 
+        private InputLayout inputLayout;
         /// <summary>
         /// Gets or sets the input layout.
         /// </summary>
@@ -43,11 +50,13 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         {
             set
             {
+                if(inputLayout == value) { return; }
+                inputLayout = value;
                 deviceContext.InputAssembler.InputLayout = value;
             }
             get
             {
-                return deviceContext.InputAssembler.InputLayout;
+                return inputLayout;
             }
         }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy/DeviceContextProxy_States.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy/DeviceContextProxy_States.cs
@@ -107,6 +107,8 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             currBlendFactor = null;
             currSampleMask = uint.MaxValue;
             currStencilRef = 0;
+            inputLayout = null;
+            currPrimitiveTopology = global::SharpDX.Direct3D.PrimitiveTopology.Undefined;
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
@@ -29,7 +29,6 @@ namespace HelixToolkit.Wpf.SharpDX
     /// </summary>
     public sealed class RenderContext : DisposeObject
     {
-        private Matrix worldMatrix = Matrix.Identity;
         private Matrix viewMatrix;
         private Matrix projectionMatrix;
 
@@ -78,26 +77,6 @@ namespace HelixToolkit.Wpf.SharpDX
                     return;
                 }
                 projectionMatrix = value;
-                matrixChanged = true;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the world matrix.
-        /// </summary>
-        /// <value>
-        /// The world matrix.
-        /// </value>
-        public Matrix WorldMatrix
-        {
-            get { return worldMatrix; }
-            set
-            {
-                if (worldMatrix == value)
-                {
-                    return;
-                }
-                worldMatrix = value;
                 matrixChanged = true;
             }
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -175,12 +175,13 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                 Debug.WriteLine("Flatten Scene Graph");
 #endif
             }
+            int sceneCount = perFrameFlattenedScene.Count;
             if (invalidatePerFrameRenderables)
             {
 #if DEBUG
                 Debug.WriteLine("Get PerFrameRenderables");
-#endif
-                for (int i = 0; i < perFrameFlattenedScene.Count;)
+#endif               
+                for (int i = 0; i < sceneCount;)
                 {
                     var renderable = perFrameFlattenedScene[i];
                     renderable.Value.Update(context);
@@ -190,7 +191,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                         //Skip scene graph depth larger than current node
                         int depth = renderable.Key;
                         ++i;
-                        for (; i < perFrameFlattenedScene.Count; ++i)
+                        for (; i < sceneCount; ++i)
                         {
                             if (perFrameFlattenedScene[i].Key <= depth)
                             {
@@ -240,8 +241,8 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                 }
             }
             else
-            {
-                for (int i = 0; i < perFrameFlattenedScene.Count;)
+            {                
+                for (int i = 0; i < sceneCount;)
                 {
                     var renderable = perFrameFlattenedScene[i];
                     renderable.Value.Update(context);
@@ -250,7 +251,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                         //Skip scene graph depth larger than current node
                         int depth = renderable.Key;
                         ++i;
-                        for (; i < perFrameFlattenedScene.Count; ++i)
+                        for (; i < sceneCount; ++i)
                         {
                             if (perFrameFlattenedScene[i].Key <= depth)
                             {

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -617,7 +617,6 @@ namespace HelixToolkit.Wpf.SharpDX.Render
                     viewport.Update(t0);                    
                     renderContext.TimeStamp = t0;
                     renderContext.Camera = viewport.CameraCore;
-                    renderContext.WorldMatrix = viewport.WorldMatrix;
                     renderContext.OITWeightPower = RenderConfiguration.OITWeightPower;
                     renderContext.OITWeightDepthSlope = RenderConfiguration.OITWeightDepthSlope;
                     renderContext.OITWeightMode = RenderConfiguration.OITWeightMode;

--- a/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
@@ -74,13 +74,11 @@ namespace HelixToolkit.UWP
         /// </value>
         public CameraCore CameraCore { get { return this.Camera; } }
         /// <summary>
-        /// Gets the world matrix.
+        /// Gets the items.
         /// </summary>
         /// <value>
-        /// The world matrix.
+        /// The items.
         /// </value>
-        public Matrix WorldMatrix { get; } = Matrix.Identity;
-
         public ObservableElement3DCollection Items { get; } = new ObservableElement3DCollection();
         /// <summary>
         /// Gets the renderables.

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.Properties.cs
@@ -960,15 +960,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public static readonly DependencyProperty EnableSwapChainRenderingProperty
             = DependencyProperty.Register("EnableSwapChainRendering", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(false));
-        /// <summary>
-        /// The world matrix property
-        /// </summary>
-        public static readonly DependencyProperty WorldMatrixProperty
-            = DependencyProperty.Register("WorldMatrix", typeof(global::SharpDX.Matrix), typeof(Viewport3DX), new PropertyMetadata(global::SharpDX.Matrix.Identity,
-                (d, e) => {
-                    (d as Viewport3DX).worldMatrixInternal = (global::SharpDX.Matrix)e.NewValue;
-                    (d as Viewport3DX).InvalidateRender();
-                }));
+
         /// <summary>
         /// The content2 d property
         /// </summary>
@@ -2727,24 +2719,6 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        private global::SharpDX.Matrix worldMatrixInternal = global::SharpDX.Matrix.Identity;
-        /// <summary>
-        /// Gets or sets the world matrix.
-        /// </summary>
-        /// <value>
-        /// The world matrix.
-        /// </value>
-        public global::SharpDX.Matrix WorldMatrix
-        {
-            set
-            {
-                SetValue(WorldMatrixProperty, value);
-            }
-            get
-            {
-                return (global::SharpDX.Matrix)GetValue(WorldMatrixProperty);
-            }
-        }
         /// <summary>
         /// Gets or sets the content2d.
         /// </summary>


### PR DESCRIPTION
Obsolete the Viewport3DX.WorldMatrix. Not very useful and causes performance penalty on updating modelstruct. Can always use GroupModel to do transform. 