### PR TITLE
Prevent exception when AdornerLayer is null

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -490,6 +490,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
 
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(visual);
+            if (myAdornerLayer == null) { return; }
             if (this.targetAdorner != null)
             {
                 myAdornerLayer.Remove(this.targetAdorner);
@@ -511,6 +512,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
 
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(visual);
+            if (myAdornerLayer == null) { return; }
             if (this.rectangleAdorner != null)
             {
                 myAdornerLayer.Remove(this.rectangleAdorner);
@@ -817,6 +819,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
 
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(visual);
+            if (myAdornerLayer == null) { return; }
             this.targetAdorner = new TargetSymbolAdorner(visual, position);
             myAdornerLayer.Add(this.targetAdorner);
         }
@@ -839,6 +842,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
 
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(visual);
+            if (myAdornerLayer == null) { return; }
             this.rectangleAdorner = new RectangleAdorner(
                 visual, rect, Colors.LightGray, Colors.Black, 3, 1, 10, DashStyles.Solid);
             myAdornerLayer.Add(this.rectangleAdorner);

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
@@ -1487,6 +1487,7 @@ namespace HelixToolkit.Wpf
         public void HideRectangle()
         {
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(this.Viewport);
+            if (myAdornerLayer == null) { return; }
             if (this.rectangleAdorner != null)
             {
                 myAdornerLayer.Remove(this.rectangleAdorner);
@@ -1503,6 +1504,7 @@ namespace HelixToolkit.Wpf
         public void HideTargetAdorner()
         {
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(this.Viewport);
+            if (myAdornerLayer == null) { return; }
             if (this.targetAdorner != null)
             {
                 myAdornerLayer.Remove(this.targetAdorner);
@@ -1614,6 +1616,7 @@ namespace HelixToolkit.Wpf
             }
 
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(this.Viewport);
+            if (myAdornerLayer == null) { return; }
             this.rectangleAdorner = new RectangleAdorner(
                 this.Viewport, rect, color1, color2, 3, 1, 10, DashStyles.Solid);
             myAdornerLayer.Add(this.rectangleAdorner);
@@ -1638,6 +1641,7 @@ namespace HelixToolkit.Wpf
             }
 
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(this.Viewport);
+            if (myAdornerLayer == null) { return; }
             this.targetAdorner = new TargetSymbolAdorner(this.Viewport, position);
             myAdornerLayer.Add(this.targetAdorner);
         }

--- a/Source/HelixToolkit.Wpf/SelectionCommands/RectangleSelectionCommand.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/RectangleSelectionCommand.cs
@@ -130,6 +130,7 @@ namespace HelixToolkit.Wpf
         private void HideRectangle()
         {
             var myAdornerLayer = AdornerLayer.GetAdornerLayer(this.Viewport);
+            if (myAdornerLayer == null) { return; }
             if (this.rectangleAdorner != null)
             {
                 myAdornerLayer.Remove(this.rectangleAdorner);
@@ -165,6 +166,7 @@ namespace HelixToolkit.Wpf
             }
 
             var adornerLayer = AdornerLayer.GetAdornerLayer(this.Viewport);
+            if (adornerLayer == null) { return; }
             this.rectangleAdorner = new RectangleAdorner(this.Viewport, this.selectionRect, Colors.LightGray, Colors.Black, 1, 1, 0, DashStyles.Dash);
             adornerLayer.Add(this.rectangleAdorner);
         }


### PR DESCRIPTION
I want to resolve #283 with this pull request.

An exception was thrown when the AdornerLayer was null. This is now caught by checking the AdornerLayer and returning early in case of null.
