### PR TITLE
Make Viewport3DX.OnRender event work after OnApplyTemplate.

### DIFF
--- a/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10048/MyLineGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10048/MyLineGeometryModel3D.cs
@@ -6,13 +6,16 @@
 
 namespace Workitem10048
 {
+    using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Windows;
     using System.Windows.Forms;
 
     using HelixToolkit.Wpf.SharpDX;
     using SharpDX;
     using System.Windows.Media;
+    using HelixToolkit.Wpf.SharpDX.Model.Scene;
     using Color = System.Windows.Media.Color;
     using HitTestResult = HelixToolkit.Wpf.SharpDX.HitTestResult;
 
@@ -36,6 +39,43 @@ namespace Workitem10048
             }
 
             return result;
+        }
+
+        protected override SceneNode OnCreateSceneNode()
+        {
+            var sn = base.OnCreateSceneNode();
+            sn.OnAttached += this.OnSceneNodeOnAttached;
+            return sn;
+        }
+
+        private void OnSceneNodeOnAttached(object sender, EventArgs e)
+        {
+            var sn = this.SceneNode;
+            if (sn?.RenderHost?.Viewport is Viewport3DX vp)
+            {
+                vp.OnRendered += this.OnViewportOnRendered;
+                vp.CameraChanged += this.OnViewportCameraChanged;
+            }
+        }
+
+        private void OnViewportCameraChanged(object sender, RoutedEventArgs e)
+        {
+            Debug.WriteLine("Viewport3DX.CameraChanged works!");
+            var sn = this.SceneNode;
+            if (sn?.RenderHost?.Viewport is Viewport3DX vp)
+            {
+                vp.CameraChanged -= this.OnViewportCameraChanged;
+            }                        
+        }
+
+        private void OnViewportOnRendered(object sender, EventArgs e)
+        {
+            Debug.WriteLine("Viewport3DX.OnRendered works!");
+            var sn = this.SceneNode;
+            if (sn?.RenderHost?.Viewport is Viewport3DX vp)
+            {
+                vp.OnRendered -= this.OnViewportOnRendered;
+            }            
         }
 
         //// alternative way, 3.36 times faster, but wrong PointHit

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -625,12 +625,17 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 hostPresenter.Content = new DPFCanvas(EnableDeferredRendering);
             }
+
+            if (this.renderHostInternal != null)
+            {
+                this.renderHostInternal.OnRendered -= this.OnRenderHostInternalOnRendered;
+                this.renderHostInternal.ExceptionOccurred -= this.HandleRenderException;
+            }
+
             renderHostInternal = (hostPresenter.Content as IRenderCanvas).RenderHost;
             if (this.renderHostInternal != null)
             {
-                this.renderHostInternal.OnRendered -= this.OnRendered;
-                this.renderHostInternal.OnRendered += this.OnRendered;
-                this.renderHostInternal.ExceptionOccurred -= this.HandleRenderException;
+                this.renderHostInternal.OnRendered += this.OnRenderHostInternalOnRendered;
                 this.renderHostInternal.ExceptionOccurred += this.HandleRenderException;
                 this.renderHostInternal.ClearColor = BackgroundColor.ToColor4();
                 this.renderHostInternal.IsShadowMapEnabled = IsShadowMappingEnabled;
@@ -1735,6 +1740,12 @@ namespace HelixToolkit.Wpf.SharpDX
                     this.RaiseEvent(new MouseUp3DEventArgs(this, null, pt, this));
                 }
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void OnRenderHostInternalOnRendered(object sender, EventArgs e)
+        {
+            this.OnRendered?.Invoke(sender, e);
         }
 
         public static T FindVisualAncestor<T>(DependencyObject obj) where T : DependencyObject


### PR DESCRIPTION
There's a bug that prevents Viewport3DX.OnRender to work for handlers that are subscribed after OnApplyTemplate. This pull request demonstrates and fixes the issue.