### PR TITLE
Bug fix

### DIFF
--- a/Source/HelixToolkit.SharpDX.SharedModel/Element2D/Element2DCore.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element2D/Element2DCore.cs
@@ -80,7 +80,28 @@ namespace HelixToolkit.Wpf.SharpDX.Core2D
 
         private void SceneNode_OnDetached(object sender, EventArgs e)
         {
-            OnDetached();
+#if NETFX_CORE
+            if(Dispatcher != null)
+            {
+                if (Dispatcher.HasThreadAccess)
+                {
+                    OnDetached();
+                }
+            }
+
+#else
+            if(this.Dispatcher != null && this.Dispatcher.Thread.IsAlive)
+            {
+                if (this.Dispatcher.CheckAccess())
+                {
+                    OnDetached();
+                }
+                else
+                {
+                    Dispatcher.Invoke(() => { OnDetached(); });
+                }
+            }
+#endif
         }
 
         private void SceneNode_OnAttached(object sender, EventArgs e)


### PR DESCRIPTION
Fix memory leak, surface D3D not properly dispose. Side-effect from fixing #963 Device Reset/Lost.
Fix #973. Check thread access before calling OnDetached in Element2DCore