### PR TITLE
Fix #998

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/EffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/EffectsManager.cs
@@ -267,6 +267,10 @@ namespace HelixToolkit.UWP
             Log(LogLevel.Information, $"Adapter Index = {adapterIndex}");
             var adapter = GetAdapter(ref adapterIndex);
             AdapterIndex = adapterIndex;
+            if(AdapterIndex < 0 || adapter == null)
+            {
+                throw new PlatformNotSupportedException("Graphic adapter does not meet minimum requirement, must support DirectX 10 or above.");
+            }
 #if DX11
             if (adapter != null)
             {
@@ -469,7 +473,7 @@ namespace HelixToolkit.UWP
         {
             using (var f = new Factory1())
             {
-                if (f.Adapters.Length <= index)
+                if (f.Adapters.Length <= index || index < 0)
                 {
                     return GetBestAdapter(out index);
                 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DX11ImageSourceRenderHost.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DX11ImageSourceRenderHost.cs
@@ -112,7 +112,7 @@ namespace HelixToolkit.Wpf.SharpDX.Controls
                 frontBufferChange = true;
                 if (EffectsManager.Device.DeviceRemovedReason.Success)
                 {
-                    StopRendering();
+                    //StopRendering();
                 }
                 else
                 {


### PR DESCRIPTION
1. Fix Make DPFCanvas work over Remote Desktop again #998. Does not need to stop rendering if fall back to software rendering.
2. Throw proper exception if graphic card does not support minimum requirement. Avoid index out of bound exception.