### PR TITLE
Fix #1013. Improve SSAO

### DIFF
--- a/Source/Examples/WPF.SharpDX/Viewport3DXCodeBehindTester/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/Viewport3DXCodeBehindTester/MainWindow.xaml
@@ -23,6 +23,9 @@
                 Click="Button_Click_Initialize">
                 Initialize Viewport
             </Button>
+            <Button x:Name="buttonRemoveViewport" Click="ButtonRemove_Click">
+                Remove Viewport
+            </Button>
             <Button
                 x:Name="buttonAdd"
                 Margin="4"

--- a/Source/Examples/WPF.SharpDX/Viewport3DXCodeBehindTester/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/Viewport3DXCodeBehindTester/MainWindow.xaml.cs
@@ -30,13 +30,14 @@ namespace Viewport3DXCodeBehindTester
         private Viewport3DX viewport;
         private Models models = new Models();
         private ViewModel viewmodel = new ViewModel();
-        private SceneNodeGroupModel3D sceneNodeGroup = new SceneNodeGroupModel3D();
+        private SceneNodeGroupModel3D sceneNodeGroup;
 
         public MainWindow()
         {
             InitializeComponent();
             manager = new DefaultEffectsManager();
             DataContext = viewmodel;
+            buttonRemoveViewport.IsEnabled = false;
         }
 
         private void Button_Click_Add(object sender, RoutedEventArgs e)
@@ -66,11 +67,13 @@ namespace Viewport3DXCodeBehindTester
             viewport.EffectsManager = manager;
             viewport.Items.Add(new DirectionalLight3D() { Direction = new System.Windows.Media.Media3D.Vector3D(-1, -1, -1) });
             viewport.Items.Add(new AmbientLight3D() { Color = Color.FromArgb(255, 50, 50, 50) });
+            sceneNodeGroup = new SceneNodeGroupModel3D();
             viewport.Items.Add(sceneNodeGroup);
             viewport.MouseDown3D += Viewport_MouseDown3D;
             Grid.SetColumn(viewport, 0);
             mainGrid.Children.Add(viewport);
             buttonInit.IsEnabled = false;
+            buttonRemoveViewport.IsEnabled = true;
             viewmodel.EnableButtons = true;
         }
 
@@ -93,6 +96,13 @@ namespace Viewport3DXCodeBehindTester
         private void buttonSceneNode_Click(object sender, RoutedEventArgs e)
         {
             sceneNodeGroup.AddNode(models.GetSceneNodeRandom());
+        }
+
+        private void ButtonRemove_Click(object sender, RoutedEventArgs e)
+        {
+            mainGrid.Children.Remove(viewport);
+            buttonInit.IsEnabled = true;
+            buttonRemoveViewport.IsEnabled = false;
         }
     }
 

--- a/Source/HelixToolkit.Native.ShaderBuilder/Common/CommonBuffers.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/Common/CommonBuffers.hlsl
@@ -274,10 +274,10 @@ static const uint SSAOKernalSize = 32;
 cbuffer cbSSAO : register(b1)
 {
     float4 kernel[SSAOKernalSize];
-    float4 frustumCorner[4];
     float2 noiseScale;
     int isPerspective;
     float radius;    
+    float4x4 invProjection;
 }
 #endif
 
@@ -303,6 +303,7 @@ Texture2D<float> texShadowMap : register(t30);
 Texture2D texSSAOMap : register(t31);
 #if defined(SSAO)
 Texture2D<float3> texSSAONoise : register(t32);
+Texture2D<float> texSSAODepth : register(t33);
 #endif
 
 Texture2D texParticle : register(t0);

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psSSAO.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psSSAO.hlsl
@@ -10,19 +10,26 @@ struct SSAOPS_INPUT
     float4 Pos : SV_POSITION;
     noperspective
     float2 Tex : TEXCOORD0;
-    float4 Corner : TEXCOORD1;
 };
+
+float3 getPos(in float2 tex, in float depth)
+{
+    float x = tex.x * 2 - 1;
+    float y = 1 - tex.y * 2;
+    float4 v = mul(float4(x, y, depth, 1), invProjection);
+    return (v / v.w).xyz;
+}
 
 float4 main(SSAOPS_INPUT input) : SV_Target
 {
     float4 value = texSSAOMap.Sample(samplerSurface, input.Tex);
     float3 normal = normalize(value.rgb);
-    float depth = value.a;
+    float depth = texSSAODepth.Sample(samplerSurface, input.Tex); 
     if (depth == 1)
     {
         return float4(1, 0, 0, 0);
     }
-    float3 position = float3(input.Corner.xy, input.Corner.z * depth) * (1 - isPerspective) + input.Corner.xyz * depth * isPerspective;
+    float3 position = getPos(input.Tex, depth); 
     
     float3 randomVec = texSSAONoise.Sample(samplerNoise, input.Tex * noiseScale);
 
@@ -32,13 +39,6 @@ float4 main(SSAOPS_INPUT input) : SV_Target
     float occlusion = 0;
     const float inv = 1.0 / SSAOKernalSize;
 
-    //float3 sample = mul(float3(0, 0, 1), TBN);
-    //sample = mad(sample, radius, position);
-    //float4 offset = float4(sample, 1);
-    //offset = mul(offset, mProjection);
-    //offset.xy /= offset.w;
-    //offset.xy = mad(offset.xy, float2(0.5, -0.5), 0.5f);
-    //return texSSAOMap.SampleLevel(samplerSurface, offset.xy, 0);
     [loop]
     for (uint i = 0; i < SSAOKernalSize; ++i)
     {
@@ -48,17 +48,18 @@ float4 main(SSAOPS_INPUT input) : SV_Target
         offset = mul(offset, mProjection);
         offset.xy /= offset.w;
         offset.xy = mad(offset.xy, float2(0.5, -0.5), 0.5f);
-        float sampleDepth = texSSAOMap.SampleLevel(samplerSurface, offset.xy, 0).a;
+        float sampleDepth = texSSAODepth.SampleLevel(samplerSurface, offset.xy, 0); 
         if (sampleDepth == 1)
         {
             continue;
         }
-        sampleDepth *= input.Corner.z;
+        sampleDepth = getPos(offset.xy, sampleDepth).z; //*= input.Corner.z;
         float rangeCheck = smoothstep(0.0, 1.0, radius / abs(position.z - sampleDepth)) * SSAOIntensity;
         //float rangeCheck = whenlt(abs(position.z - sampleDepth), radius); 
         occlusion += whenle(abs(sampleDepth), abs(sample.z - SSAOBias)) * rangeCheck;
     }
-    occlusion = 1.0 - occlusion * inv * whenge(occlusion, 5);//Filter out occlusion lower than 5. May need future improvement
+    occlusion = 1.0 - occlusion * inv * whenge(occlusion, 5);
     return float4(occlusion, 0, 0, 0);
+
 }
 #endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psSSAOP1.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psSSAOP1.hlsl
@@ -14,7 +14,6 @@ struct SSAOIn
 
 float4 main(SSAOIn input) : SV_TARGET
 {
-    float fd = -input.depth / vFrustum.w;
-    return float4(normalize(input.normal), fd);
+    return float4(normalize(input.normal), 1);
 }
 #endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/VS/vsSSAO.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/VS/vsSSAO.hlsl
@@ -18,7 +18,6 @@ struct SSAOPS_INPUT
     float4 Pos : SV_POSITION;
     noperspective
     float2 Tex : TEXCOORD0;
-    float4 Corner : TEXCOORD1;
 };
 
 SSAOPS_INPUT main(uint vI : SV_VERTEXID)
@@ -27,7 +26,6 @@ SSAOPS_INPUT main(uint vI : SV_VERTEXID)
     float2 texcoord = quadtexcoords[vI];
     output.Tex = texcoord;
     output.Pos = float4((texcoord.x - 0.5f) * 2, -(texcoord.y - 0.5f) * 2, 0, 1);
-    output.Corner = frustumCorner[vI];
     return output;
 }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SSAOCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SSAOCore.cs
@@ -184,7 +184,7 @@ namespace HelixToolkit.UWP.Core
                         continue;
                     }
                     float scale = i / 32f;
-                    scale = 0.1f + 0.9f * scale * scale;
+                    scale = 0.1f + 0.9f * scale;
                     v *= scale;
                     kernels[i] = new Vector4(v.X, v.Y, v.Z, 0);
                     break;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SSAOCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SSAOCore.cs
@@ -41,7 +41,7 @@ namespace HelixToolkit.UWP.Core
 
         private ShaderResourceViewProxy ssaoView, ssaoNoise;
         private int width, height;
-        private int ssaoTexSlot, noiseTexSlot, surfaceSampleSlot, noiseSamplerSlot;
+        private int ssaoTexSlot, noiseTexSlot, surfaceSampleSlot, noiseSamplerSlot, depthSlot;
         private ShaderPass ssaoPass, ssaoBlur;
         private SamplerStateProxy surfaceSampler, noiseSampler, blurSampler;
         private SSAOParamStruct ssaoParam;
@@ -49,7 +49,9 @@ namespace HelixToolkit.UWP.Core
         private const int KernalSize = 32;
         private readonly Vector4[] kernels = new Vector4[KernalSize];
         private readonly Vector3[] frustumCorners = new Vector3[8];
-        private readonly Vector4[] fpCorners = new Vector4[4];
+        private const global::SharpDX.DXGI.Format DEPTHFORMAT = global::SharpDX.DXGI.Format.R32_Typeless;
+        private const global::SharpDX.DXGI.Format RENDERTARGETFORMAT = global::SharpDX.DXGI.Format.R16G16B16A16_Float;
+        private const global::SharpDX.DXGI.Format SSAOTARGETFORMAT = global::SharpDX.DXGI.Format.R16_Float;
 
         public SSAOCore() : base(RenderType.PreProc)
         {
@@ -59,9 +61,9 @@ namespace HelixToolkit.UWP.Core
         public override void Render(RenderContext context, DeviceContextProxy deviceContext)
         {
             EnsureTextureResources((int)context.ActualWidth, (int)context.ActualHeight, deviceContext);
-            var ds = context.RenderHost.RenderBuffer.FullResDepthStencilPool.Get(global::SharpDX.DXGI.Format.D32_Float);
-            var rt0 = context.RenderHost.RenderBuffer.FullResRenderTargetPool.Get(global::SharpDX.DXGI.Format.R16G16B16A16_Float);
-            var rt1 = context.RenderHost.RenderBuffer.FullResRenderTargetPool.Get(global::SharpDX.DXGI.Format.R16_Float);
+            var ds = context.RenderHost.RenderBuffer.FullResDepthStencilPool.Get(DEPTHFORMAT);
+            var rt0 = context.RenderHost.RenderBuffer.FullResRenderTargetPool.Get(RENDERTARGETFORMAT);
+            var rt1 = context.RenderHost.RenderBuffer.FullResRenderTargetPool.Get(SSAOTARGETFORMAT);
             deviceContext.ClearDepthStencilView(ds, DepthStencilClearFlags.Depth, 1, 0);
             deviceContext.ClearRenderTargetView(rt0, new Color4(0, 0, 0, 1));//Set alpha channel to 1 for max depth value
             deviceContext.SetRenderTarget(ds, rt0);
@@ -82,18 +84,15 @@ namespace HelixToolkit.UWP.Core
                 }
                 node.RenderDepth(context, deviceContext, ssaoPass1);
             }
-            context.BoundingFrustum.GetCorners(frustumCorners);
-            Vector3.Transform(ref frustumCorners[5], ref context.ViewMatrix, out fpCorners[0]);
-            Vector3.Transform(ref frustumCorners[6], ref context.ViewMatrix, out fpCorners[1]);
-            Vector3.Transform(ref frustumCorners[4], ref context.ViewMatrix, out fpCorners[2]);
-            Vector3.Transform(ref frustumCorners[7], ref context.ViewMatrix, out fpCorners[3]);
+
+            var invProjection = context.ProjectionMatrix.Inverted(); //* context.ViewMatrix.PsudoInvert();
+            ssaoParam.InvProjection = invProjection;
             ssaoParam.NoiseScale = new Vector2(context.ActualWidth / 4f, context.ActualHeight / 4f);
             ssaoParam.Radius = radius;
             ssaoParam.IsPerspective = context.IsPerspective ? 1 : 0;
             ssaoCB.ModelConstBuffer.UploadDataToBuffer(deviceContext, (stream) =>
             {
                 stream.WriteRange(kernels);
-                stream.WriteRange(fpCorners);
                 stream.Write(ssaoParam);
             });
             deviceContext.SetRenderTarget(null, rt1);
@@ -101,9 +100,12 @@ namespace HelixToolkit.UWP.Core
             ssaoPass.BindStates(deviceContext, StateType.All);
             ssaoPass.PixelShader.BindTexture(deviceContext, ssaoTexSlot, rt0);
             ssaoPass.PixelShader.BindTexture(deviceContext, noiseTexSlot, ssaoNoise);
+            ssaoPass.PixelShader.BindTexture(deviceContext, depthSlot, ds);
             ssaoPass.PixelShader.BindSampler(deviceContext, surfaceSampleSlot, surfaceSampler);
             ssaoPass.PixelShader.BindSampler(deviceContext, noiseSamplerSlot, noiseSampler);
             deviceContext.Draw(4, 0);
+
+            ssaoPass.PixelShader.BindTexture(deviceContext, depthSlot, null);
 
             deviceContext.SetRenderTarget(null, ssaoView);
             ssaoBlur.BindShader(deviceContext);
@@ -115,9 +117,9 @@ namespace HelixToolkit.UWP.Core
 
             context.RenderHost.SetDefaultRenderTargets(false);
             deviceContext.SetShaderResource(PixelShader.Type, ssaoTexSlot, ssaoView);
-            context.RenderHost.RenderBuffer.FullResDepthStencilPool.Put(global::SharpDX.DXGI.Format.D32_Float, ds);
-            context.RenderHost.RenderBuffer.FullResRenderTargetPool.Put(global::SharpDX.DXGI.Format.R16G16B16A16_Float, rt0);
-            context.RenderHost.RenderBuffer.FullResRenderTargetPool.Put(global::SharpDX.DXGI.Format.R16_Float, rt1);
+            context.RenderHost.RenderBuffer.FullResDepthStencilPool.Put(DEPTHFORMAT, ds);
+            context.RenderHost.RenderBuffer.FullResRenderTargetPool.Put(RENDERTARGETFORMAT, rt0);
+            context.RenderHost.RenderBuffer.FullResRenderTargetPool.Put(SSAOTARGETFORMAT, rt1);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -154,8 +156,9 @@ namespace HelixToolkit.UWP.Core
             }
             ssaoTexSlot = ssaoPass.PixelShader.ShaderResourceViewMapping.TryGetBindSlot(DefaultBufferNames.SSAOMapTB);
             noiseTexSlot = ssaoPass.PixelShader.ShaderResourceViewMapping.TryGetBindSlot(DefaultBufferNames.SSAONoiseTB);
+            depthSlot = ssaoPass.PixelShader.ShaderResourceViewMapping.TryGetBindSlot(DefaultBufferNames.SSAODepthTB);
             surfaceSampleSlot = ssaoPass.PixelShader.SamplerMapping.TryGetBindSlot(DefaultSamplerStateNames.SurfaceSampler);
-            noiseSamplerSlot = ssaoPass.PixelShader.SamplerMapping.TryGetBindSlot(DefaultSamplerStateNames.NoiseSampler);
+            noiseSamplerSlot = ssaoPass.PixelShader.SamplerMapping.TryGetBindSlot(DefaultSamplerStateNames.NoiseSampler);           
             surfaceSampler = Collect(technique.EffectsManager.StateManager.Register(DefaultSamplers.SSAOSamplerClamp));
             noiseSampler = Collect(technique.EffectsManager.StateManager.Register(DefaultSamplers.SSAONoise));
             blurSampler = Collect(technique.EffectsManager.StateManager.Register(DefaultSamplers.LinearSamplerClampAni1));

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultBuffers.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultBuffers.cs
@@ -14,73 +14,74 @@ namespace HelixToolkit.UWP.Shaders
     /// </summary>
     public static class DefaultBufferNames
     {
-        public static string GlobalTransformCB = "cbTransforms";
-        public static string ModelCB = "cbMesh";
-        public static string SimpleMeshCB = "cbMeshSimple";
-        public static string PointLineModelCB = "cbPointLineModel";
-        public static string ParticleModelCB = "cbParticleModel";
-        public static string PlaneGridModelCB = "cbPlaneGridModel";
-        public static string LightCB = "cbLights";
-        public static string ClipParamsCB = "cbClipping";
-        public static string BorderEffectCB = "cbBorderEffect";
-        public static string DynamicCubeMapCB = "cbDynamicCubeMap";
-        public static string ScreenQuadCB = "cbScreenQuad";
-        public static string VolumeModelCB = "cbVolumeModel";
-        public static string SSAOCB = "cbSSAO";
+        public const string GlobalTransformCB = "cbTransforms";
+        public const string ModelCB = "cbMesh";
+        public const string SimpleMeshCB = "cbMeshSimple";
+        public const string PointLineModelCB = "cbPointLineModel";
+        public const string ParticleModelCB = "cbParticleModel";
+        public const string PlaneGridModelCB = "cbPlaneGridModel";
+        public const string LightCB = "cbLights";
+        public const string ClipParamsCB = "cbClipping";
+        public const string BorderEffectCB = "cbBorderEffect";
+        public const string DynamicCubeMapCB = "cbDynamicCubeMap";
+        public const string ScreenQuadCB = "cbScreenQuad";
+        public const string VolumeModelCB = "cbVolumeModel";
+        public const string SSAOCB = "cbSSAO";
 #if !NETFX_CORE
-        public static string ScreenDuplicationCB = "cbScreenClone";
+        public const string ScreenDuplicationCB = "cbScreenClone";
 #endif
         //-----------Materials--------------------
-        public static string DiffuseMapTB = "texDiffuseMap";
-        public static string AlphaMapTB = "texAlphaMap";
-        public static string NormalMapTB = "texNormalMap";
-        public static string DisplacementMapTB = "texDisplacementMap";
-        public static string CubeMapTB = "texCubeMap";
-        public static string ShadowMapTB = "texShadowMap";
-        public static string SpecularTB = "texSpecularMap";
-        public static string BillboardTB = "billboardTexture";
-        public static string ColorStripe1DXTB = "texColorStripe1DX";
-        public static string ColorStripe1DYTB = "texColorStripe1DY";
-        public static string RMAMapTB = "texRMAMap";
-        public static string EmissiveTB = "texEmissiveMap";
-        public static string IrradianceMap = "texIrradianceMap";
+        public const string DiffuseMapTB = "texDiffuseMap";
+        public const string AlphaMapTB = "texAlphaMap";
+        public const string NormalMapTB = "texNormalMap";
+        public const string DisplacementMapTB = "texDisplacementMap";
+        public const string CubeMapTB = "texCubeMap";
+        public const string ShadowMapTB = "texShadowMap";
+        public const string SpecularTB = "texSpecularMap";
+        public const string BillboardTB = "billboardTexture";
+        public const string ColorStripe1DXTB = "texColorStripe1DX";
+        public const string ColorStripe1DYTB = "texColorStripe1DY";
+        public const string RMAMapTB = "texRMAMap";
+        public const string EmissiveTB = "texEmissiveMap";
+        public const string IrradianceMap = "texIrradianceMap";
         //----------Particle--------------
-        public static string ParticleFrameCB = "cbParticleFrame";
-        public static string ParticleCreateParameters = "cbParticleCreateParameters";
-        public static string ParticleMapTB = "texParticle";
-        public static string CurrentSimulationStateUB = "CurrentSimulationState";
-        public static string NewSimulationStateUB = "NewSimulationState";
-        public static string SimulationStateTB = "SimulationState";
+        public const string ParticleFrameCB = "cbParticleFrame";
+        public const string ParticleCreateParameters = "cbParticleCreateParameters";
+        public const string ParticleMapTB = "texParticle";
+        public const string CurrentSimulationStateUB = "CurrentSimulationState";
+        public const string NewSimulationStateUB = "NewSimulationState";
+        public const string SimulationStateTB = "SimulationState";
         //----------ShadowMap---------------
-        public static string ShadowParamCB = "cbShadow";
+        public const string ShadowParamCB = "cbShadow";
         //----------Order Independent Transparent-----------
-        public static string OITColorTB = "texOITColor";
-        public static string OITAlphaTB = "texOITAlpha";
+        public const string OITColorTB = "texOITColor";
+        public const string OITAlphaTB = "texOITAlpha";
         //----------Bone Skin--------------
-        public static string BoneSkinSB = "skinMatrices"; // Structured Buffer
+        public const string BoneSkinSB = "skinMatrices"; // Structured Buffer
 
-        public static string SpriteTB = "texSprite";
+        public const string SpriteTB = "texSprite";
 
-        public static string VolumeTB = "texVolume";
-        public static string VolumeFront = "texVolumeFront";
-        public static string VolumeBack = "texVolumeBack";
+        public const string VolumeTB = "texVolume";
+        public const string VolumeFront = "texVolumeFront";
+        public const string VolumeBack = "texVolumeBack";
 
-        public static string SSAOMapTB = "texSSAOMap";
-        public static string SSAONoiseTB = "texSSAONoise";
+        public const string SSAOMapTB = "texSSAOMap";
+        public const string SSAONoiseTB = "texSSAONoise";
+        public const string SSAODepthTB = "texSSAODepth";
     }
 
     public static class DefaultSamplerStateNames
     {
-        public static string SurfaceSampler = "samplerSurface";
-        public static string IBLSampler = "samplerIBL";
-        public static string DisplacementMapSampler = "samplerDisplace";
-        public static string CubeMapSampler = "samplerCube";
-        public static string ShadowMapSampler = "samplerShadow";
-        public static string ParticleTextureSampler = "samplerParticle";
-        public static string BillboardTextureSampler = "samplerBillboard";
-        public static string SpriteSampler = "samplerSprite";
-        public static string VolumeSampler = "samplerVolume";
+        public const string SurfaceSampler = "samplerSurface";
+        public const string IBLSampler = "samplerIBL";
+        public const string DisplacementMapSampler = "samplerDisplace";
+        public const string CubeMapSampler = "samplerCube";
+        public const string ShadowMapSampler = "samplerShadow";
+        public const string ParticleTextureSampler = "samplerParticle";
+        public const string BillboardTextureSampler = "samplerBillboard";
+        public const string SpriteSampler = "samplerSprite";
+        public const string VolumeSampler = "samplerVolume";
 
-        public static string NoiseSampler = "samplerNoise";
+        public const string NoiseSampler = "samplerNoise";
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -271,6 +271,14 @@ namespace HelixToolkit.UWP
         /// </summary>
         void EndD3D();
         /// <summary>
+        /// Starts the rendering. Trigger <see cref="StartRenderLoop"/>
+        /// </summary>
+        void StartRendering();
+        /// <summary>
+        /// Stops the rendering. Trigger <see cref="StopRenderLoop"/>
+        /// </summary>
+        void StopRendering();
+        /// <summary>
         /// Updates the and render.
         /// </summary>
         void UpdateAndRender();

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Layouts.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Layouts.cs
@@ -509,11 +509,11 @@ namespace HelixToolkit.Wpf.SharpDX
     {
         //[MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
         //public Vector4[] Kernels;
-        //public Vector4[] FrustumFarplaneCorner;
         public Vector2 NoiseScale;
         public int IsPerspective;
         public float Radius;
-        public const int SizeInBytes = 4 * (4 * 32 + 4 * 4 + 4);
+        public Matrix InvProjection;
+        public const int SizeInBytes = 4 * (4 * 32 + 4 + 4 * 4);
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 4)]

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -770,6 +770,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             Log(LogLevel.Information, $"Width = {width}; Height = {height};");
             if (IsInitialized)
             {
+                StartRendering();
                 return;
             }
             ActualWidth = width;
@@ -794,7 +795,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <summary>
         /// Starts the rendering.
         /// </summary>
-        protected virtual void StartRendering()
+        public virtual void StartRendering()
         {
             Log(LogLevel.Information, "");
             renderStatistics.Reset();
@@ -928,7 +929,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
         /// <summary>
         /// Stops the rendering.
         /// </summary>
-        protected virtual void StopRendering()
+        public virtual void StopRendering()
         {
             Log(LogLevel.Information, "");
             StopRenderLoop?.Invoke(this, EventArgs.Empty);

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -770,6 +770,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             Log(LogLevel.Information, $"Width = {width}; Height = {height};");
             if (IsInitialized)
             {
+                Log(LogLevel.Information, $"RenderHost already Initialized.");
                 StartRendering();
                 return;
             }
@@ -789,6 +790,7 @@ namespace HelixToolkit.Wpf.SharpDX.Render
             RenderTechnique = EffectsManager[DefaultRenderTechniqueNames.Mesh];
             CreateAndBindBuffers();
             IsInitialized = true;
+            Log(LogLevel.Information, $"Initialized.");
             AttachRenderable(EffectsManager);
             StartRendering();
         }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
@@ -551,6 +551,16 @@ namespace HelixToolkit.Wpf.SharpDX
         {
 
         }
+
+        public void StartRendering()
+        {
+
+        }
+
+        public void StopRendering()
+        {
+
+        }
         /// <summary>
         /// Updates the and render.
         /// </summary>

--- a/Source/HelixToolkit.UWP/CommonDX/SwapChainRenderHost.cs
+++ b/Source/HelixToolkit.UWP/CommonDX/SwapChainRenderHost.cs
@@ -55,7 +55,14 @@ namespace HelixToolkit.UWP
 
         private void SwapChainRenderHost_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            EndD3D();
+            if (DataContext == null)
+            {
+                EndD3D();
+            }
+            else
+            {
+                renderHost.StopRendering();
+            }
         }
 
         private void SwapChainRenderHost_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -77,7 +77,6 @@ namespace HelixToolkit.Wpf.SharpDX
         public event EventHandler<RelayExceptionEventArgs> ExceptionOccurred = delegate { };
 
         private readonly CompositionTargetEx compositionTarget = new CompositionTargetEx();
-
         /// <summary>
         /// 
         /// </summary>
@@ -152,7 +151,14 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 parentWindow.Closed -= ParentWindow_Closed;
             }
-            EndD3D();
+            if (DataContext == null)
+            {
+                EndD3D();
+            }
+            else
+            {
+                RenderHost.StopRendering();
+            }
         }
 
         /// <summary>
@@ -179,7 +185,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             RenderHost.UpdateAndRender();
         }
-        private TimeSpan _last = TimeSpan.Zero;
+
         /// <summary>
         /// 
         /// </summary>
@@ -278,8 +284,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 var parent = System.Windows.Media.VisualTreeHelper.GetParent(obj);
                 while (parent != null)
                 {
-                    var typed = parent as T;
-                    if (typed != null)
+                    if (parent is T typed)
                     {
                         return typed;
                     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
@@ -32,7 +32,7 @@ namespace HelixToolkit.Wpf.SharpDX
     /// <seealso cref="System.Windows.Controls.Image" />
     public class DPFSurfaceSwapChain : WinformHostExtend, IRenderCanvas
     {
-        private IRenderHost renderHost;
+        private readonly IRenderHost renderHost;
         /// <summary>
         /// Gets or sets the render host.
         /// </summary>
@@ -126,7 +126,14 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 parentWindow.Closed -= ParentWindow_Closed;
             }
-            EndD3D();
+            if (DataContext == null)
+            {
+                EndD3D();
+            }
+            else
+            {
+                RenderHost.StopRendering();
+            }
         }
 
         private void ParentWindow_Closed(object sender, EventArgs e)
@@ -207,8 +214,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             EndD3D();
 
-            var sdxException = exception as SharpDXException;
-            if (sdxException != null &&
+            if (exception is SharpDXException sdxException &&
                 (sdxException.Descriptor == global::SharpDX.DXGI.ResultCode.DeviceRemoved ||
                  sdxException.Descriptor == global::SharpDX.DXGI.ResultCode.DeviceReset))
             {
@@ -231,8 +237,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 var parent = System.Windows.Media.VisualTreeHelper.GetParent(obj);
                 while (parent != null)
                 {
-                    var typed = parent as T;
-                    if (typed != null)
+                    if (parent is T typed)
                     {
                         return typed;
                     }


### PR DESCRIPTION
1. Avoid unnecessary resource dispose when `Viewport3DX` is inside `TabControl`. Use `DataContext` to determine whether the viewport is removed from logical tree or only removed from visual tree. Ref #1013

2. Improve SSAO using depth buffer. Reduce banding artifacts on flat surface.
