### PR TITLE
 Change Material Texture from Stream to TextureModel

### DIFF
--- a/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
@@ -19,6 +19,7 @@ namespace CoreTest
 {
     public class CoreTestApp
     {
+        public ViewportCore Viewport { get => viewport; }
         private readonly ViewportCore viewport;
         private readonly Form window;
         private readonly EffectsManager effectsManager;

--- a/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
@@ -1,11 +1,10 @@
 ﻿//#define TESTADDREMOVE
 
-using HelixToolkit.SharpDX.Core.Controls;
-using HelixToolkit.SharpDX.Core.Model;
 using HelixToolkit.SharpDX.Core;
 using HelixToolkit.SharpDX.Core.Cameras;
+using HelixToolkit.SharpDX.Core.Controls;
+using HelixToolkit.SharpDX.Core.Model;
 using HelixToolkit.SharpDX.Core.Model.Scene;
-using HelixToolkit.SharpDX.Core.Shaders;
 using ImGuiNET;
 using SharpDX;
 using SharpDX.Windows;
@@ -14,9 +13,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Windows.Forms;
-using HelixToolkit.SharpDX.Core.Animations;
 
 namespace CoreTest
 {
@@ -30,7 +27,7 @@ namespace CoreTest
         private GroupNode groupSphere, groupBox, groupPoints, groupLines, groupModel;
         private DirectionalLightNode directionalLight;
         private AmbientLightNode ambientLight;
-        private const int NumItems = 40;
+        private const int NumItems = 400;
         private Random rnd = new Random((int)Stopwatch.GetTimestamp());
         private Dictionary<string, MaterialCore> materials = new Dictionary<string, MaterialCore>();
         private MaterialCore[] materialList;
@@ -45,7 +42,11 @@ namespace CoreTest
             BackgroundColor = new System.Numerics.Vector3(0.4f, 0.4f, 0.4f),
             DirectionalLightFollowCamera = true,
             DirectionLightIntensity = 0.8f,
-            EnableFrustum = true, EnableFXAA = true, EnableSSAO = true, WalkAround = false
+            EnableFrustum = true,
+            EnableFXAA = true,
+            EnableSSAO = true,
+            WalkAround = false,
+            ShowRenderDetail = false
         };
 
         public CoreTestApp(Form window)
@@ -83,6 +84,7 @@ namespace CoreTest
             viewport.EnableRenderFrustum = options.EnableFrustum;
             viewport.BackgroundColor = new Color4(options.BackgroundColor.X, options.BackgroundColor.Y, options.BackgroundColor.Z, 1);
             viewport.EnableSSAO = options.EnableSSAO;
+            viewport.ShowRenderDetail = options.ShowRenderDetail;
             if (options.ShowWireframeChanged)
             {
                 options.ShowWireframeChanged = false;

--- a/Source/Examples/SharpDX.Core/CoreTest/Form1.Designer.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/Form1.Designer.cs
@@ -29,13 +29,18 @@
         private void InitializeComponent()
         {
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.button1 = new System.Windows.Forms.Button();
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.label1 = new System.Windows.Forms.Label();
+            this.checkBox1 = new System.Windows.Forms.CheckBox();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
             // splitContainer1
@@ -44,10 +49,12 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
             // 
+            this.splitContainer1.Panel1.Controls.Add(this.groupBox1);
             this.splitContainer1.Panel1.Controls.Add(this.label1);
             this.splitContainer1.Panel1.Controls.Add(this.checkBox1);
             this.splitContainer1.Panel1.Controls.Add(this.textBox1);
@@ -56,59 +63,103 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.AccessibleName = "panel2";
-            this.splitContainer1.Size = new System.Drawing.Size(800, 450);
-            this.splitContainer1.SplitterDistance = 153;
+            this.splitContainer1.Size = new System.Drawing.Size(1600, 865);
+            this.splitContainer1.SplitterDistance = 306;
+            this.splitContainer1.SplitterWidth = 8;
             this.splitContainer1.TabIndex = 0;
             // 
-            // button1
+            // label1
             // 
-            this.button1.Location = new System.Drawing.Point(12, 23);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(105, 23);
-            this.button1.TabIndex = 0;
-            this.button1.Text = "WinFormControls";
-            this.button1.UseVisualStyleBackColor = true;
-            // 
-            // textBox1
-            // 
-            this.textBox1.Location = new System.Drawing.Point(4, 155);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(135, 20);
-            this.textBox1.TabIndex = 1;
-            this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(2, 267);
+            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(296, 25);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "Input Text to show in viewport";
             // 
             // checkBox1
             // 
             this.checkBox1.AutoSize = true;
-            this.checkBox1.Location = new System.Drawing.Point(13, 106);
+            this.checkBox1.Location = new System.Drawing.Point(26, 204);
+            this.checkBox1.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(80, 17);
+            this.checkBox1.Size = new System.Drawing.Size(150, 29);
             this.checkBox1.TabIndex = 2;
             this.checkBox1.Text = "checkBox1";
             this.checkBox1.UseVisualStyleBackColor = true;
             // 
-            // label1
+            // textBox1
             // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(1, 139);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(149, 13);
-            this.label1.TabIndex = 3;
-            this.label1.Text = "Input Text to show in viewport";
+            this.textBox1.Location = new System.Drawing.Point(8, 298);
+            this.textBox1.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(266, 31);
+            this.textBox1.TabIndex = 1;
+            this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(24, 44);
+            this.button1.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(210, 44);
+            this.button1.TabIndex = 0;
+            this.button1.Text = "WinFormControls";
+            this.button1.UseVisualStyleBackColor = true;
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(14, 53);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(170, 59);
+            this.button2.TabIndex = 4;
+            this.button2.Text = "Screenshot";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.button2_Click);
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pictureBox1.Location = new System.Drawing.Point(10, 139);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(276, 251);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pictureBox1.TabIndex = 5;
+            this.pictureBox1.TabStop = false;
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.AutoSize = true;
+            this.groupBox1.Controls.Add(this.pictureBox1);
+            this.groupBox1.Controls.Add(this.button2);
+            this.groupBox1.Location = new System.Drawing.Point(12, 438);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(292, 420);
+            this.groupBox1.TabIndex = 6;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "groupBox1";
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(1600, 865);
             this.Controls.Add(this.splitContainer1);
+            this.Margin = new System.Windows.Forms.Padding(6, 6, 6, 6);
             this.Name = "Form1";
             this.Text = "HelixToolkit Winform Integration";
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.groupBox1.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -120,5 +171,8 @@
         private System.Windows.Forms.TextBox textBox1;
         private System.Windows.Forms.CheckBox checkBox1;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button button2;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.GroupBox groupBox1;
     }
 }

--- a/Source/Examples/SharpDX.Core/CoreTest/Form1.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/Form1.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-
+using HelixToolkit.SharpDX.Core;
 namespace CoreTest
 {
     public partial class Form1 : Form
@@ -57,6 +57,15 @@ namespace CoreTest
         private void textBox1_TextChanged(object sender, EventArgs e)
         {
             SceneUI.SomeTextFromOutside = textBox1.Text;
+        }
+
+        private void button2_Click(object sender, EventArgs e)
+        {
+            using (var mem = app.Viewport.RenderToBitmapStream())
+            {
+                var bmp = new Bitmap(mem);
+                pictureBox1.Image = bmp;
+            }
         }
     }
 }

--- a/Source/Examples/SharpDX.Core/CoreTest/SceneUI.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/SceneUI.cs
@@ -26,6 +26,7 @@ namespace CoreTest
         private static string[] animationNames;
         private static int currentSelectedAnimation = -1;
         private static float[] fps = new float[128];
+        private static float[] frustumTest = new float[128];
         private static int currFPSIndex = 0;
 
         public static void DrawUI(int width, int height, ref ViewportOptions options, GroupNode rootNode)
@@ -82,9 +83,14 @@ namespace CoreTest
                 }
             }
             ImGui.Separator();
-            ImGui.PlotLines("FPS", ref fps[0], fps.Length, 0, $"{fps[currFPSIndex]}", 30, 70, new System.Numerics.Vector2(200, 50));
-            fps[currFPSIndex++] = 1000f / (float)options.Viewport.RenderHost.RenderStatistics.FPSStatistics.AverageValue;
+            ImGui.Text("FPS");
+            ImGui.PlotLines("", ref fps[0], fps.Length, 0, $"{fps[currFPSIndex]}", 30, 70, new System.Numerics.Vector2(200, 50));
+            ImGui.Text("Frustum Test Time");
+            ImGui.PlotLines("", ref frustumTest[0], frustumTest.Length, 0, $"{frustumTest[currFPSIndex]}ms", 0, 5, new System.Numerics.Vector2(200, 50));
+            fps[currFPSIndex] = 1000f / (float)options.Viewport.RenderHost.RenderStatistics.LatencyStatistics.AverageValue;
+            frustumTest[currFPSIndex++] = (float)options.Viewport.RenderHost.RenderStatistics.FrustumTestTime * 1000;
             currFPSIndex %= 128;
+
             if (!loading && ImGui.CollapsingHeader("Scene Graph", ImGuiTreeNodeFlags.DefaultOpen))
             {
                 DrawSceneGraph(rootNode);

--- a/Source/Examples/SharpDX.Core/CoreTest/ViewportControl.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/ViewportControl.cs
@@ -15,6 +15,7 @@ namespace CoreTest
         public bool EnableSSAO;
         public bool EnableFXAA;
         public bool EnableFrustum;
+        public bool ShowRenderDetail;
         public System.Numerics.Vector3 BackgroundColor;
         public float DirectionLightIntensity;
         public float AmbientLightIntensity;

--- a/Source/Examples/UWP/SimpleDemo/MainPageViewModel.cs
+++ b/Source/Examples/UWP/SimpleDemo/MainPageViewModel.cs
@@ -102,7 +102,7 @@ namespace SimpleDemoW10
             get { return transform4; }
         }
 
-        public Stream EnvironmentMap { private set; get; }
+        public TextureModel EnvironmentMap { private set; get; }
 
         public Vector3 DirectionalLightDirection { get; } = new Vector3(-0.5f, -1, 0);
         private DispatcherTimer timer;
@@ -148,6 +148,7 @@ namespace SimpleDemoW10
             Material1.RenderDiffuseMap = false;
             Material1.RenderNormalMap = false;
             Material1.RenderEnvironmentMap = true;
+            Material1.RenderShadowMap = true;
            
             var lineBuilder = new LineBuilder();
             lineBuilder.AddLine(Vector3.Zero, new Vector3(5, 0, 0));
@@ -173,6 +174,7 @@ namespace SimpleDemoW10
 
             FloorMaterial = PhongMaterials.Obsidian;
             FloorMaterial.ReflectiveColor = Color.Silver;
+            FloorMaterial.RenderShadowMap = true;
 
             EnvironmentMap = LoadTexture("Cubemap_Grandcanyon.dds");
 

--- a/Source/Examples/UWP/SimpleDemo/ParticleViewModel.cs
+++ b/Source/Examples/UWP/SimpleDemo/ParticleViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using GalaSoft.MvvmLight;
+using HelixToolkit.UWP;
 using SharpDX;
 using SharpDX.Direct3D11;
 using System;
@@ -67,8 +68,8 @@ namespace SimpleDemoW10
             }
         }
 
-        private Stream particleTexture;
-        public Stream ParticleTexture
+        private TextureModel particleTexture;
+        public TextureModel ParticleTexture
         {
             set
             {

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/Shaders/CommonBuffers.hlsl
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/Shaders/CommonBuffers.hlsl
@@ -277,7 +277,7 @@ cbuffer cbSSAO : register(b1)
 {
     float4 kernel[SSAOKernalSize];
     float2 noiseScale;
-    int isPerspective;
+    int texScale; // Used when viewport size does not match texture size
     float radius;    
     float4x4 invProjection;
 }

--- a/Source/Examples/WPF.SharpDX/InstancingDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/InstancingDemo/MainViewModel.cs
@@ -92,7 +92,7 @@ namespace InstancingDemo
             ModelMaterial.DiffuseMap = LoadFileToMemory(new System.Uri(@"TextureCheckerboard2.jpg", System.UriKind.RelativeOrAbsolute).ToString());
             ModelMaterial.NormalMap = LoadFileToMemory(new System.Uri(@"TextureCheckerboard2_dot3.jpg", System.UriKind.RelativeOrAbsolute).ToString());
 
-            BillboardModel = new BillboardSingleImage3D(ModelMaterial.DiffuseMap, 20, 20);
+            BillboardModel = new BillboardSingleImage3D(ModelMaterial.DiffuseMap.CompressedStream, 20, 20);
             Texture = LoadFileToMemory("Cubemap_Grandcanyon.dds");
             CreateModels();
             timer.Interval = TimeSpan.FromMilliseconds(30);

--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/Importer.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/Importer.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
+using System.Collections.ObjectModel;
 #if !NETFX_CORE
 namespace HelixToolkit.Wpf.SharpDX
 #else
@@ -24,7 +25,7 @@ namespace HelixToolkit.UWP
 #endif
 {
     using HelixToolkit.Logger;
-    using Model;  
+    using Model;
     using HxAnimations = Animations;
     using HxScene = Model.Scene;
 
@@ -35,7 +36,15 @@ namespace HelixToolkit.UWP
         public partial class Importer : IDisposable
         {
             private const string ToUpperDictString = @"..\";
+
             private string path = "";
+            public static readonly string[] SupportedTextureFormats = new string[]
+            {
+                "bmp", "jpg", "jpeg", "png", "dds", "tiff", "wmp", "gif",
+            };
+
+            protected static readonly HashSet<string> SupportedTextureFormatDict;
+
             static Importer()
             {
                 using (var temp = new AssimpContext())
@@ -56,6 +65,7 @@ namespace HelixToolkit.UWP
                 }
 
                 SupportedFormatsString = builder.ToString(0, builder.Length - 1);
+                SupportedTextureFormatDict = new HashSet<string>(SupportedTextureFormats);
             }
             #region Properties
             /// <summary>
@@ -129,7 +139,7 @@ namespace HelixToolkit.UWP
 
             private int MaterialIndexForNoName = 0;
             private int MeshIndexForNoName = 0;
-
+            private List<EmbeddedTexture> embeddedTextures;
             #region Public Methods
             /// <summary>
             ///     Loads the model specified file path.
@@ -324,10 +334,12 @@ namespace HelixToolkit.UWP
                     {
                         if (scene.HasMaterials)
                         {
+                            embeddedTextures = scene.HasTextures ? scene.Textures : new List<EmbeddedTexture>();
                             for (var i = 0; i < scene.MaterialCount; ++i)
                             {
                                 s.Materials[i] = OnCreateHelixMaterial(scene.Materials[i]);
                             }
+                            embeddedTextures = null;
                         }
                     });
                 return s;

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
@@ -2,41 +2,18 @@
 The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
-using System;
-using System.Collections.Generic;
 using global::SharpDX;
+using System;
 
 namespace HelixToolkit.SharpDX.Core.Controls
-{   
+{
     using Cameras;
     using Model.Scene;
-    using Model.Scene2D;
     using Render;
 
 
     public partial class ViewportCore : DisposeObject, IViewport3DX
     {
-        /// <summary>
-        /// Occurs when [on start rendering].
-        /// </summary>
-        public event EventHandler StartRendering;
-        /// <summary>
-        /// Occurs when [on stop rendering].
-        /// </summary>
-        public event EventHandler StopRendering;
-        /// <summary>
-        /// Occurs when [on error occurred].
-        /// </summary>
-        public event EventHandler<Exception> ErrorOccurred;
-
-
-        internal ViewBoxNode ViewCube { get; } = new ViewBoxNode();
-
-        internal CoordinateSystemNode CoordinateSystem { get; } = new CoordinateSystemNode();
-
-        private List<HitTestResult> hits = new List<HitTestResult>();
-
-        private SceneNode currentNode;
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewportCore"/> class.
         /// </summary>
@@ -49,7 +26,6 @@ namespace HelixToolkit.SharpDX.Core.Controls
                 RenderHost = new SwapChainRenderHost(nativeWindowPointer,
                     (device) => { return new DeferredContextRenderer(device, new AutoRenderTaskScheduler()); })
                 {
-                    ShowRenderDetail = RenderDetail.Statistics | RenderDetail.FPS,
                     Viewport = this,
                 };
             }
@@ -57,7 +33,6 @@ namespace HelixToolkit.SharpDX.Core.Controls
             {
                 RenderHost = new SwapChainRenderHost(nativeWindowPointer)
                 {
-                    ShowRenderDetail = RenderDetail.Statistics | RenderDetail.FPS,
                     Viewport = this,
                 };
             }
@@ -65,7 +40,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
             RenderHost.StartRenderLoop += RenderHost_StartRenderLoop;
             RenderHost.StopRenderLoop += RenderHost_StopRenderLoop;
             RenderHost.ExceptionOccurred += (s, e) => { HandleExceptionOccured(e.Exception); };
-            Items2D.ItemsInternal.Add(new FrameStatisticsNode2D());
+            Items2D.ItemsInternal.Add(frameStatisticsNode);
         }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCoreProperties.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCoreProperties.cs
@@ -84,7 +84,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
         /// <value>
         /// The d2 d renderables.
         /// </value>
-        public IEnumerable<SceneNode2D> D2DRenderables => Items2D.ItemsInternal;
+        public IEnumerable<SceneNode2D> D2DRenderables { get { yield return Items2D; } }
         /// <summary>
         /// Gets the items.
         /// </summary>
@@ -347,5 +347,30 @@ namespace HelixToolkit.SharpDX.Core.Controls
             get => ViewCube.Visible;
         }
         #endregion
+
+        #region Events
+        /// <summary>
+        /// Occurs when [on start rendering].
+        /// </summary>
+        public event EventHandler StartRendering;
+        /// <summary>
+        /// Occurs when [on stop rendering].
+        /// </summary>
+        public event EventHandler StopRendering;
+        /// <summary>
+        /// Occurs when [on error occurred].
+        /// </summary>
+        public event EventHandler<Exception> ErrorOccurred;
+        #endregion
+
+        internal ViewBoxNode ViewCube { get; } = new ViewBoxNode();
+
+        internal CoordinateSystemNode CoordinateSystem { get; } = new CoordinateSystemNode();
+
+        private List<HitTestResult> hits = new List<HitTestResult>();
+
+        private SceneNode currentNode;
+
+        private FrameStatisticsNode2D frameStatisticsNode = new FrameStatisticsNode2D();
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/BillboardBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/BillboardBufferModel.cs
@@ -49,7 +49,7 @@ namespace HelixToolkit.UWP
             /// </value>
             public BillboardType Type { private set; get; }
 
-            private Stream textureStream;
+            private TextureModel texture;
             /// <summary>
             /// Initializes a new instance of the <see cref="BillboardBufferModel{VertexStruct}"/> class.
             /// </summary>
@@ -89,20 +89,20 @@ namespace HelixToolkit.UWP
                     {
                         Type = billboardGeometry.Type;              
                         buffer.UploadDataToBuffer(context, billboardGeometry.BillboardVertices, billboardGeometry.BillboardVertices.Count, 0, geometry.PreDefinedVertexCount);
-                        if(textureStream != billboardGeometry.Texture)
+                        if(texture != billboardGeometry.Texture)
                         {
                             RemoveAndDispose(ref textureView);
-                            textureStream = billboardGeometry.Texture;
-                            if (textureStream != null)
+                            texture = billboardGeometry.Texture;
+                            if (texture != null)
                             {
-                                textureView = Collect(deviceResources.MaterialTextureManager.Register(textureStream));
+                                textureView = Collect(deviceResources.MaterialTextureManager.Register(texture));
                             }
                         }
                     }
                     else
                     {
                         RemoveAndDispose(ref textureView);
-                        textureStream = null;
+                        texture = null;
                         buffer.UploadDataToBuffer(context, emptyVerts, 0);
                     }
                 }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/DrawScreenQuadCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/DrawScreenQuadCore.cs
@@ -41,14 +41,14 @@ namespace HelixToolkit.UWP
 
             public ScreenQuadModelStruct ModelStruct;
 
-            private Stream texture;
+            private TextureModel texture;
             /// <summary>
             /// Gets or sets the texture.
             /// </summary>
             /// <value>
             /// The texture.
             /// </value>
-            public Stream Texture
+            public TextureModel Texture
             {
                 set
                 {
@@ -104,7 +104,7 @@ namespace HelixToolkit.UWP
                 };
             }
 
-            private void UpdateTexture(Stream texture)
+            private void UpdateTexture(TextureModel texture)
             {
                 RemoveAndDispose(ref textureProxy);
                 if (texture != null)

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ParticleRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ParticleRenderCore.cs
@@ -136,12 +136,12 @@ namespace HelixToolkit.UWP
                 }
             }
 
-            private Stream particleTexture;
+            private TextureModel particleTexture;
 
             /// <summary>
             /// Particle Texture
             /// </summary>
-            public Stream ParticleTexture
+            public TextureModel ParticleTexture
             {
                 set
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SkyBoxRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SkyBoxRenderCore.cs
@@ -83,14 +83,14 @@ namespace HelixToolkit.UWP
             #endregion
 
             #region Properties
-            private Stream cubeTexture = null;
+            private TextureModel cubeTexture = null;
             /// <summary>
             /// Gets or sets the cube texture.
             /// </summary>
             /// <value>
             /// The cube texture.
             /// </value>
-            public Stream CubeTexture
+            public TextureModel CubeTexture
             {
                 set
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SkyDomeRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SkyDomeRenderCore.cs
@@ -47,14 +47,14 @@ namespace HelixToolkit.UWP
             #endregion
 
             #region Properties
-            private Stream cubeTexture = null;
+            private TextureModel cubeTexture = null;
             /// <summary>
             /// Gets or sets the cube texture.
             /// </summary>
             /// <value>
             /// The cube texture.
             /// </value>
-            public Stream CubeTexture
+            public TextureModel CubeTexture
             {
                 set
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Core2D/Device2DProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core2D/Device2DProxy.cs
@@ -5,8 +5,6 @@ Copyright (c) 2018 Helix Toolkit contributors
 using SharpDX.Direct2D1;
 using SharpDX.Direct3D11;
 using SharpDX.DXGI;
-using System;
-using Device2D = global::SharpDX.Direct2D1.Device;
 using DeviceContext2D = global::SharpDX.Direct2D1.DeviceContext;
 
 #if !NETFX_CORE

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/IViewportExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/IViewportExtensions.cs
@@ -435,5 +435,26 @@ namespace HelixToolkit.UWP
             }
             return bounds;
         }
+
+        /// <summary>
+        /// Renders to bitmap stream.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <returns></returns>
+        public static System.IO.MemoryStream RenderToBitmapStream(this IViewport3DX view)
+        {
+            if (view.RenderHost != null && view.RenderHost.IsRendering)
+            {
+                view.RenderHost.UpdateAndRender();              
+                if (view.RenderHost != null && view.RenderHost.IsRendering)
+                {
+                    var memoryStream = new System.IO.MemoryStream();
+                    Utilities.ScreenCapture.SaveWICTextureToBitmapStream(view.RenderHost.EffectsManager, 
+                        view.RenderHost.RenderBuffer.BackBuffer.Resource as global::SharpDX.Direct3D11.Texture2D, memoryStream);
+                    return memoryStream;
+                }
+            }
+            return null;
+        }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -377,6 +377,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TokenizerHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\TreeTraverser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\Buffers\UAVBufferViewProxy.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\TypeConverters.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\VolumeDataHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -135,6 +135,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\LineMaterialCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\PBRMaterialCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\PointMaterialCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Material\TextureModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\BillboardMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\ColorStripeMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\DiffuseMaterialVariable.cs" />
@@ -179,6 +180,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\ScreenQuadNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\Sprite2DNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\VolumeTextureNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Render\RenderHost\DefaultRenderHostPartial_Properties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShaderManager\MaterialVariablePool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShaderManager\TextureResourceManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\PhongMaterialVariable.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IModels.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IModels.cs
@@ -36,7 +36,7 @@ namespace HelixToolkit.UWP
         /// <value>
         /// The texture.
         /// </value>
-        Stream Texture { get; }
+        TextureModel Texture { get; }
 
         /// <summary>
         /// Draws the texture.

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
@@ -310,7 +310,7 @@ namespace HelixToolkit.UWP
             /// <value>
             /// The cube texture.
             /// </value>
-            Stream CubeTexture { set; get; }
+            TextureModel CubeTexture { set; get; }
         }
         /// <summary>
         /// 

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/ITextureResourceManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/ITextureResourceManager.cs
@@ -12,7 +12,7 @@ namespace HelixToolkit.UWP
 {
     using System.IO;
     using Utilities;
-
+    using Model;
     public interface ITextureResourceManager
     {
         int Count { get; }
@@ -21,13 +21,13 @@ namespace HelixToolkit.UWP
         /// </summary>
         /// <param name="textureStream">The texture stream.</param>
         /// <returns></returns>
-        ShaderResourceViewProxy Register(Stream textureStream);
+        ShaderResourceViewProxy Register(TextureModel textureStream);
         /// <summary>
         /// Registers the specified texture stream.
         /// </summary>
         /// <param name="textureStream">The texture stream.</param>
         /// <param name="disableAutoGenMipMap">if set to <c>true</c> [disable automatic gen mip map].</param>
         /// <returns></returns>
-        ShaderResourceViewProxy Register(Stream textureStream, bool disableAutoGenMipMap);
+        ShaderResourceViewProxy Register(TextureModel textureStream, bool disableAutoGenMipMap);
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BillboardBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BillboardBase.cs
@@ -2,10 +2,8 @@
 The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
-using System.Collections.Generic;
 using SharpDX;
-using System.IO;
-using System.Linq;
+using System.Collections.Generic;
 #if NETFX_CORE
 
 #else
@@ -23,8 +21,6 @@ namespace HelixToolkit.UWP
 #endif
 #endif
 {
-    using Core;
-    using System;
     using System.Diagnostics;
 
     public abstract class BillboardBase : Geometry3D, IBillboardText
@@ -40,7 +36,7 @@ namespace HelixToolkit.UWP
             get;
         }
 
-        public Stream Texture
+        public TextureModel Texture
         {
             protected set;
             get;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BillboardSingleImage3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BillboardSingleImage3D.cs
@@ -115,21 +115,21 @@ namespace HelixToolkit.UWP
                 Width = image.Description.Width;
                 Height = image.Description.Height;
             }
-            Texture.Position = 0;
+            Texture.CompressedStream.Position = 0;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BillboardSingleImage3D"/> class.
         /// </summary>
-        /// <param name="imageStream">The image stream.</param>
+        /// <param name="texture">The image texture.</param>
         /// <param name="width">The width.</param>
         /// <param name="height">The height.</param>
-        public BillboardSingleImage3D(Stream imageStream, float width, float height)
+        public BillboardSingleImage3D(TextureModel texture, float width, float height)
         {
-            this.Texture = imageStream;
+            this.Texture = texture;
             Width = width;
             Height = height;
-            Texture.Position = 0;
+            Texture.CompressedStream.Position = 0;
         }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/DiffuseMaterialCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/DiffuseMaterialCore.cs
@@ -35,14 +35,14 @@ namespace HelixToolkit.UWP
                 set { Set(ref diffuseColor, value); }
                 get { return diffuseColor; }
             }
-            private Stream diffuseMap;
+            private TextureModel diffuseMap;
             /// <summary>
             /// Gets or sets the diffuse map.
             /// </summary>
             /// <value>
             /// The diffuse map.
             /// </value>
-            public Stream DiffuseMap
+            public TextureModel DiffuseMap
             {
                 set { Set(ref diffuseMap, value); }
                 get { return diffuseMap; }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/PBRMaterialCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/PBRMaterialCore.cs
@@ -216,14 +216,14 @@ namespace HelixToolkit.UWP
                 get => enableAutoTangent;
             }
 
-            private Stream albedoMap;
+            private TextureModel albedoMap;
             /// <summary>
             /// Gets or sets the albedo map.
             /// </summary>
             /// <value>
             /// The albedo map.
             /// </value>
-            public Stream AlbedoMap
+            public TextureModel AlbedoMap
             {
                 set => Set(ref albedoMap, value);
                 get => albedoMap;
@@ -236,14 +236,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string AlbedoMapFilePath { set; get; }
 
-            private Stream emissiveMap;
+            private TextureModel emissiveMap;
             /// <summary>
             /// Gets or sets the emissive map.
             /// </summary>
             /// <value>
             /// The emissive map.
             /// </value>
-            public Stream EmissiveMap
+            public TextureModel EmissiveMap
             {
                 set => Set(ref emissiveMap, value);
                 get => emissiveMap; 
@@ -256,14 +256,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string EmissiveMapFilePath { set; get; }
 
-            private Stream normalMap;
+            private TextureModel normalMap;
             /// <summary>
             /// Gets or sets the NormalMap.
             /// </summary>
             /// <value>
             /// NormalMap
             /// </value>
-            public Stream NormalMap
+            public TextureModel NormalMap
             {
                 set => Set(ref normalMap, value); 
                 get => normalMap; 
@@ -277,14 +277,14 @@ namespace HelixToolkit.UWP
             public string NormalMapFilePath { set; get; }
 
 
-            private Stream displacementMap;
+            private TextureModel displacementMap;
             /// <summary>
             /// Gets or sets the DisplacementMap.
             /// </summary>
             /// <value>
             /// DisplacementMap
             /// </value>
-            public Stream DisplacementMap
+            public TextureModel DisplacementMap
             {
                 set => Set(ref displacementMap, value); 
                 get => displacementMap; 
@@ -297,14 +297,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string DisplacementMapFilePath { set; get; }
 
-            private Stream irradianceMap;
+            private TextureModel irradianceMap;
             /// <summary>
             /// Gets or sets the irradiance map.
             /// </summary>
             /// <value>
             /// The irradiance map.
             /// </value>
-            public Stream IrradianceMap
+            public TextureModel IrradianceMap
             {
                 set => Set(ref irradianceMap, value);
                 get => irradianceMap; 
@@ -317,14 +317,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string IrradianceMapFilePath { set; get; }
 
-            private Stream rmaMap;
+            private TextureModel rmaMap;
             /// <summary>
             /// Gets or sets the Roughness, Metallic, Ambient Occlusion map. glTF2 defines occlusion as R channel, roughness as G channel, metalness as B channel
             /// </summary>
             /// <value>
             /// The rma map.
             /// </value>
-            public Stream RMAMap
+            public TextureModel RMAMap
             {
                 set => Set(ref rmaMap, value); 
                 get => rmaMap; 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/PhongMaterialCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/PhongMaterialCore.cs
@@ -110,14 +110,14 @@ namespace HelixToolkit.UWP
                 get { return specularShininess; }
             }
 
-            private Stream diffuseMap;
+            private TextureModel diffuseMap;
             /// <summary>
             /// Gets or sets the diffuse map.
             /// </summary>
             /// <value>
             /// The diffuse map.
             /// </value>
-            public Stream DiffuseMap
+            public TextureModel DiffuseMap
             {
                 set { Set(ref diffuseMap, value); }
                 get { return diffuseMap; }
@@ -131,14 +131,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string DiffuseMapFilePath { set; get; }
 
-            private Stream diffuseAlphaMap;
+            private TextureModel diffuseAlphaMap;
             /// <summary>
             /// Gets or sets the DiffuseAlphaMap.
             /// </summary>
             /// <value>
             /// DiffuseAlphaMap
             /// </value>
-            public Stream DiffuseAlphaMap
+            public TextureModel DiffuseAlphaMap
             {
                 set { Set(ref diffuseAlphaMap, value); }
                 get { return diffuseAlphaMap; }
@@ -151,14 +151,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string DiffuseAlphaMapFilePath { set; get; }
 
-            private Stream normalMap;
+            private TextureModel normalMap;
             /// <summary>
             /// Gets or sets the NormalMap.
             /// </summary>
             /// <value>
             /// NormalMap
             /// </value>
-            public Stream NormalMap
+            public TextureModel NormalMap
             {
                 set { Set(ref normalMap, value); }
                 get { return normalMap; }
@@ -171,14 +171,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string NormalMapFilePath { set; get; }
 
-            private Stream specularColorMap;
+            private TextureModel specularColorMap;
             /// <summary>
             /// Gets or sets the specular color map.
             /// </summary>
             /// <value>
             /// The specular color map.
             /// </value>
-            public Stream SpecularColorMap
+            public TextureModel SpecularColorMap
             {
                 set { Set(ref specularColorMap, value); }
                 get { return specularColorMap; }
@@ -191,14 +191,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string SpecularColorMapFilePath { set; get; }
 
-            private Stream displacementMap;
+            private TextureModel displacementMap;
             /// <summary>
             /// Gets or sets the DisplacementMap.
             /// </summary>
             /// <value>
             /// DisplacementMap
             /// </value>
-            public Stream DisplacementMap
+            public TextureModel DisplacementMap
             {
                 set { Set(ref displacementMap, value); }
                 get { return displacementMap; }
@@ -211,14 +211,14 @@ namespace HelixToolkit.UWP
             /// </value>
             public string DisplacementMapFilePath { set; get; }
 
-            private Stream emissiveMap;
+            private TextureModel emissiveMap;
             /// <summary>
             /// Gets or sets the emissive map.
             /// </summary>
             /// <value>
             /// The emissive map.
             /// </value>
-            public Stream EmissiveMap
+            public TextureModel EmissiveMap
             {
                 set { Set(ref emissiveMap, value); }
                 get { return emissiveMap; }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/TextureModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/TextureModel.cs
@@ -22,9 +22,7 @@ namespace HelixToolkit.UWP
     /// <para>For compress textures, only provide their memory stream.</para>
     /// <para>For uncompressed textures, provides either data as byte[] or Color4[] with width/height and proper <see cref="Format"/></para>
     /// </summary>
-#if !NETFX_CORE
-    [System.ComponentModel.TypeConverter(typeof(Utilities.StreamToTextureModelConverter))]
-#endif
+    [System.ComponentModel.TypeConverter(typeof(StreamToTextureModelConverter))]
     public sealed class TextureModel
     {
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/TextureModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/TextureModel.cs
@@ -1,0 +1,130 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+using SharpDX;
+using SharpDX.DXGI;
+using System;
+using System.IO;
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    /// <summary>
+    /// Texture model, used to support both compressed texture and uncompressed texture.
+    /// <para>For compress textures, only provide their memory stream.</para>
+    /// <para>For uncompressed textures, provides either data as byte[] or Color4[] with width/height and proper <see cref="Format"/></para>
+    /// </summary>
+#if !NETFX_CORE
+    [System.ComponentModel.TypeConverter(typeof(Utilities.StreamToTextureModelConverter))]
+#endif
+    public sealed class TextureModel
+    {
+        /// <summary>
+        /// The compressed stream
+        /// </summary>
+        public readonly Stream CompressedStream;
+        /// <summary>
+        /// Indicate whether this texture is compressed. Use <see cref="CompressedStream"/> if is compressed, otherwise use <see cref="NonCompressedData"/>
+        /// </summary>
+        public readonly bool IsCompressed = true;
+
+        /// <summary>
+        /// The uncompressed data
+        /// </summary>
+        public Color4[] NonCompressedData;
+
+        /// <summary>
+        /// The uncompressed format
+        /// </summary>
+        public readonly Format UncompressedFormat;
+        /// <summary>
+        /// The width. Only for uncompressed
+        /// </summary>
+        public readonly int Width;
+        /// <summary>
+        /// The height. Only for uncompressed
+        /// </summary>
+        public readonly int Height;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextureModel"/> class.
+        /// </summary>
+        public TextureModel()
+        {
+
+        }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextureModel"/> class.
+        /// </summary>
+        /// <param name="stream">The compressed texture stream. Supports Jpg, Bmp, Png, Tiff, DDS, Wmp</param>
+        public TextureModel(Stream stream)
+        {
+            CompressedStream = stream;
+        }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextureModel"/> class.
+        /// </summary>
+        /// <param name="colorArray">The color array.</param>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        /// <exception cref="ArgumentException">Width * Height = {width * height} does not equal to the Color Array Length {colorArray.Length}</exception>
+        public TextureModel(Color4[] colorArray, int width, int height)
+        {
+            if(width * height != colorArray.Length)
+            {
+                throw new ArgumentException($"Width * Height = {width * height} does not equal to the Color Array Length {colorArray.Length}");
+            }
+            NonCompressedData = colorArray;               
+            IsCompressed = false;
+            UncompressedFormat = Format.R32G32B32A32_Float;
+            Width = width;
+            Height = height;
+        }
+
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="CompressedStream"/> to <see cref="TextureModel"/>.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static implicit operator TextureModel(Stream stream)
+        {
+            return new TextureModel(stream);
+        }
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="TextureModel"/> to <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static explicit operator Stream(TextureModel model)
+        {
+            return model?.CompressedStream;
+        }
+        /// <summary>
+        /// Gets the key.
+        /// </summary>
+        /// <returns></returns>
+        internal object GetKey()
+        {
+            if (IsCompressed)
+            {
+                return CompressedStream;
+            }
+            else
+            {
+                return NonCompressedData;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/DiffuseMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/DiffuseMaterialVariable.cs
@@ -143,10 +143,10 @@ namespace HelixToolkit.UWP
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private void CreateTextureView(System.IO.Stream stream, int index)
+            private void CreateTextureView(TextureModel texture, int index)
             {
                 RemoveAndDispose(ref TextureResource);
-                TextureResource = stream == null ? null : Collect(textureManager.Register(stream));
+                TextureResource = texture == null ? null : Collect(textureManager.Register(texture));
                 if (TextureResource != null)
                 {
                     textureIndex |= 1u << index;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PBRMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PBRMaterialVariable.cs
@@ -128,10 +128,10 @@ namespace HelixToolkit.UWP
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private void CreateTextureView(System.IO.Stream stream, int index)
+            private void CreateTextureView(TextureModel texture, int index)
             {
                 RemoveAndDispose(ref TextureResources[index]);
-                TextureResources[index] = stream == null ? null : Collect(textureManager.Register(stream));
+                TextureResources[index] = texture == null ? null : Collect(textureManager.Register(texture));
                 if (TextureResources[index] != null)
                 {
                     textureIndex |= 1u << index;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PhongMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PhongMaterialVariable.cs
@@ -2,8 +2,8 @@
 The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
-using System.Runtime.CompilerServices;
 using SharpDX;
+using System.Runtime.CompilerServices;
 #if !NETFX_CORE
 namespace HelixToolkit.Wpf.SharpDX
 #else
@@ -18,7 +18,7 @@ namespace HelixToolkit.UWP
     {
         using Render;
         using ShaderManager;
-        using Shaders;       
+        using Shaders;
         using Utilities;
 
         /// <summary>
@@ -265,10 +265,10 @@ namespace HelixToolkit.UWP
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private void CreateTextureView(System.IO.Stream stream, int index)
+            private void CreateTextureView(TextureModel textureModel, int index)
             {
                 RemoveAndDispose(ref textureResources[index]);
-                textureResources[index] = stream == null ? null : Collect(textureManager.Register(stream));
+                textureResources[index] = textureModel == null ? null : Collect(textureManager.Register(textureModel));
                 if (textureResources[index] != null)
                 {
                     textureIndex |= 1u << index;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
@@ -391,6 +391,13 @@ namespace HelixToolkit.UWP
                 set => Set(ref tag, value);
                 get => tag;
             }
+            /// <summary>
+            /// Gets or sets a value indicating whether this instance is in frustum in current frame.
+            /// </summary>
+            /// <value>
+            ///   <c>true</c> if this instance is in frustum; otherwise, <c>false</c>.
+            /// </value>
+            public bool IsInFrustum { internal set; get; }
             #endregion Properties
 
             #region Events            
@@ -556,6 +563,7 @@ namespace HelixToolkit.UWP
             public virtual void Update(RenderContext context)
             {
                 IsRenderable = CanRender(context) && core.CanRenderFlag;
+                IsInFrustum = true;//Reset during update
                 if (!IsRenderable)
                 {
                     return;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/EnvironmentMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/EnvironmentMapNode.cs
@@ -30,7 +30,7 @@ namespace HelixToolkit.UWP
             /// <value>
             /// The texture.
             /// </value>
-            public Stream Texture
+            public TextureModel Texture
             {
                 set
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ParticleStormNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ParticleStormNode.cs
@@ -166,7 +166,7 @@ namespace HelixToolkit.UWP
             /// <value>
             /// The particle texture.
             /// </value>
-            public Stream ParticleTexture
+            public TextureModel ParticleTexture
             {
                 set { particleCore.ParticleTexture = value; }
                 get { return particleCore.ParticleTexture; }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenQuadNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenQuadNode.cs
@@ -29,7 +29,7 @@ namespace HelixToolkit.UWP
             /// <value>
             /// The texture.
             /// </value>
-            public Stream Texture
+            public TextureModel Texture
             {
                 set { (RenderCore as DrawScreenQuadCore).Texture = value; }
                 get { return (RenderCore as DrawScreenQuadCore).Texture; }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderBuffers/DX11SwapChainRenderBufferProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderBuffers/DX11SwapChainRenderBufferProxy.cs
@@ -94,7 +94,8 @@ namespace HelixToolkit.UWP
                     // The CreateSwapChain method is used so we can descend
                     // from this class and implement a swapchain for a desktop
                     // or a Windows 8 AppStore app
-                    return new SwapChain1(dxgiFactory2, Device, surfacePointer, ref desc);
+                    return surfacePointer == IntPtr.Zero ? new SwapChain1(dxgiFactory2, Device, ref desc) 
+                        : new SwapChain1(dxgiFactory2, Device, surfacePointer, ref desc);
                 }
             }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHostPartial_Properties.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHostPartial_Properties.cs
@@ -1,0 +1,154 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+using System.Collections.Generic;
+using System.Linq;
+
+#if DX11_1
+#else
+using Device = SharpDX.Direct3D11.Device;
+#endif
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    namespace Render
+    {
+        using Core;
+        using Model.Scene;
+        using Model.Scene2D;
+
+        public partial class DefaultRenderHost
+        {
+            #region Per frame render list
+            protected readonly FastList<SceneNode> viewportRenderables = new FastList<SceneNode>();
+            /// <summary>
+            /// The pending renderables
+            /// </summary>
+            protected readonly FastList<KeyValuePair<int, SceneNode>> perFrameFlattenedScene = new FastList<KeyValuePair<int, SceneNode>>();
+            /// <summary>
+            /// The light renderables
+            /// </summary>
+            protected readonly FastList<SceneNode> lightNodes = new FastList<SceneNode>();
+            /// <summary>
+            /// The pending render nodes
+            /// </summary>
+            protected readonly FastList<SceneNode> opaqueNodes = new FastList<SceneNode>();
+            /// <summary>
+            /// The opaque nodes in frustum
+            /// </summary>
+            protected readonly FastList<SceneNode> opaqueNodesInFrustum = new FastList<SceneNode>();
+            /// <summary>
+            /// The transparent nodes
+            /// </summary>
+            protected readonly FastList<SceneNode> transparentNodes = new FastList<SceneNode>();
+            /// <summary>
+            /// The transparent nodes in frustum
+            /// </summary>
+            protected readonly FastList<SceneNode> transparentNodesInFrustum = new FastList<SceneNode>();
+            /// <summary>
+            /// The particle nodes
+            /// </summary>
+            protected readonly FastList<SceneNode> particleNodes = new FastList<SceneNode>();
+            /// <summary>
+            /// The pending render nodes
+            /// </summary>
+            protected readonly FastList<SceneNode> preProcNodes = new FastList<SceneNode>();
+            /// <summary>
+            /// The pending render nodes
+            /// </summary>
+            protected readonly FastList<SceneNode> postProcNodes = new FastList<SceneNode>();
+            /// <summary>
+            /// The render nodes for post render
+            /// </summary>
+            protected readonly FastList<SceneNode> nodesForPostRender = new FastList<SceneNode>();
+            /// <summary>
+            /// The pending render nodes
+            /// </summary>
+            protected readonly FastList<SceneNode> screenSpacedNodes = new FastList<SceneNode>();
+
+            /// <summary>
+            /// The viewport renderable2D
+            /// </summary>
+            protected readonly FastList<SceneNode2D> viewportRenderable2D = new FastList<SceneNode2D>();
+            /// <summary>
+            /// The need update cores
+            /// </summary>
+            private readonly FastList<RenderCore> needUpdateCores = new FastList<RenderCore>();
+
+            /// <summary>
+            /// Gets the current frame flattened scene graph. KeyValuePair.Key is the depth of the node.
+            /// </summary>
+            /// <value>
+            /// Gets the current frame flattened scene graph
+            /// </value>
+            public sealed override FastList<KeyValuePair<int, SceneNode>> PerFrameFlattenedScene { get { return perFrameFlattenedScene; } }
+            /// <summary>
+            /// Gets the per frame lights.
+            /// </summary>
+            /// <value>
+            /// The per frame lights.
+            /// </value>
+            public sealed override IEnumerable<LightNode> PerFrameLights
+            {
+                get { return lightNodes.Select(x => x as LightNode); }
+            }
+            /// <summary>
+            /// Gets the per frame nodes for opaque rendering. <see cref="RenderType.Opaque"/>
+            /// <para>This does not include <see cref="RenderType.Transparent"/>, <see cref="RenderType.Particle"/>, <see cref="RenderType.PreProc"/>, <see cref="RenderType.PostProc"/>, <see cref="RenderType.Light"/>, <see cref="RenderType.ScreenSpaced"/></para>
+            /// </summary>
+            public sealed override FastList<SceneNode> PerFrameOpaqueNodes { get { return opaqueNodes; } }
+            /// <summary>
+            /// Gets the per frame opaque nodes in frustum.
+            /// </summary>
+            /// <value>
+            /// The per frame opaque nodes in frustum.
+            /// </value>
+            public sealed override FastList<SceneNode> PerFrameOpaqueNodesInFrustum { get { return opaqueNodesInFrustum; } }
+
+            /// <summary>
+            /// Gets the per frame transparent nodes in frustum.
+            /// </summary>
+            /// <value>
+            /// The per frame transparent nodes in frustum.
+            /// </value>
+            public sealed override FastList<SceneNode> PerFrameTransparentNodesInFrustum { get { return transparentNodesInFrustum; } }
+            /// <summary>
+            /// Gets the per frame transparent nodes. , <see cref="RenderType.Transparent"/>, <see cref="RenderType.Particle"/>
+            /// <para>This does not include <see cref="RenderType.Opaque"/>, <see cref="RenderType.PreProc"/>, <see cref="RenderType.PostProc"/>, <see cref="RenderType.Light"/>, <see cref="RenderType.ScreenSpaced"/></para>
+            /// </summary>
+            /// <value>
+            /// The per frame transparent nodes.
+            /// </value>
+            public sealed override FastList<SceneNode> PerFrameTransparentNodes { get { return transparentNodes; } }
+            /// <summary>
+            /// Gets the per frame transparent nodes.
+            /// </summary>
+            /// <value>
+            /// The per frame transparent nodes.
+            /// </value>
+            public sealed override FastList<SceneNode> PerFrameParticleNodes { get { return particleNodes; } }
+            /// <summary>
+            /// Gets the per frame post effects cores. It is the subset of <see cref="PerFrameOpaqueNodes"/>
+            /// </summary>
+            /// <value>
+            /// The per frame post effects cores.
+            /// </value>
+            public sealed override FastList<SceneNode> PerFrameNodesWithPostEffect
+            {
+                get { return nodesForPostRender; }
+            }
+
+            public const int FrustumPartitionSize = 500;
+            #endregion
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -324,6 +324,8 @@ namespace HelixToolkit.UWP
             {
                 private set; get;
             } = false;
+
+            private bool enableRenderFrustum = true;
             /// <summary>
             /// Gets or sets a value indicating whether [enable render frustum].
             /// </summary>
@@ -332,8 +334,17 @@ namespace HelixToolkit.UWP
             /// </value>
             public bool EnableRenderFrustum
             {
-                set; get;
-            } = true;
+                set
+                {
+                    if (enableRenderFrustum == value)
+                    {
+                        return;
+                    }
+                    enableRenderFrustum = value;
+                    FrustumEnabledChanged?.Invoke(this, value ? BoolArgs.TrueArgs : BoolArgs.FalseArgs);
+                }
+                get => enableRenderFrustum;
+            }
 
             /// <summary>
             /// Gets or sets a value indicating whether [enable sharing model mode].
@@ -534,6 +545,8 @@ namespace HelixToolkit.UWP
             public event EventHandler Rendered;
 
             private readonly Func<IDevice3DResources, IRenderer> createRendererFunction;
+
+            public event EventHandler<BoolArgs> FrustumEnabledChanged;
     #endregion
 
     #region Private variables

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
@@ -13,6 +13,7 @@ namespace HelixToolkit.UWP
 #endif
 #endif
 {
+    using Model;
     namespace Utilities
     {
         /// <summary>
@@ -115,18 +116,25 @@ namespace HelixToolkit.UWP
                 TextureFormat = view.Description.Format;
             }
             /// <summary>
-            /// Creates the view from common texture file stream. Supports Bmp, Jpg, DDS, Png.
+            /// Creates the view from texture model.
             /// </summary>
-            /// <param name="stream">The stream.</param>
+            /// <param name="texture">The stream.</param>
             /// <param name="disableAutoGenMipMap">Disable auto mipmaps generation</param>
-            public void CreateView(System.IO.Stream stream, bool disableAutoGenMipMap = false)
+            public void CreateView(TextureModel texture, bool disableAutoGenMipMap = false)
             {
                 this.DisposeAndClear();
-                if (stream != null && device != null)
+                if (texture != null && device != null)
                 {
-                    resource = Collect(TextureLoader.FromMemoryAsShaderResource(device, stream, disableAutoGenMipMap));
-                    textureView = Collect(new ShaderResourceView(device, resource));
-                    TextureFormat = textureView.Description.Format;
+                    if (texture.IsCompressed)
+                    {
+                        resource = Collect(TextureLoader.FromMemoryAsShaderResource(device, texture.CompressedStream, disableAutoGenMipMap));
+                        textureView = Collect(new ShaderResourceView(device, resource));
+                        TextureFormat = textureView.Description.Format;
+                    }
+                    else
+                    {
+                        CreateView(texture.NonCompressedData, texture.UncompressedFormat, true, disableAutoGenMipMap);
+                    }
                 }
             }
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/FrameStatistics.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/FrameStatistics.cs
@@ -141,6 +141,7 @@ namespace HelixToolkit.UWP
             int NumCore3D { get; }
             int NumTriangles { get; }
             int NumDrawCalls { get; }
+            float FrustumTestTime { get; }
             RenderDetail FrameDetail { set; get; }
             ICamera Camera { set; get; }
             string GetDetailString();
@@ -169,33 +170,40 @@ namespace HelixToolkit.UWP
             public IFrameStatistics LatencyStatistics { get; } = new FrameStatistics();
 
             /// <summary>
-            /// Gets or sets the number of model3d per frame.
+            /// Gets the number of model3d per frame.
             /// </summary>
             /// <value>
             /// The number model3d.
             /// </value>
             public int NumModel3D { internal set; get; } = 0;
             /// <summary>
-            /// Gets or sets the number of render core3d per frame.
+            /// Gets the number of render core3d per frame.
             /// </summary>
             /// <value>
             /// The number core3 d.
             /// </value>
             public int NumCore3D { internal set; get; } = 0;
             /// <summary>
-            /// Gets or sets the number triangles rendered in geometry model
+            /// Gets the number triangles rendered in geometry model
             /// </summary>
             /// <value>
             /// The number triangles.
             /// </value>
             public int NumTriangles { internal set; get; } = 0;
             /// <summary>
-            /// Gets or sets the number draw calls per frame
+            /// Gets the number draw calls per frame
             /// </summary>
             /// <value>
             /// The number draw calls.
             /// </value>
             public int NumDrawCalls { internal set; get; } = 0;
+            /// <summary>
+            /// Gets the frustum test time.
+            /// </summary>
+            /// <value>
+            /// The frustum test time.
+            /// </value>
+            public float FrustumTestTime { internal set; get; } = 0;
             /// <summary>
             /// Gets or sets the camera.
             /// </summary>
@@ -274,6 +282,7 @@ namespace HelixToolkit.UWP
                 FPSStatistics.Reset();
                 LatencyStatistics.Reset();
                 NumTriangles = NumCore3D = NumModel3D = NumDrawCalls = 0;
+                FrustumTestTime = 0;
             }
             /// <summary>
             /// Returns a <see cref="System.String" /> that represents this instance.

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/TypeConverters.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/TypeConverters.cs
@@ -1,0 +1,56 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    public sealed class StreamToTextureModelConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(Stream);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(TextureModel);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is Stream st)
+            {
+                return new TextureModel(st);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (value is TextureModel md && md.IsCompressed)
+            {
+                return md.CompressedStream;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/EnvironmentMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/EnvironmentMap3D.cs
@@ -18,10 +18,10 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// The texture property
         /// </summary>
-        public static readonly DependencyProperty TextureProperty = DependencyProperty.Register("Texture", typeof(Stream), typeof(EnvironmentMap3D),
+        public static readonly DependencyProperty TextureProperty = DependencyProperty.Register("Texture", typeof(TextureModel), typeof(EnvironmentMap3D),
             new PropertyMetadata(null, (d, e) =>
             {
-                ((d as Element3DCore).SceneNode as EnvironmentMapNode).Texture = (Stream)e.NewValue;
+                ((d as Element3DCore).SceneNode as EnvironmentMapNode).Texture = (TextureModel)e.NewValue;
             }));
         /// <summary>
         /// Gets or sets the texture.
@@ -29,7 +29,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <value>
         /// The texture.
         /// </value>
-        public Stream Texture
+        public TextureModel Texture
         {
             set
             {
@@ -37,7 +37,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             get
             {
-                return (Stream)GetValue(TextureProperty);
+                return (TextureModel)GetValue(TextureProperty);
             }
         }
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/EnvironmentMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/EnvironmentMap3D.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-
+﻿
 #if NETFX_CORE
 using Windows.UI.Xaml;
 namespace HelixToolkit.UWP

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/ParticleStormModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/ParticleStormModel3D.cs
@@ -299,15 +299,15 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        public static DependencyProperty ParticleTextureProperty = DependencyProperty.Register("ParticleTexture", typeof(Stream), typeof(ParticleStormModel3D),
+        public static DependencyProperty ParticleTextureProperty = DependencyProperty.Register("ParticleTexture", typeof(TextureModel), typeof(ParticleStormModel3D),
             new PropertyMetadata(null,
             (d, e) =>
             {
-                ((d as Element3DCore).SceneNode as ParticleStormNode).ParticleTexture = (Stream)e.NewValue;
+                ((d as Element3DCore).SceneNode as ParticleStormNode).ParticleTexture = (TextureModel)e.NewValue;
             }
             ));
 
-        public Stream ParticleTexture
+        public TextureModel ParticleTexture
         {
             set
             {
@@ -315,7 +315,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             get
             {
-                return (Stream)GetValue(ParticleTextureProperty);
+                return (TextureModel)GetValue(ParticleTextureProperty);
             }
         }
 

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/ScreenQuadModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/ScreenQuadModel3D.cs
@@ -4,7 +4,6 @@ Copyright (c) 2018 Helix Toolkit contributors
 */
 using global::SharpDX.Direct3D11;
 using System;
-using System.IO;
 #if NETFX_CORE
 using Windows.UI.Xaml;
 using Color = Windows.UI.Color;
@@ -25,16 +24,16 @@ namespace HelixToolkit.Wpf.SharpDX
     /// </summary>
     public class ScreenQuadModel3D : Element3D
     {
-        public Stream Texture
+        public TextureModel Texture
         {
-            get { return (Stream)GetValue(TextureProperty); }
+            get { return (TextureModel)GetValue(TextureProperty); }
             set { SetValue(TextureProperty, value); }
         }
 
         public static readonly DependencyProperty TextureProperty =
-            DependencyProperty.Register("Texture", typeof(Stream), typeof(ScreenQuadModel3D), new PropertyMetadata(null, (d,e)=>
+            DependencyProperty.Register("Texture", typeof(TextureModel), typeof(ScreenQuadModel3D), new PropertyMetadata(null, (d,e)=>
             {
-                ((d as ScreenQuadModel3D).SceneNode as ScreenQuadNode).Texture = (Stream)e.NewValue;
+                ((d as ScreenQuadModel3D).SceneNode as ScreenQuadNode).Texture = (TextureModel)e.NewValue;
             }));
 
 

--- a/Source/HelixToolkit.SharpDX.SharedModel/Material/DiffuseMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Material/DiffuseMaterial.cs
@@ -48,8 +48,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty DiffuseMapProperty =
-            DependencyProperty.Register("DiffuseMap", typeof(Stream), typeof(DiffuseMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as DiffuseMaterialCore).DiffuseMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("DiffuseMap", typeof(TextureModel), typeof(DiffuseMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as DiffuseMaterialCore).DiffuseMap = e.NewValue as TextureModel; }));
 
         /// <summary>
         /// Gets or sets the diffuse map.
@@ -57,9 +57,9 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <value>
         /// The diffuse map.
         /// </value>
-        public Stream DiffuseMap
+        public TextureModel DiffuseMap
         {
-            get { return (Stream)this.GetValue(DiffuseMapProperty); }
+            get { return (TextureModel)this.GetValue(DiffuseMapProperty); }
             set { this.SetValue(DiffuseMapProperty, value); }
         }
 

--- a/Source/HelixToolkit.SharpDX.SharedModel/Material/PBRMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Material/PBRMaterial.cs
@@ -100,40 +100,40 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty AlbedoMapProperty =
-            DependencyProperty.Register("AlbedoMap", typeof(Stream), typeof(PBRMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PBRMaterialCore).AlbedoMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("AlbedoMap", typeof(TextureModel), typeof(PBRMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PBRMaterialCore).AlbedoMap = e.NewValue as TextureModel; }));
         /// <summary>
         /// 
         /// </summary>
         public static readonly DependencyProperty EmissiveMapProperty =
-            DependencyProperty.Register("EmissiveMap", typeof(Stream), typeof(PBRMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PBRMaterialCore).EmissiveMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("EmissiveMap", typeof(TextureModel), typeof(PBRMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PBRMaterialCore).EmissiveMap = e.NewValue as TextureModel; }));
         /// <summary>
         /// glTF2 defines metalness as B channel, roughness as G channel, and occlusion as R channel
         /// </summary>
         public static readonly DependencyProperty RMAMapProperty =
-            DependencyProperty.Register("RMAMap", typeof(Stream), typeof(PBRMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PBRMaterialCore).RMAMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("RMAMap", typeof(TextureModel), typeof(PBRMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PBRMaterialCore).RMAMap = e.NewValue as TextureModel; }));
         /// <summary>
         /// 
         /// </summary>
         public static readonly DependencyProperty NormalMapProperty =
-            DependencyProperty.Register("NormalMap", typeof(Stream), typeof(PBRMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PBRMaterialCore).NormalMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("NormalMap", typeof(TextureModel), typeof(PBRMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PBRMaterialCore).NormalMap = e.NewValue as TextureModel; }));
 
         /// <summary>
         /// 
         /// </summary>
         public static readonly DependencyProperty DisplacementMapProperty =
-            DependencyProperty.Register("DisplacementMap", typeof(Stream), typeof(PBRMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PBRMaterialCore).DisplacementMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("DisplacementMap", typeof(TextureModel), typeof(PBRMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PBRMaterialCore).DisplacementMap = e.NewValue as TextureModel; }));
 
         /// <summary>
         /// 
         /// </summary>
         public static readonly DependencyProperty IrradianceMapProperty =
-            DependencyProperty.Register("IrrandianceMap", typeof(Stream), typeof(PBRMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PBRMaterialCore).IrradianceMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("IrrandianceMap", typeof(TextureModel), typeof(PBRMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PBRMaterialCore).IrradianceMap = e.NewValue as TextureModel; }));
 
         /// <summary>
         /// 
@@ -360,16 +360,16 @@ namespace HelixToolkit.Wpf.SharpDX
             set { this.SetValue(ClearCoatRoughnessProperty, value); }
         }
 
-        public Stream AlbedoMap
+        public TextureModel AlbedoMap
         {
-            get { return (Stream)this.GetValue(AlbedoMapProperty); }
+            get { return (TextureModel)this.GetValue(AlbedoMapProperty); }
             set { this.SetValue(AlbedoMapProperty, value); }
         }
 
 
-        public Stream EmissiveMap
+        public TextureModel EmissiveMap
         {
-            get { return (Stream)this.GetValue(EmissiveMapProperty); }
+            get { return (TextureModel)this.GetValue(EmissiveMapProperty); }
             set { this.SetValue(EmissiveMapProperty, value); }
         }
         /// <summary>
@@ -378,32 +378,32 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <value>
         /// The rma map.
         /// </value>
-        public Stream RMAMap
+        public TextureModel RMAMap
         {
-            get { return (Stream)this.GetValue(RMAMapProperty); }
+            get { return (TextureModel)this.GetValue(RMAMapProperty); }
             set { this.SetValue(RMAMapProperty, value); }
         }
         /// <summary>
         /// 
         /// </summary>
-        public Stream NormalMap
+        public TextureModel NormalMap
         {
-            get { return (Stream)this.GetValue(NormalMapProperty); }
+            get { return (TextureModel)this.GetValue(NormalMapProperty); }
             set { this.SetValue(NormalMapProperty, value); }
         }
         /// <summary>
         /// 
         /// </summary>
-        public Stream DisplacementMap
+        public TextureModel DisplacementMap
         {
-            get { return (Stream)this.GetValue(DisplacementMapProperty); }
+            get { return (TextureModel)this.GetValue(DisplacementMapProperty); }
             set { this.SetValue(DisplacementMapProperty, value); }
         }
 
 
-        public Stream IrradianceMap
+        public TextureModel IrradianceMap
         {
-            get { return (Stream)this.GetValue(IrradianceMapProperty); }
+            get { return (TextureModel)this.GetValue(IrradianceMapProperty); }
             set { this.SetValue(IrradianceMapProperty, value); }
         }
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Material/PhongMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Material/PhongMaterial.cs
@@ -90,43 +90,43 @@ namespace HelixToolkit.Wpf.SharpDX
         /// 
         /// </summary>
         public static readonly DependencyProperty DiffuseMapProperty =
-            DependencyProperty.Register("DiffuseMap", typeof(Stream), typeof(PhongMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PhongMaterialCore).DiffuseMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("DiffuseMap", typeof(TextureModel), typeof(PhongMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PhongMaterialCore).DiffuseMap = e.NewValue as TextureModel; }));
 
         /// <summary>
         /// Supports alpha channel image, such as PNG.
-        /// Usage: Load the image file(BMP, PNG, etc) as a stream.
+        /// Usage: Load the image file(BMP, PNG, etc) as a TextureModel.
         /// It can be used to replace DiffuseMap, or used as a mask and apply onto diffuse map. 
         /// The color will be cDiffuse*cAlpha.
         /// </summary>
         public static readonly DependencyProperty DiffuseAlphaMapProperty =
-            DependencyProperty.Register("DiffuseAlphaMap", typeof(Stream), typeof(PhongMaterial), new PropertyMetadata(null, 
-                (d,e)=> { ((d as Material).Core as PhongMaterialCore).DiffuseAlphaMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("DiffuseAlphaMap", typeof(TextureModel), typeof(PhongMaterial), new PropertyMetadata(null, 
+                (d,e)=> { ((d as Material).Core as PhongMaterialCore).DiffuseAlphaMap = e.NewValue as TextureModel; }));
 
         /// <summary>
         /// 
         /// </summary>
         public static readonly DependencyProperty NormalMapProperty =
-            DependencyProperty.Register("NormalMap", typeof(Stream), typeof(PhongMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PhongMaterialCore).NormalMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("NormalMap", typeof(TextureModel), typeof(PhongMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PhongMaterialCore).NormalMap = e.NewValue as TextureModel; }));
         /// <summary>
         /// 
         /// </summary>
         public static readonly DependencyProperty SpecularColorMapProperty =
-            DependencyProperty.Register("SpecularColorMap", typeof(Stream), typeof(PhongMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PhongMaterialCore).SpecularColorMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("SpecularColorMap", typeof(TextureModel), typeof(PhongMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PhongMaterialCore).SpecularColorMap = e.NewValue as TextureModel; }));
         /// <summary>
         /// 
         /// </summary>
         public static readonly DependencyProperty DisplacementMapProperty =
-            DependencyProperty.Register("DisplacementMap", typeof(Stream), typeof(PhongMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PhongMaterialCore).DisplacementMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("DisplacementMap", typeof(TextureModel), typeof(PhongMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PhongMaterialCore).DisplacementMap = e.NewValue as TextureModel; }));
         /// <summary>
         /// 
         /// </summary>
         public static readonly DependencyProperty EmissiveMapProperty =
-            DependencyProperty.Register("EmissiveMap", typeof(Stream), typeof(PhongMaterial), new PropertyMetadata(null,
-                (d, e) => { ((d as Material).Core as PhongMaterialCore).EmissiveMap = e.NewValue as Stream; }));
+            DependencyProperty.Register("EmissiveMap", typeof(TextureModel), typeof(PhongMaterial), new PropertyMetadata(null,
+                (d, e) => { ((d as Material).Core as PhongMaterialCore).EmissiveMap = e.NewValue as TextureModel; }));
         /// <summary>
         /// 
         /// </summary>
@@ -347,47 +347,47 @@ namespace HelixToolkit.Wpf.SharpDX
         /// System.Windows.Media.Brush to be applied as a System.Windows.Media.Media3D.Material
         /// to a 3-D model.
         /// </summary>
-        public Stream DiffuseMap
+        public TextureModel DiffuseMap
         {
-            get { return (Stream)this.GetValue(DiffuseMapProperty); }
+            get { return (TextureModel)this.GetValue(DiffuseMapProperty); }
             set { this.SetValue(DiffuseMapProperty, value); }
         }
 
 
-        public Stream DiffuseAlphaMap
+        public TextureModel DiffuseAlphaMap
         {
-            get { return (Stream)this.GetValue(DiffuseAlphaMapProperty); }
+            get { return (TextureModel)this.GetValue(DiffuseAlphaMapProperty); }
             set { this.SetValue(DiffuseAlphaMapProperty, value); }
         }
 
         /// <summary>
         /// 
         /// </summary>
-        public Stream NormalMap
+        public TextureModel NormalMap
         {
-            get { return (Stream)this.GetValue(NormalMapProperty); }
+            get { return (TextureModel)this.GetValue(NormalMapProperty); }
             set { this.SetValue(NormalMapProperty, value); }
         }
 
         /// <summary>
         /// 
         /// </summary>
-        public Stream SpecularColorMap
+        public TextureModel SpecularColorMap
         {
-            get { return (Stream)this.GetValue(SpecularColorMapProperty); }
+            get { return (TextureModel)this.GetValue(SpecularColorMapProperty); }
             set { this.SetValue(SpecularColorMapProperty, value); }
         }
         /// <summary>
         /// 
         /// </summary>
-        public Stream DisplacementMap
+        public TextureModel DisplacementMap
         {
-            get { return (Stream)this.GetValue(DisplacementMapProperty); }
+            get { return (TextureModel)this.GetValue(DisplacementMapProperty); }
             set { this.SetValue(DisplacementMapProperty, value); }
         }
-        public Stream EmissiveMap
+        public TextureModel EmissiveMap
         {
-            get { return (Stream)this.GetValue(EmissiveMapProperty); }
+            get { return (TextureModel)this.GetValue(EmissiveMapProperty); }
             set { this.SetValue(EmissiveMapProperty, value); }
         }
         /// <summary>

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -172,9 +172,9 @@
     <Compile Include="Model\Material\PhongMaterialFactory.cs" />
     <Compile Include="Model\Scene\SceneNode.cs" />
     <Compile Include="Properties\AssemblyDescription.cs" />
-      <Compile Include="..\AssemblyInfo.cs">
-          <Link>Properties\AssemblyInfo.cs</Link>
-      </Compile>
+    <Compile Include="..\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
     <EmbeddedResource Include="Properties\HelixToolkit.UWP.rd.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Importers/ObjReaderTests.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Importers/ObjReaderTests.cs
@@ -311,11 +311,11 @@ map_bump " + prefix + Path.GetFileName(tempTexBump) + @"
                 var material = (PhongMaterialCore)model[0].Material;
                 using(var fs = new FileStream(tempTexDiffuse, FileMode.Open))
                 {
-                    Compare(fs, material.DiffuseMap);
+                    Compare(fs, material.DiffuseMap.CompressedStream);
                 }
                 using (var fs = new FileStream(tempTexBump, FileMode.Open))
                 {
-                    Compare(fs, material.NormalMap);
+                    Compare(fs, material.NormalMap.CompressedStream);
                 }
             }
             finally
@@ -363,11 +363,11 @@ map_bump " + tempTexBump + @"
                 var material = (PhongMaterialCore)model[0].Material;
                 using(var fs = new FileStream(tempTexDiffuse, FileMode.Open))
                 {
-                    Compare(fs, material.DiffuseMap);
+                    Compare(fs, material.DiffuseMap.CompressedStream);
                 }
                 using (var fs = new FileStream(tempTexBump, FileMode.Open))
                 {
-                    Compare(fs, material.NormalMap);
+                    Compare(fs, material.NormalMap.CompressedStream);
                 }
             }
             finally

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjExporter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/ObjExporter.cs
@@ -337,7 +337,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     var texturePath = Path.Combine(this.directory, textureFilename);
 
                     // create .png bitmap file for the brush
-                    RenderBrush(texturePath, pm.DiffuseMap);
+                    RenderBrush(texturePath, pm.DiffuseMap.CompressedStream);
                     this.mwriter.WriteLine(string.Format("map_Ka {0}", textureFilename));
                 }
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverter.cs
@@ -529,4 +529,41 @@ namespace HelixToolkit.Wpf.SharpDX.Utilities
             return base.ConvertTo(context, culture, value, destinationType);
         }
     }
+
+    public sealed class StreamToTextureModelConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(System.IO.Stream);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(TextureModel);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if(value is System.IO.Stream st)
+            {
+                return new TextureModel(st);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if(value is TextureModel md && md.IsCompressed)
+            {
+                return md.CompressedStream;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverter.cs
@@ -529,41 +529,4 @@ namespace HelixToolkit.Wpf.SharpDX.Utilities
             return base.ConvertTo(context, culture, value, destinationType);
         }
     }
-
-    public sealed class StreamToTextureModelConverter : TypeConverter
-    {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-        {
-            return sourceType == typeof(System.IO.Stream);
-        }
-
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            return destinationType == typeof(TextureModel);
-        }
-
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-        {
-            if(value is System.IO.Stream st)
-            {
-                return new TextureModel(st);
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-        {
-            if(value is TextureModel md && md.IsCompressed)
-            {
-                return md.CompressedStream;
-            }
-            else
-            {
-                return null;
-            }
-        }
-    }
 }


### PR DESCRIPTION
1. Change Material Texture from `Stream` to `TextureModel`, so importer can supports embedded raw texture data. Also provider user to directly pass in Color4[] as texture. (Potential breaking change)
2. Improve frustum test.