### PR TITLE
Bug fix. Must return false for EmptyBufferModel.AttachBuffers

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/EmptyBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/EmptyBufferModel.cs
@@ -111,7 +111,7 @@ namespace HelixToolkit.UWP.Core
         /// <returns></returns>
         public bool AttachBuffers(DeviceContextProxy context, ref int vertexBufferStartSlot, IDeviceResources deviceResources)
         {
-            return true;
+            return false;
         }
         /// <summary>
         /// Attaches the render host.


### PR DESCRIPTION
Bug fix. Must return false for EmptyBufferModel.AttachBuffers