### PR TITLE
Issue  #870

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/ImportExport/StudioReader.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/ImportExport/StudioReader.cs
@@ -554,7 +554,7 @@ namespace HelixToolkit.UWP
             {
                 float x = reader.ReadSingle();
                 float y = reader.ReadSingle();
-                pts.Add(new Vector2(x, y));
+                pts.Add(new Vector2(x,1- y));
             }
             return pts;
         }


### PR DESCRIPTION
Reading Texturecoordinates was ported wrong from Helixtoolkit.WPF to Sharp.DX