### PR TITLE
Bugfix: meshSizeU was being used for MeshSizeV

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/ParametricSurface3DNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/ParametricSurface3DNode.cs
@@ -42,7 +42,7 @@ namespace HelixToolkit.Wpf.SharpDX.Model.Scene
                     TessellateAsync();
                 }
             }
-            get => meshSizeU;
+            get => meshSizeV;
         }
 
         private bool isTessellating = false;


### PR DESCRIPTION
In ParametricSurface3DNode.cs the backing field meshSizeU was being used for the getter in both MeshSizeU and MeshSizeV properties. This has been fixed so MeshSizeV now uses the meshSizeV in the getter.