### PR TITLE
Supports unlit property for DiffuseMaterial

### DIFF
--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psDiffuseMap.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psDiffuseMap.hlsl
@@ -14,6 +14,10 @@ float4 main(PSInput input) : SV_Target
     {
 		c *= texDiffuseMap.Sample(samplerSurface, input.t);
     }
+    if (bHasNormalMap)
+    {
+        return c;
+    }
     float3 dir = normalize(vEyePos - input.wp.xyz);
     float f = clamp(0.5 + 0.5 * abs(dot(dir, normalize(input.n))), 0, 1);
     c.rgb *= f;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/DiffuseMaterialCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/DiffuseMaterialCore.cs
@@ -2,21 +2,100 @@
 The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
+using SharpDX;
+using SharpDX.Direct3D11;
+using System.IO;
 #if !NETFX_CORE
 namespace HelixToolkit.Wpf.SharpDX.Model
 #else
 namespace HelixToolkit.UWP.Model
 #endif
 {
-    public sealed class DiffuseMaterialCore : PhongMaterialCore
+    using Shaders;
+    public class DiffuseMaterialCore : MaterialCore
     {
+        private Color4 diffuseColor = Color.White;
+        /// <summary>
+        /// Gets or sets the color of the diffuse.
+        /// </summary>
+        /// <value>
+        /// The color of the diffuse.
+        /// </value>
+        public Color4 DiffuseColor
+        {
+            set { Set(ref diffuseColor, value); }
+            get { return diffuseColor; }
+        }
+        private Stream diffuseMap;
+        /// <summary>
+        /// Gets or sets the diffuse map.
+        /// </summary>
+        /// <value>
+        /// The diffuse map.
+        /// </value>
+        public Stream DiffuseMap
+        {
+            set { Set(ref diffuseMap, value); }
+            get { return diffuseMap; }
+        }
+        private Matrix uvTransform = Matrix.Identity;
+        /// <summary>
+        /// Gets or sets the uv transform.
+        /// </summary>
+        /// <value>
+        /// The uv transform.
+        /// </value>
+        public Matrix UVTransform
+        {
+            set { Set(ref uvTransform, value); }
+            get { return uvTransform; }
+        }
+        private SamplerStateDescription diffuseMapSampler = DefaultSamplers.LinearSamplerWrapAni4;
+        /// <summary>
+        /// Gets or sets the DiffuseMapSampler.
+        /// </summary>
+        /// <value>
+        /// DiffuseMapSampler
+        /// </value>
+        public SamplerStateDescription DiffuseMapSampler
+        {
+            set { Set(ref diffuseMapSampler, value); }
+            get { return diffuseMapSampler; }
+        }
+
+        private bool renderDiffuseMap = true;
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool RenderDiffuseMap
+        {
+            set
+            {
+                Set(ref renderDiffuseMap, value);
+            }
+            get { return renderDiffuseMap; }
+        }
+
+        private bool enableUnLit = false;
+        /// <summary>
+        /// Gets or sets a value indicating whether disable lighting. Directly render diffuse color and diffuse map
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable un lit]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableUnLit
+        {
+            set { Set(ref enableUnLit, value); }
+            get { return enableUnLit; }
+        }
+
         public override MaterialVariable CreateMaterialVariables(IEffectsManager manager, IRenderTechnique technique)
         {
             return new DiffuseMaterialVariables(DefaultPassNames.Diffuse, manager, technique, this);
         }
     }
 
-    public sealed class ViewCubeMaterialCore : PhongMaterialCore
+    public sealed class ViewCubeMaterialCore : DiffuseMaterialCore
     {
         public override MaterialVariable CreateMaterialVariables(IEffectsManager manager, IRenderTechnique technique)
         {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/DiffuseMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/DiffuseMaterialVariable.cs
@@ -61,7 +61,7 @@ namespace HelixToolkit.UWP.Model
         /// </summary>
         public string SamplerShadowMapName {  get; } = DefaultSamplerStateNames.ShadowMapSampler;
 
-        private readonly PhongMaterialCore material;
+        private readonly DiffuseMaterialCore material;
         /// <summary>
         /// Initializes a new instance of the <see cref="DiffuseMaterialVariables"/> class.
         /// </summary>
@@ -73,7 +73,7 @@ namespace HelixToolkit.UWP.Model
         /// <param name="materialOITPassName">Name of the material oit pass.</param>
         /// <param name="wireframeOITPassName">Name of the wireframe oit pass.</param>
         /// <param name="shadowPassName">Name of the shadow pass.</param>
-        private DiffuseMaterialVariables(IEffectsManager manager, IRenderTechnique technique, PhongMaterialCore materialCore,
+        private DiffuseMaterialVariables(IEffectsManager manager, IRenderTechnique technique, DiffuseMaterialCore materialCore,
             string materialPassName = DefaultPassNames.Default, string wireframePassName = DefaultPassNames.Wireframe,
             string materialOITPassName = DefaultPassNames.OITPass, string wireframeOITPassName = DefaultPassNames.OITPass,
             string shadowPassName = DefaultPassNames.ShadowPass)
@@ -94,13 +94,14 @@ namespace HelixToolkit.UWP.Model
             CreateSamplers();
         }
         /// <summary>
-        /// Initializes a new instance of the <see cref="PhongMaterialVariables"/> class. This construct will be using the PassName pass into constructor only.
+        /// Initializes a new instance of the <see cref="DiffuseMaterialVariables"/> class. This construct will be using the PassName pass into constructor only.
         /// </summary>
         /// <param name="passName">Name of the pass.</param>
         /// <param name="manager">The manager.</param>
         /// <param name="technique"></param>
         /// <param name="material">The material.</param>
-        public DiffuseMaterialVariables(string passName, IEffectsManager manager, IRenderTechnique technique, PhongMaterialCore material)
+        public DiffuseMaterialVariables(string passName, IEffectsManager manager, IRenderTechnique technique, 
+            DiffuseMaterialCore material)
             : this(manager, technique, material)
         {
             MaterialPass = technique[passName];
@@ -109,22 +110,25 @@ namespace HelixToolkit.UWP.Model
         protected override void OnInitialPropertyBindings()
         {
             base.OnInitialPropertyBindings();
-            AddPropertyBinding(nameof(PhongMaterialCore.DiffuseColor), () => { WriteValue(PhongPBRMaterialStruct.DiffuseStr, material.DiffuseColor); });
-            AddPropertyBinding(nameof(PhongMaterialCore.UVTransform), () => 
+            AddPropertyBinding(nameof(DiffuseMaterialCore.DiffuseColor), () => 
+            { WriteValue(PhongPBRMaterialStruct.DiffuseStr, material.DiffuseColor); });
+            AddPropertyBinding(nameof(DiffuseMaterialCore.UVTransform), () => 
             {
                 WriteValue(PhongPBRMaterialStruct.UVTransformR1Str, material.UVTransform.Column1);
                 WriteValue(PhongPBRMaterialStruct.UVTransformR2Str, material.UVTransform.Column2);
             });
-            AddPropertyBinding(nameof(PhongMaterialCore.DiffuseMap), () =>
+            AddPropertyBinding(nameof(DiffuseMaterialCore.DiffuseMap), () =>
             {
                 CreateTextureView(material.DiffuseMap, DiffuseIdx);
                 WriteValue(PhongPBRMaterialStruct.HasDiffuseMapStr, material.RenderDiffuseMap && TextureResource != null ? 1 : 0);
             });
-            AddPropertyBinding(nameof(PhongMaterialCore.DiffuseMapSampler), () =>
+            AddPropertyBinding(nameof(DiffuseMaterialCore.DiffuseMapSampler), () =>
             {
                 RemoveAndDispose(ref SamplerResource);
                 SamplerResource = Collect(statePoolManager.Register(material.DiffuseMapSampler));
             });
+            AddPropertyBinding(nameof(DiffuseMaterialCore.EnableUnLit), () => 
+            { WriteValue(PhongPBRMaterialStruct.HasNormalMapStr, material.EnableUnLit); });
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Source/HelixToolkit.SharpDX.SharedModel/Material/DiffuseMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Material/DiffuseMaterial.cs
@@ -128,7 +128,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 DiffuseColor = DiffuseColor,
                 DiffuseMap = DiffuseMap,
                 UVTransform = UVTransform,
-                DiffuseMapSampler = DiffuseMapSampler
+                DiffuseMapSampler = DiffuseMapSampler,
+                EnableUnLit = EnableUnLit,
             };
         }
 
@@ -141,7 +142,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 DiffuseMap = DiffuseMap,
                 DiffuseMapSampler = DiffuseMapSampler,
                 UVTransform = UVTransform,
-                Name = Name
+                Name = Name,
+                EnableUnLit = EnableUnLit,
             };
         }
 #endif

--- a/Source/HelixToolkit.SharpDX.SharedModel/Material/DiffuseMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Material/DiffuseMaterial.cs
@@ -13,9 +13,9 @@ using System.Windows;
 namespace HelixToolkit.Wpf.SharpDX
 #endif
 {
-    using System.ComponentModel;
     using Model;
     using Shaders;
+    using System.ComponentModel;
     using Utilities;
 
 
@@ -28,7 +28,7 @@ namespace HelixToolkit.Wpf.SharpDX
             DependencyProperty.Register("DiffuseColor", typeof(Color4), typeof(DiffuseMaterial), new PropertyMetadata((Color4)Color.White,
                 (d, e) =>
                 {
-                    ((d as Material).Core as PhongMaterialCore).DiffuseColor = (Color4)e.NewValue;
+                    ((d as Material).Core as DiffuseMaterialCore).DiffuseColor = (Color4)e.NewValue;
                 }));
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public static readonly DependencyProperty DiffuseMapProperty =
             DependencyProperty.Register("DiffuseMap", typeof(Stream), typeof(DiffuseMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PhongMaterialCore).DiffuseMap = e.NewValue as Stream; }));
+                (d, e) => { ((d as Material).Core as DiffuseMaterialCore).DiffuseMap = e.NewValue as Stream; }));
 
         /// <summary>
         /// Gets or sets the diffuse map.
@@ -68,7 +68,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public static readonly DependencyProperty DiffuseMapSamplerProperty =
             DependencyProperty.Register("DiffuseMapSampler", typeof(SamplerStateDescription), typeof(DiffuseMaterial), new PropertyMetadata(DefaultSamplers.LinearSamplerWrapAni4,
-                (d, e) => { ((d as Material).Core as PhongMaterialCore).DiffuseMapSampler = (SamplerStateDescription)e.NewValue; }));
+                (d, e) => { ((d as Material).Core as DiffuseMaterialCore).DiffuseMapSampler = (SamplerStateDescription)e.NewValue; }));
         /// <summary>
         /// 
         /// </summary>
@@ -83,7 +83,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty UVTransformProperty =
             DependencyProperty.Register("UVTransform", typeof(Matrix), typeof(DiffuseMaterial), new PropertyMetadata(Matrix.Identity, (d, e) =>
             {
-                ((d as Material).Core as PhongMaterialCore).UVTransform = (Matrix)e.NewValue;
+                ((d as Material).Core as DiffuseMaterialCore).UVTransform = (Matrix)e.NewValue;
             }));
         /// <summary>
         /// Gets or sets the texture uv transform.
@@ -96,6 +96,30 @@ namespace HelixToolkit.Wpf.SharpDX
             get { return (Matrix)GetValue(UVTransformProperty); }
             set { SetValue(UVTransformProperty, value); }
         }
+
+
+        /// <summary>
+        /// Gets or sets a value indicating whether whether disable lighting. Directly render diffuse color and diffuse map.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable un lit]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableUnLit
+        {
+            get { return (bool)GetValue(EnableUnLitProperty); }
+            set { SetValue(EnableUnLitProperty, value); }
+        }
+
+        /// <summary>
+        /// The enable un lit property
+        /// </summary>
+        public static readonly DependencyProperty EnableUnLitProperty =
+            DependencyProperty.Register("EnableUnLit", typeof(bool), typeof(DiffuseMaterial), new PropertyMetadata(false,
+                (d,e)=> 
+                {
+                    ((d as Material).Core as DiffuseMaterialCore).EnableUnLit = (bool)e.NewValue;
+                }));
+
 
         protected override MaterialCore OnCreateCore()
         {


### PR DESCRIPTION
Supports unlit property for DiffuseMaterial. Ref  #824
Enable unlit if only wants to render diffuse color or diffuse map without any lighting.