### PR TITLE
Improve bone skinning, implement pre-compute bone skinned vertices

### DIFF
--- a/Source/Examples/SharpDX.Core/CoreTest/Program.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/Program.cs
@@ -15,11 +15,37 @@ namespace CoreTest
         [STAThread]
         static void Main()
         {
+            NVOptimusEnabler nvEnabler = new NVOptimusEnabler();
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             RenderForm form = new RenderForm();
             CoreTestApp app = new CoreTestApp(form);
             Application.Run(form);
         }
+    }
+
+    public sealed class NVOptimusEnabler
+    {
+        static NVOptimusEnabler()
+        {
+            try
+            {
+
+                if (Environment.Is64BitProcess)
+                    NativeMethods.LoadNvApi64();
+                else
+                    NativeMethods.LoadNvApi32();
+            }
+            catch { } // will always fail since 'fake' entry point doesn't exists
+        }
+    };
+
+    internal static class NativeMethods
+    {
+        [System.Runtime.InteropServices.DllImport("nvapi64.dll", EntryPoint = "fake")]
+        internal static extern int LoadNvApi64();
+
+        [System.Runtime.InteropServices.DllImport("nvapi.dll", EntryPoint = "fake")]
+        internal static extern int LoadNvApi32();
     }
 }

--- a/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
@@ -90,19 +90,6 @@ namespace BoneSkinDemo
             get;
         } = PhongMaterials.Indigo;
 
-        private IList<BoneIds> vertexBoneParams;
-        public IList<BoneIds> VertexBoneParams
-        {
-            set
-            {
-                SetValue(ref vertexBoneParams, value, nameof(VertexBoneParams));
-            }
-            get
-            {
-                return vertexBoneParams;
-            }
-        }
-
         private BoneMatricesStruct bones;
         public BoneMatricesStruct Bones
         {
@@ -193,7 +180,7 @@ namespace BoneSkinDemo
             this.AmbientLightColor = Colors.DarkGray;
             SetupCameraBindings(this.Camera);
 
-            var builder = new MeshBuilder(true, true, true);
+            var builder = new MeshBuilder(true, false);
             path = new List<Vector3>();
             for(int i=0; i< NumSegments; ++i)
             {
@@ -245,7 +232,7 @@ namespace BoneSkinDemo
                 }
             }
 
-            VertexBoneParams = boneParams.ToArray();
+            Model = new BoneSkinnedMeshGeometry3D(Model) { VertexBoneIds = boneParams.ToArray() };
 
             Instances = new List<Matrix>();
             for (int i = 0; i < 3; ++i)

--- a/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainWindow.xaml
@@ -22,10 +22,10 @@
             EffectsManager="{Binding EffectsManager}"
             EnableDesignModeRendering="True"
             EnableSwapChainRendering="False"
-            IsShadowMappingEnabled="True"
+            IsShadowMappingEnabled="True" 
             RenderTechnique="{Binding RenderTechnique}"
             ShowCoordinateSystem="False"
-            ShowFrameRate="True"
+            ShowFrameRate="True" 
             TextBrush="Black"
             UseDefaultGestures="False">
             <hx:Viewport3DX.InputBindings>
@@ -51,8 +51,7 @@
                 Geometry="{Binding Model}"
                 Instances="{Binding Instances}"
                 IsThrowingShadow="True"
-                Material="{Binding Material}"
-                VertexBoneIds="{Binding VertexBoneParams}" />
+                Material="{Binding Material}"/>
             <hx:MeshGeometryModel3D Geometry="{Binding FloorModel}" Material="{Binding FloorMaterial}" />
         </hx:Viewport3DX>
         <StackPanel

--- a/Source/HelixToolkit.Native.ShaderBuilder/Common/DataStructs.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/Common/DataStructs.hlsl
@@ -22,6 +22,23 @@ struct LightStruct
     matrix mLightProj; //56
 };
 
+struct VSSkinnedInput
+{
+    float4 p : POSITION;
+    float3 n : NORMAL;
+    float3 t1 : TANGENT;
+    float3 t2 : BINORMAL;
+    int4 bones : BONEIDS;
+    float4 boneWeights : BONEWEIGHTS;
+};
+
+struct VSSkinnedOutput
+{
+    float4 p : POSITION;
+    float3 n : NORMAL;
+    float3 t1 : TANGENT;
+    float3 t2 : BINORMAL;
+};
 
 struct VSInput
 {

--- a/Source/HelixToolkit.Native.ShaderBuilder/GS/gsMeshSkinnedOut.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/GS/gsMeshSkinnedOut.hlsl
@@ -1,0 +1,15 @@
+#ifndef GSMESHSKINNED_HLSL
+#define GSMESHSKINNED_HLSL
+#define MESH
+#include"..\Common\DataStructs.hlsl"
+#include"..\Common\Common.hlsl"
+
+[maxvertexcount(1)]
+void main(point VSSkinnedOutput input[1], inout PointStream<VSSkinnedOutput> output)
+{
+    input[0].p /= input[0].p.w;
+    output.Append(input[0]);
+    output.RestartStrip();
+}
+
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj
@@ -226,6 +226,16 @@ xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(Solut
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Geometry</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
     </FxCompile>
+    <FxCompile Include="GS\gsMeshSkinnedOut.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+    </FxCompile>
     <FxCompile Include="GS\gsParticle.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Geometry</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
@@ -741,6 +751,16 @@ xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(Solut
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="VS\vsBoneSkinningBasic.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Vertex</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Vertex</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
     </FxCompile>
     <FxCompile Include="VS\vsBoneSkinningShadow.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>

--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj.filters
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj.filters
@@ -276,5 +276,11 @@
     <FxCompile Include="VS\vsMeshBatchedShadow.hlsl">
       <Filter>VS</Filter>
     </FxCompile>
+    <FxCompile Include="GS\gsMeshSkinnedOut.hlsl">
+      <Filter>GS</Filter>
+    </FxCompile>
+    <FxCompile Include="VS\vsBoneSkinningBasic.hlsl">
+      <Filter>VS</Filter>
+    </FxCompile>
   </ItemGroup>
 </Project>

--- a/Source/HelixToolkit.Native.ShaderBuilder/VS/vsBoneSkinningBasic.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/VS/vsBoneSkinningBasic.hlsl
@@ -1,0 +1,54 @@
+#ifndef VSBONESKINNING_HLSL
+#define VSBONESKINNING_HLSL
+#define MESH
+#include"..\Common\Common.hlsl"
+
+VSSkinnedOutput main(VSSkinnedInput input)
+{
+    VSSkinnedOutput output = (VSSkinnedOutput) 0;
+    float4 inputp = input.p;
+    float3 inputn = input.n;
+    output.p = inputp;
+    output.n = inputn;
+    float3 inputt1 = input.t1;
+    float3 inputt2 = input.t2;
+
+    //if (bHasBones)
+    {
+        int4 bones = clamp(input.bones, minBoneV, maxBoneV);
+
+        output.p = mul(inputp, skinMatrices[bones.x]) * input.boneWeights.x;
+        output.n = mul(inputn, (float3x3) skinMatrices[bones.x]) * input.boneWeights.x;
+
+
+        output.p += mul(inputp, skinMatrices[bones.y]) * input.boneWeights.y;
+        output.n += mul(inputn, (float3x3) skinMatrices[bones.y]) * input.boneWeights.y;
+
+
+        output.p += mul(inputp, skinMatrices[bones.z]) * input.boneWeights.z;
+        output.n += mul(inputn, (float3x3) skinMatrices[bones.z]) * input.boneWeights.z;
+
+
+        output.p += mul(inputp, skinMatrices[bones.w]) * input.boneWeights.w;
+        output.n += mul(inputn, (float3x3) skinMatrices[bones.w]) * input.boneWeights.w;
+        output.n = normalize(output.n);
+
+        //if (bHasNormalMap)
+        {
+            output.t1 = mul(inputt1, (float3x3) skinMatrices[bones.x]) * input.boneWeights.x;
+            output.t2 = mul(inputt2, (float3x3) skinMatrices[bones.x]) * input.boneWeights.x;
+            output.t1 += mul(inputt1, (float3x3) skinMatrices[bones.y]) * input.boneWeights.y;
+            output.t2 += mul(inputt2, (float3x3) skinMatrices[bones.y]) * input.boneWeights.y;
+            output.t1 += mul(inputt1, (float3x3) skinMatrices[bones.z]) * input.boneWeights.z;
+            output.t2 += mul(inputt2, (float3x3) skinMatrices[bones.z]) * input.boneWeights.z;
+            output.t1 += mul(inputt1, (float3x3) skinMatrices[bones.w]) * input.boneWeights.w;
+            output.t2 += mul(inputt2, (float3x3) skinMatrices[bones.w]) * input.boneWeights.w;
+
+            output.t1 = normalize(output.t1);
+            output.t2 = normalize(output.t2);
+        }
+    }
+    return output;
+}
+
+#endif

--- a/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
+++ b/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
@@ -38,6 +38,7 @@
     <None Remove="Resources\gsBillboard.cso" />
     <None Remove="Resources\gsLine.cso" />
     <None Remove="Resources\gsMeshNormalVector.cso" />
+    <None Remove="Resources\gsMeshSkinnedOut.cso" />
     <None Remove="Resources\gsParticle.cso" />
     <None Remove="Resources\gsPoint.cso" />
     <None Remove="Resources\hsMeshTriTessellation.cso" />
@@ -84,10 +85,7 @@
     <None Remove="Resources\psWireframeOIT.cso" />
     <None Remove="Resources\vsBillboard.cso" />
     <None Remove="Resources\vsBillboardInstancing.cso" />
-    <None Remove="Resources\vsBoneSkinning.cso" />
-    <None Remove="Resources\vsBoneSkinningShadow.cso" />
-    <None Remove="Resources\vsBoneSkinningTessellation.cso" />
-    <None Remove="Resources\vsBoneSkinningWireframe.cso" />
+    <None Remove="Resources\vsBoneSkinningBasic.cso" />
     <None Remove="Resources\vsCubeMap.cso" />
     <None Remove="Resources\vsMeshBatched.cso" />
     <None Remove="Resources\vsMeshBatchedShadow.cso" />
@@ -118,6 +116,7 @@
     <EmbeddedResource Include="Resources\gsBillboard.cso" />
     <EmbeddedResource Include="Resources\gsLine.cso" />
     <EmbeddedResource Include="Resources\gsMeshNormalVector.cso" />
+    <EmbeddedResource Include="Resources\gsMeshSkinnedOut.cso" />
     <EmbeddedResource Include="Resources\gsParticle.cso" />
     <EmbeddedResource Include="Resources\gsPoint.cso" />
     <EmbeddedResource Include="Resources\hsMeshTriTessellation.cso" />
@@ -164,10 +163,7 @@
     <EmbeddedResource Include="Resources\psWireframeOIT.cso" />
     <EmbeddedResource Include="Resources\vsBillboard.cso" />
     <EmbeddedResource Include="Resources\vsBillboardInstancing.cso" />
-    <EmbeddedResource Include="Resources\vsBoneSkinning.cso" />
-    <EmbeddedResource Include="Resources\vsBoneSkinningShadow.cso" />
-    <EmbeddedResource Include="Resources\vsBoneSkinningTessellation.cso" />
-    <EmbeddedResource Include="Resources\vsBoneSkinningWireframe.cso" />
+    <EmbeddedResource Include="Resources\vsBoneSkinningBasic.cso" />
     <EmbeddedResource Include="Resources\vsCubeMap.cso" />
     <EmbeddedResource Include="Resources\vsMeshBatched.cso" />
     <EmbeddedResource Include="Resources\vsMeshBatchedShadow.cso" />

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
@@ -28,10 +28,6 @@ namespace HelixToolkit.UWP.Core
         private RasterizerStateProxy invertCullModeState = null;
         public RasterizerStateProxy InvertCullModeState { get { return invertCullModeState; } }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public InputLayout VertexLayout { private set; get; }
         private IElementsBufferModel instanceBuffer;
         /// <summary>
         /// 
@@ -214,7 +210,6 @@ namespace HelixToolkit.UWP.Core
             {
                 DefaultShaderPass = technique[DefaultShaderPassName];
                 ShadowPass = technique[DefaultShadowPassName];
-                this.VertexLayout = technique.Layout;
                 CreateRasterState(rasterDescription, true);       
                 return true;
             }
@@ -266,7 +261,7 @@ namespace HelixToolkit.UWP.Core
         /// <param name="vertStartSlot"></param>
         protected override bool OnAttachBuffers(DeviceContextProxy context, ref int vertStartSlot)
         {
-            bool succ = GeometryBuffer.AttachBuffers(context, this.VertexLayout, ref vertStartSlot, EffectTechnique.EffectsManager);
+            bool succ = GeometryBuffer.AttachBuffers(context, ref vertStartSlot, EffectTechnique.EffectsManager);
             InstanceBuffer?.AttachBuffer(context, ref vertStartSlot);
             return succ;
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Batching/StaticGeometryBatchingBufferBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Batching/StaticGeometryBatchingBufferBase.cs
@@ -199,11 +199,10 @@ namespace HelixToolkit.UWP.Core
         /// Attaches the buffers.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="vertexLayout">The vertex layout.</param>
         /// <param name="vertexBufferStartSlot">The vertex buffer start slot.</param>
         /// <param name="deviceResources">The device resources.</param>
         /// <returns></returns>
-        public bool AttachBuffers(DeviceContextProxy context, InputLayout vertexLayout, ref int vertexBufferStartSlot, IDeviceResources deviceResources)
+        public bool AttachBuffers(DeviceContextProxy context, ref int vertexBufferStartSlot, IDeviceResources deviceResources)
         {        
             if (!Commit(context) && vertexBufferBindings.Length > 0)
             {
@@ -222,9 +221,13 @@ namespace HelixToolkit.UWP.Core
             {
                 context.SetIndexBuffer(null, Format.Unknown, 0);
             }
-            context.InputLayout = vertexLayout;
             context.PrimitiveTopology = Topology;
             return true;
+        }
+
+        public void UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
+        {
+
         }
 
         protected override void OnDispose(bool disposeManagedResources)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Batching/StaticGeometryBatchingBufferBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Batching/StaticGeometryBatchingBufferBase.cs
@@ -225,9 +225,9 @@ namespace HelixToolkit.UWP.Core
             return true;
         }
 
-        public void UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
+        public bool UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
         {
-
+            return false;
         }
 
         protected override void OnDispose(bool disposeManagedResources)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/BoneSkinRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/BoneSkinRenderCore.cs
@@ -14,12 +14,16 @@ namespace HelixToolkit.UWP.Core
 
     public class BoneSkinRenderCore : MeshRenderCore
     {
+        private bool matricsChanged = true;
         private BoneMatricesStruct boneMatrices;
         public BoneMatricesStruct BoneMatrices
         {
             set
             {
-                SetAffectsRender(ref boneMatrices, value);
+                if(SetAffectsRender(ref boneMatrices, value))
+                {
+                    matricsChanged = true;
+                }
             }
             get { return boneMatrices; }
         }
@@ -36,6 +40,7 @@ namespace HelixToolkit.UWP.Core
         {
             if(base.OnAttach(technique))
             {
+                matricsChanged = true;
                 boneCB = technique.ConstantBufferPool.Register(new ConstantBufferDescription(DefaultBufferNames.BoneCB, BoneMatricesStruct.SizeInBytes));
                 boneSkinPass = technique[DefaultPassNames.MeshBoneSkinned];
                 return true;
@@ -48,7 +53,7 @@ namespace HelixToolkit.UWP.Core
 
         protected override void OnUpdate(RenderContext context, DeviceContextProxy deviceContext)
         {
-            if (boneSkinPass.IsNULL)
+            if (boneSkinPass.IsNULL || !matricsChanged)
             {
                 return;
             }
@@ -64,6 +69,7 @@ namespace HelixToolkit.UWP.Core
                 deviceContext.Draw(GeometryBuffer.VertexBuffer[0].ElementCount, 0);
                 boneBuffer.UnBindSkinnedVertexBufferToOutput(deviceContext);
             }
+            matricsChanged = false;
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/BoneSkinRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/BoneSkinRenderCore.cs
@@ -61,10 +61,7 @@ namespace HelixToolkit.UWP.Core
             if (GeometryBuffer is IBoneSkinMeshBufferModel boneBuffer)
             {
                 boneBuffer.BindSkinnedVertexBufferToOutput(deviceContext);
-                if (BoneMatrices.Bones != null)
-                {
-                    boneCB.UploadDataToBuffer(deviceContext, BoneMatrices.Bones, BoneMatricesStruct.NumberOfBones);
-                }
+                boneCB.UploadDataToBuffer(deviceContext, BoneMatrices.Bones ?? BoneMatricesStruct.DefaultBones, BoneMatricesStruct.NumberOfBones);
                 boneSkinPass.BindShader(deviceContext);
                 deviceContext.Draw(GeometryBuffer.VertexBuffer[0].ElementCount, 0);
                 boneBuffer.UnBindSkinnedVertexBufferToOutput(deviceContext);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/BoneSkinBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/BoneSkinBufferModel.cs
@@ -1,0 +1,258 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+
+using global::SharpDX.Direct3D;
+using global::SharpDX.Direct3D11;
+using SharpDX;
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX.Core
+#else
+namespace HelixToolkit.UWP.Core
+#endif
+{
+    using Render;
+    using Utilities;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="VertexStruct">The type of the ertex structure.</typeparam>
+    public abstract class BoneSkinMeshBufferModel<VertexStruct> : MeshGeometryBufferModel<VertexStruct>, IBoneSkinMeshBufferModel where VertexStruct : struct
+    {
+        protected IElementsBufferProxy skinnedVertexBuffer;
+        protected IElementsBufferProxy boneIdBuffer;
+        protected VertexBufferBinding[] skinnedOutputBindings = new VertexBufferBinding[0];
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoneSkinMeshBufferModel{VertexStruct}"/> class.
+        /// </summary>
+        /// <param name="topology">The topology.</param>
+        /// <param name="vertexBuffer">The vertex buffer.</param>
+        /// <param name="indexBuffer">The index buffer.</param>
+        public BoneSkinMeshBufferModel(PrimitiveTopology topology, IElementsBufferProxy vertexBuffer, IElementsBufferProxy indexBuffer)
+            : base(topology, vertexBuffer, indexBuffer)
+        {
+            skinnedVertexBuffer = Collect(new ImmutableBufferProxy(vertexBuffer.StructureSize, BindFlags.VertexBuffer | BindFlags.StreamOutput, ResourceOptionFlags.None, ResourceUsage.Default));
+            boneIdBuffer = Collect(new ImmutableBufferProxy(BoneIds.SizeInBytes, BindFlags.VertexBuffer, ResourceOptionFlags.None));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoneSkinMeshBufferModel{VertexStruct}"/> class.
+        /// </summary>
+        /// <param name="topology">The topology.</param>
+        /// <param name="vertexBuffer">The vertex buffer.</param>
+        /// <param name="indexBuffer">The index buffer.</param>
+        public BoneSkinMeshBufferModel(PrimitiveTopology topology, IElementsBufferProxy[] vertexBuffer, IElementsBufferProxy indexBuffer)
+            : base(topology, vertexBuffer, indexBuffer)
+        {
+            skinnedVertexBuffer = Collect(new ImmutableBufferProxy(vertexBuffer[0].StructureSize, BindFlags.VertexBuffer | BindFlags.StreamOutput, ResourceOptionFlags.None, ResourceUsage.Default));
+            boneIdBuffer = Collect(new ImmutableBufferProxy(BoneIds.SizeInBytes, BindFlags.VertexBuffer, ResourceOptionFlags.None));
+        }
+
+        protected override VertexBufferBinding[] OnCreateVertexBufferBinding()
+        {
+            var orgBinding = base.OnCreateVertexBufferBinding();
+            if (VertexBuffer.Length > 0)
+            {
+                orgBinding[0] = new VertexBufferBinding(skinnedVertexBuffer.Buffer, skinnedVertexBuffer.StructureSize, skinnedVertexBuffer.Offset);
+                skinnedOutputBindings = new VertexBufferBinding[]
+                {
+                    new VertexBufferBinding(VertexBuffer[0].Buffer, VertexBuffer[0].StructureSize, VertexBuffer[0].Offset),
+                    new VertexBufferBinding(boneIdBuffer.Buffer, boneIdBuffer.StructureSize, boneIdBuffer.Offset)
+                };
+            }          
+            return orgBinding;
+        }
+
+        /// <summary>
+        /// Binds the skinned vertex buffer to output.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void BindSkinnedVertexBufferToOutput(DeviceContextProxy context)
+        {
+            context.SetVertexBuffers(0, skinnedOutputBindings);
+            context.SetIndexBuffer(null, global::SharpDX.DXGI.Format.Unknown, 0);
+            context.SetStreamOutputTarget(skinnedVertexBuffer.Buffer, skinnedVertexBuffer.Offset);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void UnBindSkinnedVertexBufferToOutput(DeviceContextProxy context)
+        {
+            context.SetStreamOutputTarget(null);
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class DefaultSkinnedMeshGeometryBufferModel : BoneSkinMeshBufferModel<DefaultVertex>
+    {
+        [ThreadStatic]
+        private static DefaultVertex[] vertexArrayBuffer = null;
+        private static readonly Vector2[] emptyTextureArray = new Vector2[0];
+        private static readonly Vector4[] emptyColorArray = new Vector4[0];
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultSkinnedMeshGeometryBufferModel"/> class.
+        /// </summary>
+        public DefaultSkinnedMeshGeometryBufferModel()
+            : base(PrimitiveTopology.TriangleList,
+                  new[]
+                  {
+                      new ImmutableBufferProxy(DefaultVertex.SizeInBytes, BindFlags.VertexBuffer),
+                      new ImmutableBufferProxy(Vector2.SizeInBytes, BindFlags.VertexBuffer),
+                      new ImmutableBufferProxy(Vector4.SizeInBytes, BindFlags.VertexBuffer)
+                  } as IElementsBufferProxy[], new ImmutableBufferProxy(sizeof(int), BindFlags.IndexBuffer))
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultSkinnedMeshGeometryBufferModel"/> class.
+        /// </summary>
+        /// <param name="buffers">The buffers.</param>
+        /// <param name="isDynamic"></param>
+        public DefaultSkinnedMeshGeometryBufferModel(IElementsBufferProxy[] buffers, bool isDynamic)
+            : base(PrimitiveTopology.TriangleList, buffers, 
+                  isDynamic ? new DynamicBufferProxy(sizeof(int), BindFlags.IndexBuffer) : new ImmutableBufferProxy(sizeof(int), BindFlags.IndexBuffer) as IElementsBufferProxy)
+        {
+        }
+        /// <summary>
+        /// Determines whether [is vertex buffer changed] [the specified property name].
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="bufferIndex"></param>
+        /// <returns>
+        ///   <c>true</c> if [is vertex buffer changed] [the specified property name]; otherwise, <c>false</c>.
+        /// </returns>
+        protected override bool IsVertexBufferChanged(string propertyName, int bufferIndex)
+        {
+            switch (bufferIndex)
+            {
+                case 0:
+                    return base.IsVertexBufferChanged(propertyName, bufferIndex) || propertyName.Equals(nameof(BoneSkinnedMeshGeometry3D.VertexBoneIds));
+                case 1:
+                    return propertyName.Equals(nameof(MeshGeometry3D.TextureCoordinates));
+                case 2:
+                    return propertyName.Equals(nameof(MeshGeometry3D.Colors));
+                default:
+                    return false;
+            }
+        }
+        /// <summary>
+        /// Called when [create vertex buffer].
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="bufferIndex">Index of the buffer.</param>
+        /// <param name="geometry">The geometry.</param>
+        /// <param name="deviceResources">The device resources.</param>
+        protected override void OnCreateVertexBuffer(DeviceContextProxy context, IElementsBufferProxy buffer, int bufferIndex, Geometry3D geometry, IDeviceResources deviceResources)
+        {
+            if (geometry is MeshGeometry3D mesh)
+            {
+                switch (bufferIndex)
+                {
+                    case 0:
+                        // -- set geometry if given
+                        if (geometry.Positions != null && geometry.Positions.Count > 0)
+                        {
+                            // --- get geometry
+                            var data = BuildVertexArray(mesh);
+                            buffer.UploadDataToBuffer(context, data, geometry.Positions.Count, 0, geometry.PreDefinedVertexCount);
+                            skinnedVertexBuffer.UploadDataToBuffer(context, data, Geometry.Positions.Count, 0, Geometry.PreDefinedVertexCount);
+                            if (mesh is BoneSkinnedMeshGeometry3D boneMesh && boneMesh.VertexBoneIds != null && boneMesh.VertexBoneIds.Count >= geometry.Positions.Count)
+                            {
+                                boneIdBuffer.UploadDataToBuffer(context, boneMesh.VertexBoneIds, boneMesh.VertexBoneIds.Count);
+                            }
+                            else
+                            {
+                                boneIdBuffer.UploadDataToBuffer(context, new BoneIds[0], 0);
+                            }
+                        }
+                        else
+                        {
+                            buffer.UploadDataToBuffer(context, emptyVerts, 0);
+                            skinnedVertexBuffer.UploadDataToBuffer(context, emptyVerts, 0);
+                            boneIdBuffer.UploadDataToBuffer(context, new BoneIds[0], 0);
+                        }
+                        break;
+                    case 1:
+                        if (mesh.TextureCoordinates != null && mesh.TextureCoordinates.Count > 0)
+                        {
+                            buffer.UploadDataToBuffer(context, mesh.TextureCoordinates, mesh.TextureCoordinates.Count, 0, geometry.PreDefinedVertexCount);
+                        }
+                        else
+                        {
+                            buffer.UploadDataToBuffer(context, emptyTextureArray, 0);
+                        }
+                        break;
+                    case 2:
+                        if (geometry.Colors != null && geometry.Colors.Count > 0)
+                        {
+                            buffer.UploadDataToBuffer(context, geometry.Colors, geometry.Colors.Count, 0, geometry.PreDefinedVertexCount);
+                        }
+                        else
+                        {
+                            buffer.UploadDataToBuffer(context, emptyColorArray, 0);
+                        }
+                        break;
+                }
+            }
+        }
+        /// <summary>
+        /// Builds the vertex array.
+        /// </summary>
+        /// <param name="geometry">The geometry.</param>
+        /// <returns></returns>
+        private DefaultVertex[] BuildVertexArray(MeshGeometry3D geometry)
+        {
+            //var geometry = this.geometryInternal as MeshGeometry3D;
+            var positions = geometry.Positions.GetEnumerator();
+            var vertexCount = geometry.Positions.Count;
+
+            var normals = geometry.Normals != null ? geometry.Normals.GetEnumerator() : Enumerable.Repeat(Vector3.Zero, vertexCount).GetEnumerator();
+            var tangents = geometry.Tangents != null ? geometry.Tangents.GetEnumerator() : Enumerable.Repeat(Vector3.Zero, vertexCount).GetEnumerator();
+            var bitangents = geometry.BiTangents != null ? geometry.BiTangents.GetEnumerator() : Enumerable.Repeat(Vector3.Zero, vertexCount).GetEnumerator();
+
+            var array = vertexArrayBuffer != null && vertexArrayBuffer.Length >= vertexCount ? vertexArrayBuffer : new DefaultVertex[vertexCount];
+            vertexArrayBuffer = array;
+            for (var i = 0; i < vertexCount; i++)
+            {
+                positions.MoveNext();
+                normals.MoveNext();
+                tangents.MoveNext();
+                bitangents.MoveNext();
+                array[i].Position = new Vector4(positions.Current, 1f);
+                array[i].Normal = normals.Current;
+                array[i].Tangent = tangents.Current;
+                array[i].BiTangent = bitangents.Current;
+            }
+            normals.Dispose();
+            tangents.Dispose();
+            bitangents.Dispose();
+            positions.Dispose();
+            return array;
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed class DynamicSkinnedMeshGeometryBufferModel : DefaultSkinnedMeshGeometryBufferModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicSkinnedMeshGeometryBufferModel"/> class.
+        /// </summary>
+        public DynamicSkinnedMeshGeometryBufferModel()
+            : base(new[]
+                  {
+                      new DynamicBufferProxy(DefaultVertex.SizeInBytes, BindFlags.VertexBuffer),
+                      new DynamicBufferProxy(Vector2.SizeInBytes, BindFlags.VertexBuffer),
+                      new DynamicBufferProxy(Vector4.SizeInBytes, BindFlags.VertexBuffer)
+                  } as IElementsBufferProxy[], true)
+        { }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/EmptyBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/EmptyBufferModel.cs
@@ -142,8 +142,9 @@ namespace HelixToolkit.UWP.Core
 
         }
 
-        public void UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
+        public bool UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
         {
+            return false;
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/EmptyBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/EmptyBufferModel.cs
@@ -91,6 +91,10 @@ namespace HelixToolkit.UWP.Core
         /// The effects manager.
         /// </value>
         public IEffectsManager EffectsManager { set; get; }
+#pragma warning disable CS0067
+        public event EventHandler OnVertexBufferUpdated;
+        public event EventHandler OnIndexBufferUpdated;
+#pragma warning restore CS0067
         /// <summary>
         /// Attaches this instance.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/EmptyBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/EmptyBufferModel.cs
@@ -102,11 +102,10 @@ namespace HelixToolkit.UWP.Core
         /// Attaches the buffers.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="vertexLayout">The vertex layout.</param>
         /// <param name="vertexBufferStartSlot">The vertex buffer start slot. Returns next available bind slot</param>
         /// <param name="deviceResources"></param>
         /// <returns></returns>
-        public bool AttachBuffers(DeviceContextProxy context, InputLayout vertexLayout, ref int vertexBufferStartSlot, IDeviceResources deviceResources)
+        public bool AttachBuffers(DeviceContextProxy context, ref int vertexBufferStartSlot, IDeviceResources deviceResources)
         {
             return true;
         }
@@ -141,6 +140,10 @@ namespace HelixToolkit.UWP.Core
         public void Dispose()
         {
 
+        }
+
+        public void UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
+        {
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/GeometryBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/GeometryBufferModel.cs
@@ -210,8 +210,13 @@ namespace HelixToolkit.UWP.Core
             UpdateBuffers(context, deviceResources);
             return OnAttachBuffer(context, ref vertexBufferStartSlot);
         }
-
-        public bool UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
+        /// <summary>
+        /// Updates the buffers.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="deviceResources">The device resources.</param>
+        /// <returns></returns>
+        public virtual bool UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
         {
             bool bufferUpdated = false;
             if(VertexChanged != 0)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/GeometryBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/GeometryBufferModel.cs
@@ -23,6 +23,8 @@ namespace HelixToolkit.UWP.Core
     /// </summary>
     public abstract class GeometryBufferModel : ReferenceCountDisposeObject, IGUID, IGeometryBufferModel
     {
+        public event EventHandler OnVertexBufferUpdated;
+        public event EventHandler OnIndexBufferUpdated;
         /// <summary>
         /// Gets the unique identifier.
         /// </summary>
@@ -209,8 +211,9 @@ namespace HelixToolkit.UWP.Core
             return OnAttachBuffer(context, ref vertexBufferStartSlot);
         }
 
-        public void UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
+        public bool UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
         {
+            bool bufferUpdated = false;
             if(VertexChanged != 0)
             {
                 lock (VertexBuffer)
@@ -235,6 +238,8 @@ namespace HelixToolkit.UWP.Core
                     {
                         VertexBufferBindings = OnCreateVertexBufferBinding();
                         updateVBinding = false;
+                        OnVertexBufferUpdated?.Invoke(this, EventArgs.Empty);
+                        bufferUpdated = true;
                     }
                 }
             }
@@ -245,10 +250,13 @@ namespace HelixToolkit.UWP.Core
                     if (IndexChanged)
                     {
                         OnCreateIndexBuffer(context, IndexBuffer, Geometry, deviceResources);
+                        bufferUpdated = true;
                     }
-                    IndexChanged = false;
+                    IndexChanged = false;                    
+                    OnIndexBufferUpdated?.Invoke(this, EventArgs.Empty);
                 }               
             }
+            return bufferUpdated;
         }
 
         protected virtual VertexBufferBinding[] OnCreateVertexBufferBinding()

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/GeometryBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/GeometryBufferModel.cs
@@ -199,12 +199,17 @@ namespace HelixToolkit.UWP.Core
         /// Attaches the buffers.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="vertexLayout">The vertex layout.</param>
         /// <param name="vertexBufferStartSlot">The vertex buffer slot.</param>
         /// <param name="deviceResources">The device resources.</param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool AttachBuffers(DeviceContextProxy context, InputLayout vertexLayout, ref int vertexBufferStartSlot, IDeviceResources deviceResources)
+        public bool AttachBuffers(DeviceContextProxy context, ref int vertexBufferStartSlot, IDeviceResources deviceResources)
+        {
+            UpdateBuffers(context, deviceResources);
+            return OnAttachBuffer(context, ref vertexBufferStartSlot);
+        }
+
+        public void UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources)
         {
             if(VertexChanged != 0)
             {
@@ -228,7 +233,7 @@ namespace HelixToolkit.UWP.Core
                     }  
                     if (updateVBinding)
                     {
-                        VertexBufferBindings = VertexBuffer.Select(x => x != null ? new VertexBufferBinding(x.Buffer, x.StructureSize, x.Offset) : new VertexBufferBinding()).ToArray();
+                        VertexBufferBindings = OnCreateVertexBufferBinding();
                         updateVBinding = false;
                     }
                 }
@@ -244,7 +249,11 @@ namespace HelixToolkit.UWP.Core
                     IndexChanged = false;
                 }               
             }
-            return OnAttachBuffer(context, vertexLayout, ref vertexBufferStartSlot);
+        }
+
+        protected virtual VertexBufferBinding[] OnCreateVertexBufferBinding()
+        {
+            return VertexBuffer.Select(x => x != null ? new VertexBufferBinding(x.Buffer, x.StructureSize, x.Offset) : new VertexBufferBinding()).ToArray();
         }
         /// <summary>
         /// Called when [create vertex buffer].
@@ -267,10 +276,9 @@ namespace HelixToolkit.UWP.Core
         /// Called when [attach buffer].
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="vertexLayout">The vertex layout.</param>
         /// <param name="vertexBufferStartSlot">The vertex buffer start slot. It will be changed to the next available slot after binding</param>
         /// <returns></returns>
-        protected virtual bool OnAttachBuffer(DeviceContextProxy context, InputLayout vertexLayout, ref int vertexBufferStartSlot)
+        protected virtual bool OnAttachBuffer(DeviceContextProxy context, ref int vertexBufferStartSlot)
         {
             if (VertexBuffer.Length > 0)
             {
@@ -292,7 +300,6 @@ namespace HelixToolkit.UWP.Core
             {
                 context.SetIndexBuffer(null, Format.Unknown, 0);
             }
-            context.InputLayout = vertexLayout;
             context.PrimitiveTopology = Topology;
             return true;
         }

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultGeometryShaders.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultGeometryShaders.cs
@@ -10,6 +10,7 @@ namespace HelixToolkit.Wpf.SharpDX.Shaders
 namespace HelixToolkit.UWP.Shaders
 #endif
 {
+    using global::SharpDX;
     using Helper;
     /// <summary>
     /// 
@@ -55,6 +56,11 @@ namespace HelixToolkit.UWP.Shaders
         {
             get;
         } = "gsMeshNormalVector";
+
+        public static string GSMeshBoneSkinnedOut
+        {
+            get;
+        } = "gsMeshSkinnedOut";
     }
 
 
@@ -89,5 +95,25 @@ namespace HelixToolkit.UWP.Shaders
         /// </summary>
         public static ShaderDescription GSMeshNormalVector = new ShaderDescription(nameof(GSMeshNormalVector), ShaderStage.Geometry, new ShaderReflector(),
             DefaultGSShaderByteCodes.GSMeshNormalVector);
+
+        /// <summary>
+        /// The gs mesh bone skinned out
+        /// </summary>
+        public static ShaderDescription GSMeshBoneSkinnedOut = new ShaderDescription(nameof(GSMeshBoneSkinnedOut), ShaderStage.Geometry, new ShaderReflector(),
+            DefaultGSShaderByteCodes.GSMeshBoneSkinnedOut)
+        {
+            IsGSStreamOut = true,
+            GSSOElement = new global::SharpDX.Direct3D11.StreamOutputElement[]
+            {
+                new global::SharpDX.Direct3D11.StreamOutputElement(0, "POSITION", 0, 0, 4, 0),
+                new global::SharpDX.Direct3D11.StreamOutputElement(0, "NORMAL", 0, 0, 3, 0),
+                new global::SharpDX.Direct3D11.StreamOutputElement(0, "TANGENT", 0, 0, 3, 0),
+                new global::SharpDX.Direct3D11.StreamOutputElement(0, "BINORMAL", 0, 0, 3, 0),
+            },
+            GSSOStrides = new int[] 
+            {
+                DefaultVertex.SizeInBytes
+            }
+        };
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultVertexShaders.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultVertexShaders.cs
@@ -71,29 +71,10 @@ namespace HelixToolkit.UWP.Shaders
             get;
         } = "vsMeshInstancingTessellation";
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public static string VSMeshBoneSkinning
+        public static string VSMeshBoneSkinningBasic
         {
             get;
-        } = "vsBoneSkinning";
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public static string VSMeshBoneSkinningShadow
-        {
-            get;
-        } = "vsBoneSkinningShadow";
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public static string VSMeshBoneSkinningTessellation
-        {
-            get;
-        } = "vsBoneSkinningTessellation";
+        } = "vsBoneSkinningBasic";
 
         /// <summary>
         /// 
@@ -270,25 +251,23 @@ namespace HelixToolkit.UWP.Shaders
             new InputElement("COLOR", 3, Format.R32G32B32A32_Float, InputElement.AppendAligned, 4, InputClassification.PerInstanceData, 1),
             new InputElement("TEXCOORD", 5, Format.R32G32_Float, InputElement.AppendAligned, 4, InputClassification.PerInstanceData, 1),
         };
+
         /// <summary>
-        /// 
+        /// Gets the vs input bone skinned basic.
         /// </summary>
-        public static InputElement[] VSInputBoneSkinning { get; } = new InputElement[]
+        /// <value>
+        /// The vs input bone skinned basic.
+        /// </value>
+        public static InputElement[] VSInputBoneSkinnedBasic { get; } = new InputElement[]
         {
             new InputElement("POSITION", 0, Format.R32G32B32A32_Float, InputElement.AppendAligned, 0),
             new InputElement("NORMAL",   0, Format.R32G32B32_Float,    InputElement.AppendAligned, 0),
             new InputElement("TANGENT",  0, Format.R32G32B32_Float,    InputElement.AppendAligned, 0),
             new InputElement("BINORMAL", 0, Format.R32G32B32_Float,    InputElement.AppendAligned, 0),
-            new InputElement("TEXCOORD", 0, Format.R32G32_Float,       InputElement.AppendAligned, 1),
-            new InputElement("COLOR",    0, Format.R32G32B32A32_Float, InputElement.AppendAligned, 2),
-            //INSTANCING: die 4 texcoords sind die matrix, die mit jedem buffer reinwandern
-            new InputElement("TEXCOORD", 1, Format.R32G32B32A32_Float, InputElement.AppendAligned, 3, InputClassification.PerInstanceData, 1),
-            new InputElement("TEXCOORD", 2, Format.R32G32B32A32_Float, InputElement.AppendAligned, 3, InputClassification.PerInstanceData, 1),
-            new InputElement("TEXCOORD", 3, Format.R32G32B32A32_Float, InputElement.AppendAligned, 3, InputClassification.PerInstanceData, 1),
-            new InputElement("TEXCOORD", 4, Format.R32G32B32A32_Float, InputElement.AppendAligned, 3, InputClassification.PerInstanceData, 1),
-            new InputElement("BONEIDS", 0, Format.R32G32B32A32_SInt, InputElement.AppendAligned, 4),
-            new InputElement("BONEWEIGHTS", 0, Format.R32G32B32A32_Float, InputElement.AppendAligned, 4),
+            new InputElement("BONEIDS", 0, Format.R32G32B32A32_SInt, InputElement.AppendAligned, 1),
+            new InputElement("BONEWEIGHTS", 0, Format.R32G32B32A32_Float, InputElement.AppendAligned, 1),
         };
+
         /// <summary>
         /// 
         /// </summary>
@@ -421,23 +400,11 @@ namespace HelixToolkit.UWP.Shaders
             DefaultVSShaderByteCodes.VSMeshInstancingTessellation);
 
         /// <summary>
-        /// 
+        /// The vs mesh bone skinned basic
         /// </summary>
-        public static ShaderDescription VSMeshBoneSkinning = new ShaderDescription(nameof(VSMeshBoneSkinning), ShaderStage.Vertex,
-            new ShaderReflector(),
-            DefaultVSShaderByteCodes.VSMeshBoneSkinning);
-        /// <summary>
-        /// 
-        /// </summary>
-        public static ShaderDescription VSMeshBoneSkinningTessellation = new ShaderDescription(nameof(VSMeshBoneSkinningTessellation), ShaderStage.Vertex,
-            new ShaderReflector(),
-            DefaultVSShaderByteCodes.VSMeshBoneSkinningTessellation);
-        /// <summary>
-        /// 
-        /// </summary>
-        public static ShaderDescription VSMeshBoneSkinningShadow = new ShaderDescription(nameof(VSMeshBoneSkinningShadow), ShaderStage.Vertex,
-            new ShaderReflector(),
-            DefaultVSShaderByteCodes.VSMeshBoneSkinningShadow);
+        public static ShaderDescription VSMeshBoneSkinnedBasic = new ShaderDescription(nameof(VSMeshBoneSkinnedBasic), ShaderStage.Vertex,
+            new ShaderReflector(), DefaultVSShaderByteCodes.VSMeshBoneSkinningBasic);
+
         /// <summary>
         /// 
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -33,6 +33,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\BillboardRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\BoneSkinRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\BillboardBufferModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\BoneSkinBufferModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\EmptyBufferModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\GeometryBufferModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\ElementsBufferModel.cs" />
@@ -121,6 +122,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Element2D\Element2DCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Element3D\Element3DCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Element3D\GeometryBoundManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Geometry\BoneSkinnedMeshGeometry3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\ColorStripeMaterialCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\DiffuseMaterialCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\EmptyMaterialVariable.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IGeometryBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IGeometryBufferModel.cs
@@ -68,6 +68,8 @@ namespace HelixToolkit.UWP
     /// </summary>
     public interface IGeometryBufferModel : IAttachableBufferModel
     {
+        event EventHandler OnVertexBufferUpdated;
+        event EventHandler OnIndexBufferUpdated;
         /// <summary>
         /// Gets or sets the effects manager.
         /// </summary>
@@ -103,12 +105,20 @@ namespace HelixToolkit.UWP
         /// </value>
         BillboardType Type { get; }
     }
-
     /// <summary>
     /// 
     /// </summary>
-    public interface IBoneSkinMeshBufferModel
+    public interface IBoneSkinMeshBufferModel : IGeometryBufferModel
     {
+        event EventHandler OnBoneIdBufferUpdated;
+        IElementsBufferProxy BoneIdBuffer { get; }
+    }
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IBoneSkinPreComputehBufferModel
+    {
+        bool CanPreCompute { get; }
         /// <summary>
         /// Binds the skinned vertex buffer to output.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IGeometryBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IGeometryBufferModel.cs
@@ -50,11 +50,16 @@ namespace HelixToolkit.UWP
         /// Attaches the buffers.
         /// </summary>
         /// <param name="context">The context.</param>
-        /// <param name="vertexLayout">The vertex layout.</param>
         /// <param name="vertexBufferStartSlot">The vertex buffer slot. It will be changed to next available slot after binding.</param>
         /// <param name="deviceResources"></param>
         /// <returns></returns>
-        bool AttachBuffers(DeviceContextProxy context, InputLayout vertexLayout, ref int vertexBufferStartSlot, IDeviceResources deviceResources);
+        bool AttachBuffers(DeviceContextProxy context, ref int vertexBufferStartSlot, IDeviceResources deviceResources);
+        /// <summary>
+        /// Updates the buffers.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="deviceResources">The device resources.</param>
+        void UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources);
     }
 
     /// <summary>
@@ -96,5 +101,22 @@ namespace HelixToolkit.UWP
         /// The type.
         /// </value>
         BillboardType Type { get; }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IBoneSkinMeshBufferModel
+    {
+        /// <summary>
+        /// Binds the skinned vertex buffer to output.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        void BindSkinnedVertexBufferToOutput(DeviceContextProxy context);
+        /// <summary>
+        /// Uns the bind skinned vertex buffer to output.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        void UnBindSkinnedVertexBufferToOutput(DeviceContextProxy context);
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IGeometryBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IGeometryBufferModel.cs
@@ -59,7 +59,8 @@ namespace HelixToolkit.UWP
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="deviceResources">The device resources.</param>
-        void UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources);
+        /// <returns>True if buffer updated.</returns>
+        bool UpdateBuffers(DeviceContextProxy context, IDeviceResources deviceResources);
     }
 
     /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
@@ -21,13 +21,6 @@ namespace HelixToolkit.UWP.Core
     public interface IGeometryRenderCore
     {
         /// <summary>
-        /// Gets the vertex layout.
-        /// </summary>
-        /// <value>
-        /// The vertex layout.
-        /// </value>
-        InputLayout VertexLayout { get; }
-        /// <summary>
         /// Gets or sets the instance buffer.
         /// </summary>
         /// <value>
@@ -129,26 +122,7 @@ namespace HelixToolkit.UWP.Core
         /// </value>
         SamplerStateDescription SamplerDescription { set; get; }
     }
-    /// <summary>
-    /// 
-    /// </summary>
-    public interface IBoneSkinRenderParams
-    {
-        /// <summary>
-        /// Gets or sets the vertex bone identifier buffer.
-        /// </summary>
-        /// <value>
-        /// The vertex bone identifier buffer.
-        /// </value>
-        IElementsBufferModel VertexBoneIdBuffer { set; get; }
-        /// <summary>
-        /// Gets or sets the bone matrices.
-        /// </summary>
-        /// <value>
-        /// The bone matrices.
-        /// </value>
-        BoneMatricesStruct BoneMatrices { set; get; }
-    }
+
     /// <summary>
     /// 
     /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BoneSkinnedMeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BoneSkinnedMeshGeometry3D.cs
@@ -1,0 +1,47 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+#if NETFX_CORE
+namespace HelixToolkit.UWP
+#else
+namespace HelixToolkit.Wpf.SharpDX
+#endif
+{
+    using System;
+    using System.Collections.Generic;
+#if !NETFX_CORE
+    [Serializable]
+#endif
+    public class BoneSkinnedMeshGeometry3D : MeshGeometry3D
+    {
+        public BoneSkinnedMeshGeometry3D()
+        {
+
+        }
+
+        public BoneSkinnedMeshGeometry3D(MeshGeometry3D mesh)
+        {
+            mesh.AssignTo(this);
+        }
+
+        private IList<BoneIds> vertexBoneIds;
+        /// <summary>
+        /// Gets or sets the vertex bone ids and bone weights.
+        /// </summary>
+        /// <value>
+        /// The vertex bone ids.
+        /// </value>
+        public IList<BoneIds> VertexBoneIds
+        {
+            set
+            {
+                Set(ref vertexBoneIds, value);
+            }
+            get
+            {
+                return vertexBoneIds;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BoneSkinnedMeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BoneSkinnedMeshGeometry3D.cs
@@ -2,14 +2,20 @@
 The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using global::SharpDX;
+
 #if NETFX_CORE
 namespace HelixToolkit.UWP
 #else
 namespace HelixToolkit.Wpf.SharpDX
 #endif
 {
-    using System;
-    using System.Collections.Generic;
+    using Utilities;
+    using Core;
 #if !NETFX_CORE
     [Serializable]
 #endif
@@ -42,6 +48,74 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 return vertexBoneIds;
             }
+        }
+
+        /// <summary>
+        /// Merge meshes into one
+        /// </summary>
+        /// <param name="meshes"></param>
+        /// <returns></returns>
+        public static BoneSkinnedMeshGeometry3D Merge(params BoneSkinnedMeshGeometry3D[] meshes)
+        {
+            var positions = new Vector3Collection();
+            var indices = new IntCollection();
+
+            var normals = meshes.All(x => x.Normals != null) ? new Vector3Collection() : null;
+            var colors = meshes.All(x => x.Colors != null) ? new Color4Collection() : null;
+            var textureCoods = meshes.All(x => x.TextureCoordinates != null) ? new Vector2Collection() : null;
+            var tangents = meshes.All(x => x.Tangents != null) ? new Vector3Collection() : null;
+            var bitangents = meshes.All(x => x.BiTangents != null) ? new Vector3Collection() : null;
+            var vertexIds = meshes.All(x => x.VertexBoneIds != null) ? new List<BoneIds>() : null;
+            int index = 0;
+            foreach (var part in meshes)
+            {
+                positions.AddRange(part.Positions);
+                indices.AddRange(part.Indices.Select(x => x + index));
+                index += part.Positions.Count;
+            }
+
+            if (normals != null)
+            {
+                normals = new Vector3Collection(meshes.SelectMany(x => x.Normals));
+            }
+
+            if (colors != null)
+            {
+                colors = new Color4Collection(meshes.SelectMany(x => x.Colors));
+            }
+
+            if (textureCoods != null)
+            {
+                textureCoods = new Vector2Collection(meshes.SelectMany(x => x.TextureCoordinates));
+            }
+
+            if (tangents != null)
+            {
+                tangents = new Vector3Collection(meshes.SelectMany(x => x.Tangents));
+            }
+
+            if (bitangents != null)
+            {
+                bitangents = new Vector3Collection(meshes.SelectMany(x => x.BiTangents));
+            }
+
+            if(vertexIds != null)
+            {
+                vertexIds = new List<BoneIds>(meshes.SelectMany(x => x.VertexBoneIds));
+            }
+
+            var mesh = new BoneSkinnedMeshGeometry3D()
+            {
+                Positions = positions,
+                Indices = indices,
+                Normals = normals,
+                Colors = colors,
+                TextureCoordinates = textureCoods,
+                Tangents = tangents,
+                BiTangents = bitangents,
+                VertexBoneIds = vertexIds
+            };
+            return mesh;
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
@@ -129,14 +129,12 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 Positions = positions,
                 Indices = indices,
+                Normals = normals,
+                Colors = colors,
+                TextureCoordinates = textureCoods,
+                Tangents = tangents,
+                BiTangents = bitangents
             };
-
-            mesh.Normals = normals;
-            mesh.Colors = colors;
-            mesh.TextureCoordinates = textureCoods;
-            mesh.Tangents = tangents;
-            mesh.BiTangents = bitangents;
-
             return mesh;
         }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Layouts.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Layouts.cs
@@ -3,6 +3,7 @@ The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
 using SharpDX;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 #if NETFX_CORE
@@ -131,7 +132,9 @@ namespace HelixToolkit.Wpf.SharpDX
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = NumberOfBones)]
         public Matrix[] Bones;
         public const int SizeInBytes = 4 * (4 * 4 * NumberOfBones);
+        public static readonly Matrix[] DefaultBones = Enumerable.Repeat(Matrix.Identity, NumberOfBones).ToArray();
     }
+
     /// <summary>
     /// 
     /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
@@ -114,8 +114,8 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <value>
         /// The buffer model internal.
         /// </value>
-        protected IGeometryBufferModel BufferModelInternal { get { return bufferModelInternal; } }
-        private IGeometryBufferModel bufferModelInternal;
+        protected IAttachableBufferModel BufferModelInternal { get { return bufferModelInternal; } }
+        private IAttachableBufferModel bufferModelInternal;
 
         /// <summary>
         /// Gets a value indicating whether [geometry valid].
@@ -403,7 +403,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// Called when [create buffer model].
         /// </summary>
         /// <returns></returns>
-        protected virtual IGeometryBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
+        protected virtual IAttachableBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
         {
             return EmptyGeometryBufferModel.Empty;
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BillboardNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BillboardNode.cs
@@ -70,7 +70,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <param name="modelGuid"></param>
         /// <param name="geometry"></param>
         /// <returns></returns>
-        protected override IGeometryBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
+        protected override IAttachableBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
         {
             return geometry != null && geometry.IsDynamic ? EffectsManager.GeometryBufferManager.Register<DynamicBillboardBufferModel>(modelGuid, geometry) 
                 : EffectsManager.GeometryBufferManager.Register<DefaultBillboardBufferModel>(modelGuid, geometry);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
@@ -49,8 +49,8 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
 
         protected override IAttachableBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
         {
-            return !(base.OnCreateBufferModel(modelGuid, geometry) is GeometryBufferModel buffer) ? 
-                EmptyGeometryBufferModel.Empty : new BoneSkinMeshBufferModel(buffer, buffer.VertexStructSize.FirstOrDefault()) as IAttachableBufferModel;
+            return !(EffectsManager.GeometryBufferManager.Register<BoneSkinnedMeshBufferModel>(modelGuid, geometry) is IBoneSkinMeshBufferModel buffer) ? 
+                EmptyGeometryBufferModel.Empty : new BoneSkinPreComputeBufferModel(buffer, buffer.VertexStructSize.FirstOrDefault()) as IAttachableBufferModel;
         }
         /// <summary>
         /// Views the frustum test.

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
@@ -12,26 +12,13 @@ namespace HelixToolkit.UWP.Model.Scene
 namespace HelixToolkit.Wpf.SharpDX.Model.Scene
 #endif
 {
+    using System;
     using Core;
     /// <summary>
     /// 
     /// </summary>
     public class BoneSkinMeshNode : MeshNode
     {
-        /// <summary>
-        /// Gets or sets the vertex bone ids.
-        /// </summary>
-        /// <value>
-        /// The vertex bone ids.
-        /// </value>
-        public IList<BoneIds> VertexBoneIds
-        {
-            set
-            {
-                bonesBufferModel.Elements = value;
-            }
-            get { return bonesBufferModel.Elements; }
-        }
         /// <summary>
         /// Gets or sets the bone matrices.
         /// </summary>
@@ -49,23 +36,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
                 return (RenderCore as BoneSkinRenderCore).BoneMatrices;
             }
         }
-        /// <summary>
-        /// The bones buffer model
-        /// </summary>
-        protected readonly IElementsBufferModel<BoneIds> bonesBufferModel = new VertexBoneIdBufferModel<BoneIds>(BoneIds.SizeInBytes);
-        private IBoneSkinRenderParams boneSkinRenderCore
-        {
-            get { return (IBoneSkinRenderParams)RenderCore; }
-        }
-        /// <summary>
-        /// Called when [create render technique].
-        /// </summary>
-        /// <param name="host">The host.</param>
-        /// <returns></returns>
-        protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
-        {
-            return host.EffectsManager[DefaultRenderTechniqueNames.BoneSkinBlinn];
-        }
+
         /// <summary>
         /// Called when [create render core].
         /// </summary>
@@ -74,42 +45,12 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         {
             return new BoneSkinRenderCore();
         }
-        /// <summary>
-        /// Assigns the default values to core.
-        /// </summary>
-        /// <param name="core">The core.</param>
-        protected override void AssignDefaultValuesToCore(RenderCore core)
-        {
-            base.AssignDefaultValuesToCore(core);
-            boneSkinRenderCore.BoneMatrices = BoneMatrices;
-        }
-        /// <summary>
-        /// Called when [attach].
-        /// </summary>
-        /// <param name="host">The host.</param>
-        /// <returns></returns>
-        protected override bool OnAttach(IRenderHost host)
-        {
-            if (base.OnAttach(host))
-            {
-                bonesBufferModel.Initialize();
-                boneSkinRenderCore.VertexBoneIdBuffer = bonesBufferModel;
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Called when [detach].
-        /// </summary>
-        protected override void OnDetach()
-        {
-            bonesBufferModel.DisposeAndClear();
-            base.OnDetach();
-        }
 
+        protected override IGeometryBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
+        {
+            return geometry != null && geometry.IsDynamic ? EffectsManager.GeometryBufferManager.Register<DynamicSkinnedMeshGeometryBufferModel>(modelGuid, geometry)
+                : EffectsManager.GeometryBufferManager.Register<DefaultSkinnedMeshGeometryBufferModel>(modelGuid, geometry);
+        }
         /// <summary>
         /// Views the frustum test.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
@@ -5,6 +5,7 @@ Copyright(c) 2018 Helix Toolkit contributors
 
 using SharpDX;
 using System.Collections.Generic;
+using System.Linq;
 
 #if NETFX_CORE
 namespace HelixToolkit.UWP.Model.Scene
@@ -46,10 +47,10 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
             return new BoneSkinRenderCore();
         }
 
-        protected override IGeometryBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
+        protected override IAttachableBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
         {
-            return geometry != null && geometry.IsDynamic ? EffectsManager.GeometryBufferManager.Register<DynamicSkinnedMeshGeometryBufferModel>(modelGuid, geometry)
-                : EffectsManager.GeometryBufferManager.Register<DefaultSkinnedMeshGeometryBufferModel>(modelGuid, geometry);
+            return !(base.OnCreateBufferModel(modelGuid, geometry) is GeometryBufferModel buffer) ? 
+                EmptyGeometryBufferModel.Empty : new BoneSkinMeshBufferModel(buffer, buffer.VertexStructSize.FirstOrDefault()) as IAttachableBufferModel;
         }
         /// <summary>
         /// Views the frustum test.

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/LineNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/LineNode.cs
@@ -71,7 +71,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <param name="modelGuid"></param>
         /// <param name="geometry"></param>
         /// <returns></returns>
-        protected override IGeometryBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
+        protected override IAttachableBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
         {
             return geometry != null && geometry.IsDynamic ? EffectsManager.GeometryBufferManager.Register<DynamicLineGeometryBufferModel>(modelGuid, geometry) 
                 : EffectsManager.GeometryBufferManager.Register<DefaultLineGeometryBufferModel>(modelGuid, geometry);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/MeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/MeshNode.cs
@@ -138,7 +138,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <param name="modelGuid"></param>
         /// <param name="geometry"></param>
         /// <returns></returns>
-        protected override IGeometryBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
+        protected override IAttachableBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
         {
             return geometry != null && geometry.IsDynamic ? EffectsManager.GeometryBufferManager.Register<DynamicMeshGeometryBufferModel>(modelGuid, geometry)
                 : EffectsManager.GeometryBufferManager.Register<DefaultMeshGeometryBufferModel>(modelGuid, geometry);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PointNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PointNode.cs
@@ -105,7 +105,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
         /// <param name="modelGuid"></param>
         /// <param name="geometry"></param>
         /// <returns></returns>
-        protected override IGeometryBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
+        protected override IAttachableBufferModel OnCreateBufferModel(Guid modelGuid, Geometry3D geometry)
         {
             return geometry != null && geometry.IsDynamic ? EffectsManager.GeometryBufferManager.Register<DynamicPointGeometryBufferModel>(modelGuid, geometry) 
                 : EffectsManager.GeometryBufferManager.Register<DefaultPointGeometryBufferModel>(modelGuid, geometry);

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy/DeviceContextProxy_Targets.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy/DeviceContextProxy_Targets.cs
@@ -48,7 +48,25 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         {
             deviceContext.OutputMerger.SetRenderTargets(dsv, renderTarget);
         }
-
+        /// <summary>
+        /// Sets the stream output target.
+        /// </summary>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="offset">The offset.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetStreamOutputTarget(Buffer buffer, int offset = 0)
+        {
+            deviceContext.StreamOutput.SetTarget(buffer, offset);
+        }
+        /// <summary>
+        /// Sets the stream output target.
+        /// </summary>
+        /// <param name="bufferBindings">The buffer bindings.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetStreamOutputTarget(StreamOutputBufferBinding[] bufferBindings)
+        {
+            deviceContext.StreamOutput.SetTargets(bufferBindings);
+        }
         private static readonly RenderTargetView[] ZeroRenderTargetArray = new RenderTargetView[0];
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
@@ -174,7 +174,7 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
-                    new ShaderPassDescription(DefaultPassNames.MeshBoneSkinned)
+                    new ShaderPassDescription(DefaultPassNames.PreComputeMeshBoneSkinned)
                     {
                         ShaderList = new[]
                         {
@@ -430,7 +430,7 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
-                    new ShaderPassDescription(DefaultPassNames.MeshBoneSkinned)
+                    new ShaderPassDescription(DefaultPassNames.PreComputeMeshBoneSkinned)
                     {
                         ShaderList = new[]
                         {
@@ -687,7 +687,7 @@ namespace HelixToolkit.UWP
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess,
                         Topology = PrimitiveTopology.PointList
                     },
-                    new ShaderPassDescription(DefaultPassNames.MeshBoneSkinned)
+                    new ShaderPassDescription(DefaultPassNames.PreComputeMeshBoneSkinned)
                     {
                         ShaderList = new[]
                         {

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
@@ -174,6 +174,18 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
+                    new ShaderPassDescription(DefaultPassNames.MeshBoneSkinned)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshBoneSkinnedBasic,
+                            DefaultGSShaderDescriptions.GSMeshBoneSkinnedOut
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSNoDepthNoStencil,
+                        Topology = PrimitiveTopology.PointList,
+                        InputLayoutDescription = new InputLayoutDescription(DefaultVSShaderByteCodes.VSMeshBoneSkinningBasic, DefaultInputLayout.VSInputBoneSkinnedBasic),
+                    },
                     new ShaderPassDescription(DefaultPassNames.DepthPrepass)
                     {
                         ShaderList = new[]
@@ -417,6 +429,18 @@ namespace HelixToolkit.UWP
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.MeshBoneSkinned)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshBoneSkinnedBasic,
+                            DefaultGSShaderDescriptions.GSMeshBoneSkinnedOut
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSNoDepthNoStencil,
+                        Topology = PrimitiveTopology.PointList,
+                        InputLayoutDescription = new InputLayoutDescription(DefaultVSShaderByteCodes.VSMeshBoneSkinningBasic, DefaultInputLayout.VSInputBoneSkinnedBasic),
                     },
                     new ShaderPassDescription(DefaultPassNames.DiffuseOIT)
                     {
@@ -663,6 +687,18 @@ namespace HelixToolkit.UWP
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess,
                         Topology = PrimitiveTopology.PointList
                     },
+                    new ShaderPassDescription(DefaultPassNames.MeshBoneSkinned)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshBoneSkinnedBasic,
+                            DefaultGSShaderDescriptions.GSMeshBoneSkinnedOut
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSNoDepthNoStencil,
+                        Topology = PrimitiveTopology.PointList,
+                        InputLayoutDescription = new InputLayoutDescription(DefaultVSShaderByteCodes.VSMeshBoneSkinningBasic, DefaultInputLayout.VSInputBoneSkinnedBasic),
+                    },
                     new ShaderPassDescription(DefaultPassNames.OITPass)
                     {
                         ShaderList = new[]
@@ -821,250 +857,6 @@ namespace HelixToolkit.UWP
                         ShaderList = new[]
                         {
                             DefaultVSShaderDescriptions.VSMeshInstancing,
-                            DefaultPSShaderDescriptions.PSEffectDiffuseXRayGrid
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP3,
-                        StencilRef = 1
-                    },
-                }
-            };
-
-            var renderBoneSkinning = new TechniqueDescription(DefaultRenderTechniqueNames.BoneSkinBlinn)
-            {
-                InputLayoutDescription = new InputLayoutDescription(DefaultVSShaderByteCodes.VSMeshBoneSkinning, DefaultInputLayout.VSInputBoneSkinning),
-                PassDescriptions = new[]
-                {
-                    new ShaderPassDescription(DefaultPassNames.Default)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSMeshBlinnPhong
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual
-                    },
-                    new ShaderPassDescription(DefaultPassNames.Colors)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSMeshVertColor
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual
-                    },
-                    new ShaderPassDescription(DefaultPassNames.Normals)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSMeshVertNormal
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual
-                    },
-                    new ShaderPassDescription(DefaultPassNames.Positions)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSMeshVertPosition
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual
-                    },
-                    new ShaderPassDescription(DefaultPassNames.Diffuse)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSMeshDiffuseMap
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual
-                    },
-                    new ShaderPassDescription(DefaultPassNames.ColorStripe1D)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSMeshColorStripe
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual
-                    },
-                    new ShaderPassDescription(DefaultPassNames.NormalVector)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultGSShaderDescriptions.GSMeshNormalVector,
-                            DefaultPSShaderDescriptions.PSLineColor
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSSourceAlways,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess,
-                        Topology = PrimitiveTopology.PointList
-                    },
-                    new ShaderPassDescription(DefaultPassNames.OITPass)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSMeshBlinnPhongOIT
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
-                    },
-                    new ShaderPassDescription(DefaultPassNames.DiffuseOIT)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOIT
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
-                    },
-                    new ShaderPassDescription(DefaultPassNames.DepthPrepass)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSShadow
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess
-                    },
-                    new ShaderPassDescription(DefaultPassNames.MeshTriTessellation)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinningTessellation,
-                            DefaultHullShaderDescriptions.HSMeshTessellation,
-                            DefaultDomainShaderDescriptions.DSMeshTessellation,
-                            DefaultPSShaderDescriptions.PSMeshBlinnPhong
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual,
-                        Topology = PrimitiveTopology.PatchListWith3ControlPoints
-                    },
-                    new ShaderPassDescription(DefaultPassNames.MeshTriTessellationOIT)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinningTessellation,
-                            DefaultHullShaderDescriptions.HSMeshTessellation,
-                            DefaultDomainShaderDescriptions.DSMeshTessellation,
-                            DefaultPSShaderDescriptions.PSMeshBlinnPhongOIT
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
-                        Topology = PrimitiveTopology.PatchListWith3ControlPoints
-                    },
-                    new ShaderPassDescription(DefaultPassNames.ShadowPass)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinningShadow,
-                            DefaultPSShaderDescriptions.PSShadow
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess
-                    },
-                    new ShaderPassDescription(DefaultPassNames.Wireframe)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSBoneSkinningWireframe,
-                            DefaultPSShaderDescriptions.PSMeshWireframe
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSSourceAlways,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
-                        Topology = PrimitiveTopology.TriangleList
-                    },
-                    new ShaderPassDescription(DefaultPassNames.WireframeOITPass)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSBoneSkinningWireframe,
-                            DefaultPSShaderDescriptions.PSMeshWireframeOIT
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
-                        Topology = PrimitiveTopology.TriangleList
-                    },
-                    new ShaderPassDescription(DefaultPassNames.EffectOutlineP1)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSBoneSkinningWireframe,
-                            DefaultPSShaderDescriptions.PSMeshOutlineQuadStencil
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSSourceAlways,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSMeshOutlineP1,
-                        StencilRef = 1
-                    },
-                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayP1)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSBoneSkinningWireframe,
-                            DefaultPSShaderDescriptions.PSDepthStencilOnly
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayP1,
-                    },
-                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayP2)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSEffectMeshXRay
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSOverlayBlending,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayP2,
-                        StencilRef = 1
-                    },
-                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP1)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSBoneSkinningWireframe,
-                            DefaultPSShaderDescriptions.PSDepthStencilOnly
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP1,
-                        StencilRef = 1
-                    },
-                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP2)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSBoneSkinningWireframe,
-                            DefaultPSShaderDescriptions.PSDepthStencilOnly
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP2,
-                        StencilRef = 1
-                    },
-                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP3)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
-                            DefaultPSShaderDescriptions.PSEffectXRayGrid
-                        },
-                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
-                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP3,
-                        StencilRef = 1
-                    },
-                    new ShaderPassDescription(DefaultPassNames.EffectMeshDiffuseXRayGridP3)
-                    {
-                        ShaderList = new[]
-                        {
-                            DefaultVSShaderDescriptions.VSMeshBoneSkinning,
                             DefaultPSShaderDescriptions.PSEffectDiffuseXRayGrid
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
@@ -1769,7 +1561,6 @@ namespace HelixToolkit.UWP
             yield return renderBlinn;
             yield return renderBlinnBatched;
             yield return renderBlinnInstancing;
-            yield return renderBoneSkinning;
             yield return renderPoint;
             yield return renderLine;
             yield return renderBillboardText;

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
@@ -75,10 +75,6 @@ namespace HelixToolkit.UWP
         /// <summary>
         /// 
         /// </summary>
-        public const string BoneSkinBlinn = "RenderBoneSkinBlinn";
-        /// <summary>
-        /// 
-        /// </summary>
         public const string ParticleStorm = "ParticleStorm";
         /// <summary>
         /// 
@@ -202,6 +198,10 @@ namespace HelixToolkit.UWP
         /// 
         /// </summary>
         public const string MeshOutline = "RenderMeshOutline";
+        /// <summary>
+        /// The mesh bone skinned
+        /// </summary>
+        public const string MeshBoneSkinned = "MeshBoneSkinned";
 
         /// <summary>
         /// 

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
@@ -201,7 +201,7 @@ namespace HelixToolkit.UWP
         /// <summary>
         /// The mesh bone skinned
         /// </summary>
-        public const string MeshBoneSkinned = "MeshBoneSkinned";
+        public const string PreComputeMeshBoneSkinned = "MeshBoneSkinned";
 
         /// <summary>
         /// 

--- a/Source/HelixToolkit.SharpDX.Shared/Shaders/GeometryShader.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Shaders/GeometryShader.cs
@@ -31,6 +31,22 @@ namespace HelixToolkit.UWP.Shaders
             Shader = Collect(new global::SharpDX.Direct3D11.GeometryShader(device, byteCode));
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeometryShader"/> class. This is used for stream out geometry shader
+        /// </summary>
+        /// <param name="device">The device.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="byteCode">The byte code.</param>
+        /// <param name="streamOutputElements">The stream output elements.</param>
+        /// <param name="bufferStrides">The buffer strides.</param>
+        /// <param name="rasterizedStream">The rasterized stream.</param>
+        public GeometryShader(Device device, string name, byte[] byteCode, StreamOutputElement[] streamOutputElements, int[] bufferStrides, 
+            int rasterizedStream = global::SharpDX.Direct3D11.GeometryShader.StreamOutputNoRasterizedStream)
+            : base(name, ShaderStage.Geometry)
+        {
+            Shader = Collect(new global::SharpDX.Direct3D11.GeometryShader(device, byteCode, streamOutputElements, bufferStrides, rasterizedStream));
+        }
+
         private GeometryShader(string name)
             :base(name, ShaderStage.Geometry, true)
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Shaders/ShaderDescription.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Shaders/ShaderDescription.cs
@@ -123,6 +123,40 @@ namespace HelixToolkit.UWP.Shaders
         public IShaderReflector ShaderReflector { set; get; }
 
         private readonly IShaderByteCodeReader byteCodeReader;
+        #region GS Stream output Only
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is gs stream out.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is gs stream out; otherwise, <c>false</c>.
+        /// </value>
+        [DataMember]
+        public bool IsGSStreamOut { set; get; } = false;
+        /// <summary>
+        /// Gets or sets the gs stream output element.
+        /// </summary>
+        /// <value>
+        /// The gsso element.
+        /// </value>
+        [DataMember]
+        public StreamOutputElement[] GSSOElement { set; get; } = null;
+        /// <summary>
+        /// Gets or sets the gs stream output strides.
+        /// </summary>
+        /// <value>
+        /// The gsso strides.
+        /// </value>
+        [DataMember]
+        public int[] GSSOStrides { set; get; } = null;
+        /// <summary>
+        /// Gets or sets the gs stream output rasterized stream index.
+        /// </summary>
+        /// <value>
+        /// The gsso rasterized stream index.
+        /// </value>
+        [DataMember]
+        public int GSSORasterized { set; get; } = -1;
+        #endregion
         /// <summary>
         /// Create a empty description
         /// </summary>
@@ -242,7 +276,14 @@ namespace HelixToolkit.UWP.Shaders
                     shader = new HullShader(device, Name, ByteCode);
                     break;
                 case ShaderStage.Geometry:
-                    shader = new GeometryShader(device, Name, ByteCode);
+                    if (IsGSStreamOut)
+                    {
+                        shader = new GeometryShader(device, Name, ByteCode, GSSOElement, GSSOStrides, GSSORasterized);
+                    }
+                    else
+                    {
+                        shader = new GeometryShader(device, Name, ByteCode);
+                    }
                     break;
                 default:
                     break;

--- a/Source/HelixToolkit.SharpDX.Shared/Shaders/ShaderPass.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Shaders/ShaderPass.cs
@@ -69,6 +69,14 @@ namespace HelixToolkit.UWP.Shaders
         /// </summary>
         public RasterizerStateProxy RasterState { private set; get; } = null;
         /// <summary>
+        /// Gets or sets the input layout. This is customized layout used for this ShaderPass only.
+        /// If this is not set, default is using <see cref="Technique.Layout"/> from <see cref="TechniqueDescription.InputLayoutDescription"/>
+        /// </summary>
+        /// <value>
+        /// The input layout.
+        /// </value>
+        public InputLayout Layout { private set; get; } = null;
+        /// <summary>
         /// Gets or sets the topology.
         /// </summary>
         /// <value>
@@ -82,8 +90,9 @@ namespace HelixToolkit.UWP.Shaders
         /// 
         /// </summary>
         /// <param name="passDescription"></param>
+        /// <param name="layout"></param>
         /// <param name="manager"></param>
-        public ShaderPass(ShaderPassDescription passDescription, IEffectsManager manager)
+        public ShaderPass(ShaderPassDescription passDescription, InputLayout layout, IEffectsManager manager)
         {
             Name = passDescription.Name;
 
@@ -132,6 +141,14 @@ namespace HelixToolkit.UWP.Shaders
             SampleMask = passDescription.SampleMask;
 
             Topology = passDescription.Topology;
+            if(passDescription.InputLayoutDescription != null)
+            {
+                Layout = manager.ShaderManager.RegisterInputLayout(passDescription.InputLayoutDescription);
+            }
+            else
+            {
+                Layout = layout;
+            }
         }
 
         /// <summary>
@@ -151,6 +168,10 @@ namespace HelixToolkit.UWP.Shaders
         public void BindShader(DeviceContextProxy context, bool bindConstantBuffer = true)
         {
             context.SetShaderPass(this, bindConstantBuffer);
+            if(Layout != null)
+            {
+                context.InputLayout = Layout;
+            }
         }
 
         #region Get Shaders

--- a/Source/HelixToolkit.SharpDX.Shared/Shaders/Technique.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Shaders/Technique.cs
@@ -87,7 +87,7 @@ namespace HelixToolkit.UWP.Shaders
                 {
                     foreach(var desc in description.PassDescriptions)
                     {
-                        var pass = new Lazy<ShaderPass>(()=> { return Collect(new ShaderPass(desc, manager)); }, true);
+                        var pass = new Lazy<ShaderPass>(()=> { return Collect(new ShaderPass(desc, Layout, manager)); }, true);
                         passDict.Add(desc.Name, pass);
                         passList.Add(pass);
                     }

--- a/Source/HelixToolkit.SharpDX.Shared/Shaders/TechniqueDescription.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Shaders/TechniqueDescription.cs
@@ -238,6 +238,12 @@ namespace HelixToolkit.UWP.Shaders
             }
         }
 
+        /// <summary>
+        /// Input Layout
+        /// </summary>
+        [DataMember(Name = @"InputLayoutDescription")]
+        public InputLayoutDescription InputLayoutDescription { set; get; } = null;
+
         public ShaderPassDescription() { }
 
         public ShaderPassDescription(string name)

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ElementsBufferProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ElementsBufferProxy.cs
@@ -58,17 +58,19 @@ namespace HelixToolkit.UWP.Utilities
         ///
         /// </summary>
         public ResourceOptionFlags OptionFlags { private set; get; }
-
+        public ResourceUsage Usage { private set; get; } = ResourceUsage.Immutable;
         /// <summary>
         ///
         /// </summary>
         /// <param name="structureSize"></param>
         /// <param name="bindFlags"></param>
         /// <param name="optionFlags"></param>
-        public ImmutableBufferProxy(int structureSize, BindFlags bindFlags, ResourceOptionFlags optionFlags = ResourceOptionFlags.None)
+        /// <param name="usage"></param>
+        public ImmutableBufferProxy(int structureSize, BindFlags bindFlags, ResourceOptionFlags optionFlags = ResourceOptionFlags.None, ResourceUsage usage = ResourceUsage.Immutable)
             : base(structureSize, bindFlags)
         {
             OptionFlags = optionFlags;
+            Usage = usage;
         }
 
         /// <summary>
@@ -107,7 +109,7 @@ namespace HelixToolkit.UWP.Utilities
                 OptionFlags = this.OptionFlags,
                 SizeInBytes = StructureSize * count,
                 StructureByteStride = StructureSize,
-                Usage = ResourceUsage.Immutable
+                Usage = Usage
             };
             buffer = Collect(Buffer.Create(context, data.GetArrayByType(), buffdesc));
         }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/BoneSkinmeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/BoneSkinmeshGeometryModel3D.cs
@@ -17,24 +17,6 @@ namespace HelixToolkit.Wpf.SharpDX
     /// </summary>
     public class BoneSkinMeshGeometryModel3D : MeshGeometryModel3D
     {
-        public static DependencyProperty VertexBoneIdsProperty = DependencyProperty.Register("VertexBoneIds", typeof(IList<BoneIds>), typeof(BoneSkinMeshGeometryModel3D),
-            new PropertyMetadata(null, (d, e) =>
-            {
-                ((d as Element3DCore).SceneNode as BoneSkinMeshNode).VertexBoneIds = e.NewValue as IList<BoneIds>;
-            }));
-
-        public IList<BoneIds> VertexBoneIds
-        {
-            set
-            {
-                SetValue(VertexBoneIdsProperty, value);
-            }
-            get
-            {
-                return (IList<BoneIds>)GetValue(VertexBoneIdsProperty);
-            }
-        }
-
         public static DependencyProperty BoneMatricesProperty = DependencyProperty.Register("BoneMatrices", typeof(BoneMatricesStruct), typeof(BoneSkinMeshGeometryModel3D),
             new PropertyMetadata(new BoneMatricesStruct() { Bones = new Matrix[BoneMatricesStruct.NumberOfBones] },
                 (d, e) =>
@@ -57,15 +39,6 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override SceneNode OnCreateSceneNode()
         {
             return new BoneSkinMeshNode();
-        }
-
-        protected override void AssignDefaultValuesToSceneNode(SceneNode core)
-        {
-            if (core is BoneSkinMeshNode n)
-            {
-                n.BoneMatrices = BoneMatrices;
-            }
-            base.AssignDefaultValuesToSceneNode(core);
         }
     }
 }

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -345,18 +345,6 @@
     <Content Include="Resources\vsBillboardInstancing.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Resources\vsBoneSkinning.cso">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\vsBoneSkinningShadow.cso">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\vsBoneSkinningTessellation.cso">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Resources\vsBoneSkinningWireframe.cso">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="Resources\vsCubeMap.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -455,6 +443,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Resources\vsMeshBatchedWireframe.cso">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\gsMeshSkinnedOut.cso">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\vsBoneSkinningBasic.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -175,11 +175,6 @@
     <Compile Include="Model\Scene\SceneNode.cs" />
     <Compile Include="Model\Scene\SceneNode2D.cs" />
     <Compile Include="Properties\AssemblyDescription.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
     <Compile Include="Model\Elements3D\CompositeModel3D.cs" />
     <Compile Include="Model\Elements3D\DraggableGeometryModel3D.cs">
       <SubType>Code</SubType>
@@ -201,6 +196,7 @@
     <Compile Include="Model\Lights3D\SpotLight3D.cs" />
     <Compile Include="Model\Interfaces.cs" />
     <Compile Include="Model\Lights3D\ThreePointLight3D.cs" />
+    <Compile Include="Properties\Resources.Designer.cs" />
     <Compile Include="Utilities\Exporter.cs" />
     <Compile Include="Utilities\IExporter.cs" />
     <Compile Include="Utilities\ObjExporter.cs" />
@@ -216,11 +212,6 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <SubType>Designer</SubType>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
@@ -230,6 +221,7 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <AppDesigner Include="Properties\" />
+    <EmbeddedResource Include="Properties\Resources.resx" />
     <EmbeddedResource Include="Textures\arial.fnt" />
     <None Include="Resources\csParticleInsert.cso" />
     <None Include="Resources\csParticleUpdate.cso" />
@@ -237,6 +229,7 @@
     <None Include="Resources\gsBillboard.cso" />
     <None Include="Resources\gsLine.cso" />
     <None Include="Resources\gsMeshNormalVector.cso" />
+    <None Include="Resources\gsMeshSkinnedOut.cso" />
     <None Include="Resources\gsParticle.cso" />
     <None Include="Resources\gsPoint.cso" />
     <None Include="Resources\hsMeshTriTessellation.cso" />
@@ -283,10 +276,7 @@
     <None Include="Resources\psWireframeOIT.cso" />
     <None Include="Resources\vsBillboard.cso" />
     <None Include="Resources\vsBillboardInstancing.cso" />
-    <None Include="Resources\vsBoneSkinning.cso" />
-    <None Include="Resources\vsBoneSkinningShadow.cso" />
-    <None Include="Resources\vsBoneSkinningTessellation.cso" />
-    <None Include="Resources\vsBoneSkinningWireframe.cso" />
+    <None Include="Resources\vsBoneSkinningBasic.cso" />
     <None Include="Resources\vsCubeMap.cso" />
     <None Include="Resources\vsMeshBatched.cso" />
     <None Include="Resources\vsMeshBatchedShadow.cso" />

--- a/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.resx
+++ b/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.resx
@@ -139,9 +139,6 @@
   <data name="psMeshXRay" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psmeshxray.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsBoneSkinning" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsboneskinning.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="vsCubeMap" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\vscubemap.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
@@ -193,9 +190,6 @@
   <data name="vsBillboardInstancing" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\vsbillboardinstancing.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsBoneSkinningTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsboneskinningtessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="csParticleInsert" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\csparticleinsert.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
@@ -223,9 +217,6 @@
   <data name="psShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsBoneSkinningShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsboneskinningshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="vsMeshShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\vsmeshshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
@@ -249,9 +240,6 @@
   </data>
   <data name="vsMeshWireframe" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\vsmeshwireframe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsBoneSkinningWireframe" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsboneskinningwireframe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="psDepthStencilOnly" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psdepthstencilonly.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -345,5 +333,11 @@
   </data>
   <data name="vsMeshBatchedShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\vsmeshbatchedshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="gsMeshSkinnedOut" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gsmeshskinnedout.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsBoneSkinningBasic" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsboneskinningbasic.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
Use geometry stream output to implement pre-compute bone skinned vertices.
Obsolete old bone skinned vertex shaders.
Move BoneId list into new BoneSkinnedGeometry3D.
Remove separate bone skin technique. Use common pre-compute skinned pass.