### PR TITLE
When RotateAroundMouseDownPoint and ZoomAroundMouseDownPoint are both…

### DIFF
--- a/Source/Examples/WPF/SimpleDemo/MainWindow.xaml
+++ b/Source/Examples/WPF/SimpleDemo/MainWindow.xaml
@@ -229,7 +229,7 @@
             </Style>
         </Grid.Resources>
         <!--  The HelixViewport3D supports camera manipulation, and can be used just like the Viewport3D  -->
-        <HelixToolkit:HelixViewport3D ShowFrameRate="True" ZoomExtentsWhenLoaded="True">
+        <HelixToolkit:HelixViewport3D ShowFrameRate="True" ZoomExtentsWhenLoaded="True" ZoomAroundMouseDownPoint="True" RotateAroundMouseDownPoint="True">
 
 
             <!--  Remember to add light to the scene  -->

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
@@ -447,6 +447,7 @@ namespace HelixToolkit.Wpf
             this.FocusVisualStyle = null;
 
             this.IsManipulationEnabled = true;
+            this.RotataAroundClosestVertexComplexity = 5000;
 
             this.InitializeBindings();
             this.renderingEventListener = new RenderingEventListener(this.OnCompositionTargetRendering);
@@ -1247,6 +1248,13 @@ namespace HelixToolkit.Wpf
                 this.SetValue(ZoomSensitivityProperty, value);
             }
         }
+
+        /// <summary>
+        /// Efficiency option, lower values decrease computation time for camera interaction when
+        /// RotateAroundMouseDownPoint or ZoomAroundMouseDownPoint is set to true in inspect mode.
+        /// Note: Will mostly save on computation time once the bounds are already calculated and cashed within the MeshGeometry3D.
+        /// </summary>
+        public int RotataAroundClosestVertexComplexity { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether IsOrthographicCamera.
@@ -2262,7 +2270,7 @@ namespace HelixToolkit.Wpf
             {
                 var point = e.GetPosition(this);
 
-                Point3D? nearestPoint = new Closest3DPointHitTester(this.Viewport).CalculateMouseDownNearestPoint(point, true).MouseDownNearestPoint3D;
+                Point3D? nearestPoint = new Closest3DPointHitTester(this.Viewport, this.RotataAroundClosestVertexComplexity).CalculateMouseDownNearestPoint(point, true).MouseDownNearestPoint3D;
                 if (nearestPoint.HasValue)
                 {
                     this.AddZoomForce(-e.Delta * 0.001, nearestPoint.Value);

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
@@ -2261,21 +2261,11 @@ namespace HelixToolkit.Wpf
             if (this.ZoomAroundMouseDownPoint)
             {
                 var point = e.GetPosition(this);
-                
-                Point3D nearestPoint;
-                Vector3D normal;
-                DependencyObject visual;
-                if (this.Viewport.FindNearest(point, out nearestPoint, out normal, out visual))
-                {
-                    this.AddZoomForce(-e.Delta * 0.001, nearestPoint);
-                    e.Handled = true;
-                    return;
-                }
 
-                var pos = this.Viewport.UnProject(point);
-                if (pos.HasValue)
+                Point3D? nearestPoint = new Closest3DPointHitTester(this.Viewport).CalculateMouseDownNearestPoint(point, true).MouseDownNearestPoint3D;
+                if (nearestPoint.HasValue)
                 {
-                    this.AddZoomForce(-e.Delta * 0.001, pos.Value);
+                    this.AddZoomForce(-e.Delta * 0.001, nearestPoint.Value);
                     e.Handled = true;
                     return;
                 }

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/Closest3DPointHitTester.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/Closest3DPointHitTester.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media.Media3D;
+
+namespace HelixToolkit.Wpf
+{
+    internal class Closest3DPointHitTester
+    {
+        private readonly Viewport3D mViewPort3D;
+
+        /// <summary>
+        /// Create a new CloseObjectHitTest that returns a 3D point closest to the clicked point on the camera.
+        /// </summary>
+        /// <param name="viewPort3D"></param>
+        public Closest3DPointHitTester(Viewport3D viewPort3D)
+        {
+            mViewPort3D = viewPort3D;
+        }
+
+
+        /// <summary>
+        /// Returns the 3D point that the user most likely clicked on.
+        /// Returns the closest intersection with a mesh, if possible.
+        /// If useClosestMeshIfPossible is true it will otherwise returns the mesh vertex that is closest to the clicked 2D screen coordinate, if possible.
+        /// Returns the unprojected position otherwise.
+        /// Also returns the 2D point corresponding to the returned 3D point.
+        /// </summary>
+        /// <param name="position"> The point in screen coordinates to calculate the closest vertices for. </param>
+        /// <param name="useClosestMeshIfPossible"> When true the closest vertex point to the clicked position will be used when no mesh is hit at the exact mouse cursor area.</param>
+        public NearestPointInCamera CalculateMouseDownNearestPoint(Point position, bool useClosestMeshIfPossible)
+        {
+            if (mViewPort3D.FindNearest(position, out Point3D nearestPoint, out _, out _))
+            {
+                return new NearestPointInCamera(position, nearestPoint);
+            }
+
+            if (useClosestMeshIfPossible)
+            {
+                ClosestVertexResult closestResult =
+                    new Closest3DPointHitTester(mViewPort3D).ResultOfClosestPointHit2D(position);
+                if (closestResult != null)
+                {
+                    return new NearestPointInCamera(closestResult.ClosestPointIn2D, closestResult.ClosestPoint);
+                }
+            }
+
+            Point3D? unprojectedPosition = mViewPort3D.UnProject(position);
+            return new NearestPointInCamera(position, unprojectedPosition);
+        }
+
+        public ClosestVertexResult ResultOfClosestPointHit2D(Point position)
+        {
+            List<ClosestVertexResult> closestHits =
+                FindClosestHits(position).OrderBy(x => x.DistanceToPoint2D).ToList();
+            if (closestHits.Count != 0)
+                return closestHits[0];
+            return null;
+        }
+
+        /// <summary>
+        /// For each mesh object in the viewport, this method calculates the vertex that when mapped to 2D is closest to the given 2D point on the screen
+        /// </summary>
+        /// <param name="pointToHitTest"> The point in screen coordinates to calculate the closest vertices for. </param>
+        /// <returns> A ClosestVertexResult containing the distance to the 2D point and the closest 3D vertex point for each geometry/model </returns>
+
+        public IEnumerable<ClosestVertexResult> FindClosestHits(Point pointToHitTest)
+        {
+            ProjectionCamera camera = mViewPort3D.Camera as ProjectionCamera;
+
+            if (camera == null)
+            {
+                throw new InvalidOperationException("No projection camera defined. Cannot find rectangle hits.");
+            }
+
+            List<ClosestVertexResult> results = new List<ClosestVertexResult>();
+            mViewPort3D.Children.Traverse<GeometryModel3D>(
+                (model, transform) =>
+                {
+                    MeshGeometry3D geometry = model.Geometry as MeshGeometry3D;
+                    if (geometry == null || geometry.Positions == null || geometry.TriangleIndices == null)
+                    {
+                        return;
+                    }
+
+                    // transform the positions of the mesh to screen coordinates
+                    Point3D[] point3Ds = geometry.Positions.Select(transform.Transform).ToArray();
+                    Point[] point2Ds = geometry.Positions.Select(transform.Transform)
+                        .Select(mViewPort3D.Point3DtoPoint2D).ToArray();
+
+                    double minSquaredDistanceToPoint = double.PositiveInfinity;
+
+                    Point3D closestPoint = point3Ds[0];
+                    Point closestPointIn2D = point2Ds[0];
+                    // evaluate each triangle
+                    for (int i = 0; i < point2Ds.Length; i++)
+                    {
+                        Point point = point2Ds[i];
+                        double xDiff = point.X - pointToHitTest.X;
+                        double yDiff = point.Y - pointToHitTest.Y;
+                        double squaredDistance = xDiff * xDiff + yDiff * yDiff;
+                        if (squaredDistance < minSquaredDistanceToPoint)
+                        {
+                            minSquaredDistanceToPoint = squaredDistance;
+                            closestPoint = point3Ds[i];
+                            closestPointIn2D = point;
+                        }
+                    }
+
+                    ClosestVertexResult hitTestResult = new ClosestVertexResult(model, geometry, closestPoint,
+                        closestPointIn2D, Math.Sqrt(minSquaredDistanceToPoint));
+                    results.Add(hitTestResult);
+
+                });
+
+            return results;
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/Closest3DPointHitTester.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/Closest3DPointHitTester.cs
@@ -59,11 +59,20 @@ namespace HelixToolkit.Wpf
 
         public ClosestVertexResult ResultOfClosestPointHit2D(Point position)
         {
-            List<ClosestVertexResult> closestHits =
-                FindClosestHits(position).OrderBy(x => x.DistanceToPoint2D).ToList();
-            if (closestHits.Count != 0)
-                return closestHits[0];
-            return null;
+            double minX = 0;
+            double minY = 0;
+            double maxX = mViewPort3D.ActualWidth;
+            double maxY = mViewPort3D.ActualHeight;
+            IEnumerable<ClosestVertexResult> hitsInView = FindClosestHits(position).Where(result =>
+                result.ClosestPointIn2D.X >= minX && result.ClosestPointIn2D.X <= maxX &&
+                result.ClosestPointIn2D.Y >= minY && result.ClosestPointIn2D.Y <= maxY);
+
+            IOrderedEnumerable<ClosestVertexResult> closestHits =
+                hitsInView.OrderBy(x => x.DistanceToPoint2D);
+            
+           //Return the closest valid result, or null in case no valid result was found.
+           ClosestVertexResult closestHitInView = closestHits.FirstOrDefault();
+           return closestHitInView;
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/ClosestVertexResult.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/ClosestVertexResult.cs
@@ -1,0 +1,45 @@
+﻿using System.Windows;
+using System.Windows.Media.Media3D;
+
+namespace HelixToolkit.Wpf
+{
+    /// <summary>
+    /// The result of a hit test where the point with the smallest 2D distance from a given point is searched.
+    /// </summary>
+    internal class ClosestVertexResult
+    {
+        public ClosestVertexResult(GeometryModel3D model, MeshGeometry3D geometry, Point3D closestPoint, Point closestPointIn2D, double distanceToPoint2D)
+        {
+            Model = model;
+            Geometry = geometry;
+            ClosestPoint = closestPoint;
+            DistanceToPoint2D = distanceToPoint2D;
+            ClosestPointIn2D = closestPointIn2D;
+        }
+
+        /// <summary>
+        /// The mesh vertex closest to the searched coordinate.
+        /// </summary>
+        public Point3D ClosestPoint { get; }
+
+        /// <summary>
+        /// The 2D coordinate matching the found mesh vertex.
+        /// </summary>
+        public Point ClosestPointIn2D { get; }
+
+        /// <summary>
+        /// The mesh geometry the found point belongs to.
+        /// </summary>
+        public MeshGeometry3D Geometry { get; }
+
+        /// <summary>
+        /// The geometry model the point belongs to.
+        /// </summary>
+        public GeometryModel3D Model { get; }
+
+        /// <summary>
+        /// The 2D distance from the found point to the point that was searched for.
+        /// </summary>
+        public double DistanceToPoint2D { get; }
+    }
+}

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/MouseGestureHandler.cs
@@ -180,6 +180,11 @@ namespace HelixToolkit.Wpf
         /// <summary>
         /// Gets or sets the mouse down point (2D screen coordinates).
         /// </summary>
+        protected Point MouseDownNearestPoint2D { get; set; }
+
+        /// <summary>
+        /// Gets or sets the mouse down point (2D screen coordinates).
+        /// </summary>
         protected Point MouseDownPoint { get; set; }
 
         /// <summary>
@@ -477,26 +482,12 @@ namespace HelixToolkit.Wpf
         private void SetMouseDownPoint(Point position)
         {
             this.MouseDownPoint = position;
-
-            this.MouseDownNearestPoint3D = null;
-
-            Point3D nearestPoint;
-            Vector3D normal;
-            DependencyObject visual;
-            if (this.Controller.Viewport.FindNearest(this.MouseDownPoint, out nearestPoint, out normal, out visual))
-            {
-                this.MouseDownNearestPoint3D = nearestPoint;
-            }
-            else
-            {
-                var pos = this.Viewport.UnProject(this.MouseDownPoint);
-                if (pos.HasValue)
-                {
-                    this.MouseDownNearestPoint3D = pos.Value;
-                }
-            }
-
             this.MouseDownPoint3D = this.UnProject(this.MouseDownPoint);
+            NearestPointInCamera nearestPoint = new Closest3DPointHitTester(this.Controller.Viewport).CalculateMouseDownNearestPoint(position, true);
+            this.MouseDownNearestPoint2D = nearestPoint.MouseDownNearestPoint2D;
+            this.MouseDownNearestPoint3D = nearestPoint.MouseDownNearestPoint3D;
+
+
         }
     }
 }

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/MouseGestureHandler.cs
@@ -483,7 +483,7 @@ namespace HelixToolkit.Wpf
         {
             this.MouseDownPoint = position;
             this.MouseDownPoint3D = this.UnProject(this.MouseDownPoint);
-            NearestPointInCamera nearestPoint = new Closest3DPointHitTester(this.Controller.Viewport).CalculateMouseDownNearestPoint(position, true);
+            NearestPointInCamera nearestPoint = new Closest3DPointHitTester(this.Controller.Viewport, this.Controller.RotataAroundClosestVertexComplexity).CalculateMouseDownNearestPoint(position, true);
             this.MouseDownNearestPoint2D = nearestPoint.MouseDownNearestPoint2D;
             this.MouseDownNearestPoint3D = nearestPoint.MouseDownNearestPoint3D;
 

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/NearestPointInCamera.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/NearestPointInCamera.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows;
+using System.Windows.Media.Media3D;
+
+namespace HelixToolkit.Wpf
+{
+    internal class NearestPointInCamera
+    {
+        public NearestPointInCamera(Point mouseDownNearestPoint2D, Point3D? mouseDownNearestPoint3D)
+        {
+            MouseDownNearestPoint2D = mouseDownNearestPoint2D;
+            MouseDownNearestPoint3D = mouseDownNearestPoint3D;
+        }
+
+        /// <summary>
+        /// The 3D point that most closely matches the ray from the camera cast at the current mouse position.
+        /// </summary>
+        public Point3D? MouseDownNearestPoint3D { get; set; }
+
+        /// <summary>
+        /// The 2D coordinate corresponding to said 3D point. This will usually coïncide with the mouse position, but may differ if there is no geometry directly under the mouse postion.
+        /// </summary>
+        public Point MouseDownNearestPoint2D { get; set; }
+    }
+}

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/RotateHandler.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/RotateHandler.cs
@@ -308,7 +308,10 @@ namespace HelixToolkit.Wpf
 
             if (this.Controller.CameraMode == CameraMode.Inspect)
             {
-                this.Controller.ShowTargetAdorner(this.rotationPoint);
+                if (this.Controller.ZoomAroundMouseDownPoint)
+                    this.Controller.ShowTargetAdorner(this.MouseDownNearestPoint2D);
+                else
+                    this.Controller.ShowTargetAdorner(this.MouseDownPoint);
             }
 
             switch (this.Controller.CameraRotationMode)

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/ZoomHandler.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/ZoomHandler.cs
@@ -212,7 +212,7 @@ namespace HelixToolkit.Wpf
 
             if (this.Controller.ZoomAroundMouseDownPoint && this.MouseDownNearestPoint3D != null)
             {
-                this.zoomPoint = this.MouseDownPoint;
+                this.zoomPoint = this.MouseDownNearestPoint2D;
                 this.zoomPoint3D = this.MouseDownNearestPoint3D.Value;
             }
 

--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
@@ -63,6 +63,9 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Adorners\DrawingContextExtensions.cs" />
+    <Compile Include="Controls\CameraController\Closest3DPointHitTester.cs" />
+    <Compile Include="Controls\CameraController\ClosestVertexResult.cs" />
+    <Compile Include="Controls\CameraController\NearestPointInCamera.cs" />
     <Compile Include="Controls\Stereo\InterlacedView3D.xaml.cs">
       <DependentUpon>InterlacedView3D.xaml</DependentUpon>
     </Compile>

--- a/Source/HelixToolkit.Wpf/Helpers/Viewport3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Viewport3DHelper.cs
@@ -676,6 +676,19 @@ namespace HelixToolkit.Wpf
         }
 
         /// <summary>
+        /// Transforms the set of Point3D to a set of Point2D.
+        /// </summary>
+        /// <param name="viewport">The viewport.</param>
+        /// <param name="points">The set of 3D points.</param>
+        /// <returns>The transformed points.</returns>
+        public static IEnumerable<Point> Point3DtoPoint2D(this Viewport3D viewport, IEnumerable<Point3D> points)
+        {
+            var matrix = GetTotalTransform(viewport);
+            var pointsTransformed = points.Select(point => matrix.Transform(point));
+            return pointsTransformed.Select(point => new Point(point.X, point.Y));
+        }
+
+        /// <summary>
         /// Prints the specified viewport.
         /// </summary>
         /// <param name="vp">


### PR DESCRIPTION
When RotateAroundMouseDownPoint and ZoomAroundMouseDownPoint are both on the camera target position may get really close/very far from the camera, causing bad/unexpected camera interaction when not hovering over an object. See https://github.com/helix-toolkit/helix-toolkit/issues/1028 for more information.

Added a Closest3DPointHitTester and used it to allow rotating around the closest vertex instead of always using the unprojected position when no meshes are under the mouse curser.