### PR TITLE
Add SceneNodeGroupModel3D to support directly using SceneNodes

### DIFF
--- a/Source/Examples/WPF.SharpDX/Viewport3DXCodeBehindTester/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/Viewport3DXCodeBehindTester/MainWindow.xaml
@@ -48,6 +48,9 @@
                 IsEnabled="{Binding EnableEnvironmentButtons}">
                 Add Environment
             </Button>
+            <Button x:Name="buttonSceneNode" IsEnabled="{Binding EnableButtons}" Margin="4" Click="buttonSceneNode_Click">
+                Add SceneNode
+            </Button>
         </StackPanel>
     </Grid>
 </Window>

--- a/Source/Examples/WPF.SharpDX/Viewport3DXCodeBehindTester/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/Viewport3DXCodeBehindTester/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using DemoCore;
 using HelixToolkit.Wpf.SharpDX;
+using HelixToolkit.Wpf.SharpDX.Model.Scene;
 using SharpDX;
 using System;
 using System.Collections.Generic;
@@ -29,6 +30,7 @@ namespace Viewport3DXCodeBehindTester
         private Viewport3DX viewport;
         private Models models = new Models();
         private ViewModel viewmodel = new ViewModel();
+        private SceneNodeGroupModel3D sceneNodeGroup = new SceneNodeGroupModel3D();
 
         public MainWindow()
         {
@@ -64,10 +66,20 @@ namespace Viewport3DXCodeBehindTester
             viewport.EffectsManager = manager;
             viewport.Items.Add(new DirectionalLight3D() { Direction = new System.Windows.Media.Media3D.Vector3D(-1, -1, -1) });
             viewport.Items.Add(new AmbientLight3D() { Color = Color.FromArgb(255, 50, 50, 50) });
+            viewport.Items.Add(sceneNodeGroup);
+            viewport.MouseDown3D += Viewport_MouseDown3D;
             Grid.SetColumn(viewport, 0);
             mainGrid.Children.Add(viewport);
             buttonInit.IsEnabled = false;
             viewmodel.EnableButtons = true;
+        }
+
+        private void Viewport_MouseDown3D(object sender, RoutedEventArgs e)
+        {
+            if(e is MouseDown3DEventArgs args && args.HitTestResult != null)
+            {
+                var model = args.HitTestResult.ModelHit;
+            }
         }
 
         private void buttonEnvironment_Click(object sender, RoutedEventArgs e)
@@ -76,6 +88,11 @@ namespace Viewport3DXCodeBehindTester
             var environment = new EnvironmentMap3D() { Texture = texture };
             viewport.Items.Add(environment);
             viewmodel.EnableEnvironmentButtons = false;
+        }
+
+        private void buttonSceneNode_Click(object sender, RoutedEventArgs e)
+        {
+            sceneNodeGroup.AddNode(models.GetSceneNodeRandom());
         }
     }
 
@@ -135,6 +152,22 @@ namespace Viewport3DXCodeBehindTester
             group.Children.Add(scale);
             group.Children.Add(translate);
             model.Transform = group;
+            var material = materials[rnd.Next(0, materials.Count - 1)];
+            model.Material = material;
+            if (material.DiffuseColor.Alpha < 1)
+            {
+                model.IsTransparent = true;
+            }
+            return model;
+        }
+
+        public MeshNode GetSceneNodeRandom()
+        {
+            var idx = rnd.Next(0, models.Count);
+            MeshNode model = new MeshNode() { Geometry = models[idx], CullMode = SharpDX.Direct3D11.CullMode.Back };
+            var scale = SharpDX.Matrix.Scaling((float)rnd.NextDouble(1, 5), (float)rnd.NextDouble(1, 5), (float)rnd.NextDouble(1, 5));
+            var translate = SharpDX.Matrix.Translation((float)rnd.NextDouble(-20, 20), (float)rnd.NextDouble(-20, 20), (float)rnd.NextDouble(-20, 20));
+            model.ModelMatrix = scale * translate;
             var material = materials[rnd.Next(0, materials.Count - 1)];
             model.Material = material;
             if (material.DiffuseColor.Alpha < 1)

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/SceneNodeGroupModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/SceneNodeGroupModel3D.cs
@@ -1,0 +1,35 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+#if NETFX_CORE
+namespace HelixToolkit.UWP
+#else
+namespace HelixToolkit.Wpf.SharpDX
+#endif
+{
+    using Model.Scene;
+    /// <summary>
+    /// Used to hold scene nodes without WPF/UWP dependencies.
+    /// Used for code behind only. Avoid performance penalty from Dependency Properties.
+    /// </summary>
+    public class SceneNodeGroupModel3D : Element3D
+    {
+        public GroupNode GroupNode { get; } = new GroupNode();
+
+        public void AddNode(SceneNode node)
+        {
+            GroupNode.AddChildNode(node);
+        }
+
+        public void RemoveNode(SceneNode node)
+        {
+            GroupNode.RemoveChildNode(node);
+        }
+
+        protected override SceneNode OnCreateSceneNode()
+        {
+            return GroupNode;
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.SharedModel/HelixToolkit.SharpDX.SharedModel.projitems
+++ b/Source/HelixToolkit.SharpDX.SharedModel/HelixToolkit.SharpDX.SharedModel.projitems
@@ -46,6 +46,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\PostEffects\PostEffectMeshOutlineBlur.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\PostEffects\PostEffectMeshXRay.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\PostEffects\PostEffectMeshXRayGrid.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Element3D\SceneNodeGroupModel3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\ScreenQuadModel3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\ScreenSpacedGroup3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\TransformManipulator3D.cs" />

--- a/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
@@ -563,9 +563,9 @@ namespace HelixToolkit.UWP
             if (hits.Count > 0)
             {
                 this.currentHit = hits.FirstOrDefault(x => x.IsValid);
-                if (this.currentHit != null)
+                if (this.currentHit != null && currentHit.ModelHit is Element3D ele)
                 {
-                    (this.currentHit.ModelHit as Element3D)?.RaiseMouseDownEvent(this.currentHit, pt, this);
+                    ele.RaiseMouseDownEvent(this.currentHit, pt, this);
                 }
             }
             else
@@ -587,9 +587,9 @@ namespace HelixToolkit.UWP
             {
                 return;
             }
-            if (this.currentHit != null)
+            if (this.currentHit != null && currentHit.ModelHit is Element3D ele)
             {
-                (this.currentHit.ModelHit as Element3D)?.RaiseMouseMoveEvent(this.currentHit, pt, this);
+                ele.RaiseMouseMoveEvent(this.currentHit, pt, this);
             }
             this.OnMouse3DMove?.Invoke(this, new MouseMove3DEventArgs(currentHit, pt, this));
         }
@@ -606,9 +606,9 @@ namespace HelixToolkit.UWP
             {
                 return;
             }
-            if (currentHit != null)
+            if (currentHit != null && currentHit.ModelHit is Element3D ele)
             {
-                (this.currentHit.ModelHit as Element3D)?.RaiseMouseUpEvent(this.currentHit, pt, this);               
+                ele.RaiseMouseUpEvent(this.currentHit, pt, this);               
                 currentHit = null;
             }
             this.OnMouse3DUp?.Invoke(this, new MouseUp3DEventArgs(currentHit, pt, this));

--- a/Source/HelixToolkit.Wpf.SharpDX.sln
+++ b/Source/HelixToolkit.Wpf.SharpDX.sln
@@ -99,6 +99,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BatchedMeshDemo", "Examples
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BillboardDemo", "Examples\WPF.SharpDX\BillboardDemo\BillboardDemo.csproj", "{D4DBF05A-A7D3-42AF-8447-2F1BEACB9C7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VolumeRendering", "Examples\WPF.SharpDX\VolumeRendering\VolumeRendering.csproj", "{FE982A9C-8416-40B7-9973-012D6B3E022E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		HelixToolkit.SharpDX.SharedModel\HelixToolkit.SharpDX.SharedModel.projitems*{1aefcb64-e997-425a-8c84-dc93263cc4a7}*SharedItemsImports = 13
@@ -575,6 +577,18 @@ Global
 		{D4DBF05A-A7D3-42AF-8447-2F1BEACB9C7D}.Release|x64.Build.0 = Release|Any CPU
 		{D4DBF05A-A7D3-42AF-8447-2F1BEACB9C7D}.Release|x86.ActiveCfg = Release|Any CPU
 		{D4DBF05A-A7D3-42AF-8447-2F1BEACB9C7D}.Release|x86.Build.0 = Release|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Debug|x64.Build.0 = Debug|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Debug|x86.Build.0 = Debug|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Release|x64.ActiveCfg = Release|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Release|x64.Build.0 = Release|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Release|x86.ActiveCfg = Release|Any CPU
+		{FE982A9C-8416-40B7-9973-012D6B3E022E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -616,6 +630,7 @@ Global
 		{6BAA6F89-637A-49EB-A554-76AB527A5968} = {93A5184E-0275-4A75-9C9A-9516AE9634DD}
 		{7AAEFD49-24D2-402D-9BB6-C3445DE8C059} = {93A5184E-0275-4A75-9C9A-9516AE9634DD}
 		{D4DBF05A-A7D3-42AF-8447-2F1BEACB9C7D} = {93A5184E-0275-4A75-9C9A-9516AE9634DD}
+		{FE982A9C-8416-40B7-9973-012D6B3E022E} = {93A5184E-0275-4A75-9C9A-9516AE9634DD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {67B0DD22-D5CF-4D97-9E28-F8B59C583F78}

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -1645,8 +1645,14 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.currentHit = hits.FirstOrDefault(x => x.IsValid);
                 if (this.currentHit != null)
                 {
-                    (this.currentHit.ModelHit as Element3D)?.RaiseEvent(
-                        new MouseDown3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    if(currentHit.ModelHit is Element3D ele)
+                    {
+                        ele.RaiseEvent(new MouseDown3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    }
+                    else
+                    {
+                        RaiseEvent(new MouseDown3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    }
                 }
             }
             else
@@ -1699,8 +1705,14 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 if (this.currentHit != null)
                 {
-                    (this.currentHit.ModelHit as Element3D)?.RaiseEvent(
-                        new MouseMove3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    if (currentHit.ModelHit is Element3D ele)
+                    {
+                        ele.RaiseEvent(new MouseMove3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    }
+                    else
+                    {
+                        RaiseEvent(new MouseMove3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    }
                 }
                 else
                 {
@@ -1731,8 +1743,15 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 if (this.currentHit != null)
                 {               
-                    (this.currentHit.ModelHit as Element3D)?.RaiseEvent(
-                        new MouseUp3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    if(currentHit.ModelHit is Element3D ele)
+                    {
+                        ele.RaiseEvent(new MouseUp3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    }
+                    else
+                    {
+                        RaiseEvent(new MouseUp3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                    }
+
                     this.currentHit = null;
                     Mouse.Capture(this, CaptureMode.None);
                 }


### PR DESCRIPTION
Add SceneNodeGroupModel3D to support directly using SceneNode from code behind without XAML supports.