### PR TITLE
 Re-implement GroupModel3D and ItemsModel3D and bug fixes

### DIFF
--- a/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
@@ -25,7 +25,7 @@ namespace CoreTest
         private readonly EffectsManager effectsManager;
         private CameraCore camera;
         private Geometry3D box, sphere, points, lines;
-        private GroupNode groupSphere, groupBox, groupPoints, groupLines, groupModel;
+        private GroupNode groupSphere, groupBox, groupPoints, groupLines, groupModel, groupEffects;
         private DirectionalLightNode directionalLight;
         private AmbientLightNode ambientLight;
         private const int NumItems = 400;
@@ -36,6 +36,7 @@ namespace CoreTest
         private bool resizeRequested = false;
         private CameraController cameraController;
         private Stack<IEnumerator<SceneNode>> stackCache = new Stack<IEnumerator<SceneNode>>();
+        private IApplyPostEffect currentHighlight = null;
 
         private ViewportOptions options = new ViewportOptions()
         {
@@ -141,6 +142,7 @@ namespace CoreTest
             groupBox = new GroupNode();
             groupLines = new GroupNode();
             groupPoints = new GroupNode();
+            groupEffects = new GroupNode();
             InitializeMaterials();
             materialList = materials.Values.ToArray();
             var materialCount = materialList.Length;
@@ -191,6 +193,23 @@ namespace CoreTest
             //io.KeyMap[(int)ImGuiKey.Backspace] = (int)Keys.Back;
             //io.KeyMap[(int)ImGuiKey.Enter] = (int)Keys.Enter;
             //io.KeyMap[(int)ImGuiKey.Escape] = (int)Keys.Escape;
+            groupEffects.AddChildNode(new NodePostEffectBorderHighlight() { EffectName = "highlightEffect", Color = Color.Yellow });
+            viewport.Items.AddChildNode(groupEffects);
+            viewport.NodeHitOnMouseDown += Viewport_NodeHitOnMouseDown;
+        }
+
+        private void Viewport_NodeHitOnMouseDown(object sender, SceneNodeMouseDownArgs e)
+        {
+            if(currentHighlight != null)
+            {
+                currentHighlight.PostEffects = "";
+            }
+            currentHighlight = null;
+            if(e.HitResult.ModelHit is IApplyPostEffect s)
+            {
+                currentHighlight = s;
+                currentHighlight.PostEffects = "highlightEffect";
+            }
         }
 
         private void ImGui_UpdatingImGuiUI(object sender, EventArgs e)

--- a/Source/Examples/SharpDX.Core/CoreTest/SceneUI.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/SceneUI.cs
@@ -96,7 +96,7 @@ namespace CoreTest
                 DrawSceneGraph(rootNode);
             }
 
-            if (!loading && scene != null)
+            if (!loading && scene != null && scene.Animations != null)
             {
                 DrawAnimations(scene.Animations, ref options);
             }

--- a/Source/Examples/WPF.SharpDX/GroupElementTester/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/GroupElementTester/MainViewModel.cs
@@ -49,9 +49,9 @@ namespace GroupElementTester
 
         public Transform3D Transform4 { get; } = new Media3D.TranslateTransform3D(-6, 0, 0);
 
-        public ObservableElement3DCollection GroupModelSource { get; } = new ObservableElement3DCollection();
-        public ObservableElement3DCollection TransparentGroupModelSource { get; } = new ObservableElement3DCollection();
-        public ObservableCollection<MeshDataModel> ItemsSource { get; } = new ObservableCollection<MeshDataModel>();
+        public ObservableElement3DCollection GroupModelSource { private set; get; } = new ObservableElement3DCollection();
+        public ObservableElement3DCollection TransparentGroupModelSource { private set; get; } = new ObservableElement3DCollection();
+        public ObservableCollection<MeshDataModel> ItemsSource { private set; get; } = new ObservableCollection<MeshDataModel>();
 
         private PhongMaterialCollection materialCollection = new PhongMaterialCollection();
 
@@ -74,6 +74,8 @@ namespace GroupElementTester
 
         public ICommand AnimateItemsModelCommand { private set; get; }
 
+        public ICommand ReplaceGroupSourceCommand { private set; get; }
+        public ICommand ReplaceItemsModelSourceCommand { private set; get; }
         public MainViewModel()
         {
             //    RenderTechniquesManager = new DefaultRenderTechniquesManager();           
@@ -125,8 +127,15 @@ namespace GroupElementTester
             RemoveItemsModelCommand = new RelayCommand(RemoveItemsModel);
             ClearItemsModelCommand = new RelayCommand((o) => { ItemsSource.Clear(); });
             AnimateItemsModelCommand = new RelayCommand(AnimateItemsModel);
-
-
+            ReplaceGroupSourceCommand = new RelayCommand((o) => {
+                GroupModelSource = new ObservableElement3DCollection();
+                OnPropertyChanged(nameof(GroupModelSource));
+            });
+            ReplaceItemsModelSourceCommand = new RelayCommand((o) => 
+            {
+                ItemsSource = new ObservableCollection<MeshDataModel>();
+                OnPropertyChanged(nameof(ItemsSource));
+            });
         }
 
         private void AddGroupModel(object o)

--- a/Source/Examples/WPF.SharpDX/GroupElementTester/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/GroupElementTester/MainWindow.xaml
@@ -54,24 +54,7 @@
             <hx:GroupModel3D
                 x:Name="group1"
                 ItemsSource="{Binding GroupModelSource}"
-                Transform="{Binding GroupModel3DTransform}">
-                <hx:MeshGeometryModel3D
-                    Geometry="{Binding SphereModel}"
-                    Material="{Binding RedMaterial}"
-                    Transform="{Binding Transform1}" />
-                <hx:MeshGeometryModel3D
-                    Geometry="{Binding SphereModel}"
-                    Material="{Binding RedMaterial}"
-                    Transform="{Binding Transform2}" />
-                <hx:MeshGeometryModel3D
-                    Geometry="{Binding SphereModel}"
-                    Material="{Binding RedMaterial}"
-                    Transform="{Binding Transform3}" />
-                <hx:MeshGeometryModel3D
-                    Geometry="{Binding SphereModel}"
-                    Material="{Binding RedMaterial}"
-                    Transform="{Binding Transform4}" />
-            </hx:GroupModel3D>
+                Transform="{Binding GroupModel3DTransform}" />
             <hx:ItemsModel3D
                 x:Name="itemsModel1"
                 ItemsSource="{Binding ItemsSource}"
@@ -98,11 +81,15 @@
             <Button Command="{Binding AddGroupModelCommand}">Add Group Model</Button>
             <Button Command="{Binding RemoveGroupModelCommand}">Remove Group Model</Button>
             <Button Command="{Binding ClearGroupModelCommand}">Clear Group Model</Button>
+            <Button Command="{Binding ReplaceGroupSourceCommand}">Replace Group Source</Button>
             <Button Command="{Binding AnimateGroupModelCommand}">Animate Group Model</Button>
+            <Button x:Name="detachGroupButton" Click="DetachGroupButton_Click">Detach Group</Button>
+            <Button x:Name="attachGroupButton" Click="AttachGroupButton_Click">Attach Group</Button>
             <Separator />
             <Button Command="{Binding AddItemsModelCommand}">Add Items Model</Button>
             <Button Command="{Binding RemoveItemsModelCommand}">Remove Items Model</Button>
             <Button Command="{Binding ClearItemsModelCommand}">Clear Items Model</Button>
+            <Button Command="{Binding ReplaceItemsModelSourceCommand}">Replace ItemsModel Source</Button>
             <Button Command="{Binding AnimateItemsModelCommand}">Animate Items Model</Button>
             <Separator />
             <Button Command="{Binding AddTransparentGroupModelCommand}">Add Transparent Model</Button>

--- a/Source/Examples/WPF.SharpDX/GroupElementTester/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/GroupElementTester/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HelixToolkit.Wpf.SharpDX;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -20,6 +21,8 @@ namespace GroupElementTester
     /// </summary>
     public partial class MainWindow : Window
     {
+        private GroupModel3D tempGroup;
+
         public MainWindow()
         {
             InitializeComponent();
@@ -29,6 +32,24 @@ namespace GroupElementTester
                     (DataContext as IDisposable).Dispose();
                 }
             };
+        }
+
+        private void AttachGroupButton_Click(object sender, RoutedEventArgs e)
+        {
+            if(tempGroup != null)
+            {
+                view1.Items.Add(tempGroup);
+                tempGroup = null;
+            }
+        }
+
+        private void DetachGroupButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (tempGroup == null)
+            {
+                tempGroup = group1;
+                view1.Items.Remove(group1);
+            }
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
@@ -121,6 +121,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
             {
                 currentNode = node;
                 currentNode.RaiseMouseDownEvent(this, position, hits[0]);
+                NodeHitOnMouseDown?.Invoke(this, new SceneNodeMouseDownArgs(this, position, currentNode, hits[0]));
             }
         }
         /// <summary>
@@ -132,6 +133,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
             if(currentNode != null && hits.Count > 0)
             {
                 currentNode.RaiseMouseMoveEvent(this, position, hits[0]);
+                NodeHitOnMouseMove?.Invoke(this, new SceneNodeMouseMoveArgs(this, position, currentNode, hits[0]));
             }
         }
         /// <summary>
@@ -143,6 +145,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
             if(currentNode != null && hits.Count > 0)
             {
                 currentNode.RaiseMouseUpEvent(this, position, hits[0]);
+                NodeHitOnMouseUp?.Invoke(this, new SceneNodeMouseUpArgs(this, position, currentNode, hits[0]));
             }
             hits.Clear();
             currentNode = null;

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
@@ -117,7 +117,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
             {
                 return;
             }
-            else if(this.FindHitsInFrustum(position, ref hits) && hits.Count > 0 && hits[0].ModelHit is SceneNode node)
+            else if(this.FindHits(position, ref hits) && hits.Count > 0 && hits[0].ModelHit is SceneNode node)
             {
                 currentNode = node;
                 currentNode.RaiseMouseDownEvent(this, position, hits[0]);

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCoreProperties.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCoreProperties.cs
@@ -361,6 +361,10 @@ namespace HelixToolkit.SharpDX.Core.Controls
         /// Occurs when [on error occurred].
         /// </summary>
         public event EventHandler<Exception> ErrorOccurred;
+
+        public event EventHandler<SceneNodeMouseDownArgs> NodeHitOnMouseDown;
+        public event EventHandler<SceneNodeMouseUpArgs> NodeHitOnMouseUp;
+        public event EventHandler<SceneNodeMouseMoveArgs> NodeHitOnMouseMove;
         #endregion
 
         internal ViewBoxNode ViewCube { get; } = new ViewBoxNode();

--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshOutlineBlurCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshOutlineBlurCore.cs
@@ -226,7 +226,7 @@ namespace HelixToolkit.UWP
                 {
                     using (var renderTargetBuffer = context.GetOffScreenRT(TextureSize, global::SharpDX.DXGI.Format.R8G8B8A8_UNorm))
                     {
-                        OnUpdatePerModelStruct(context);
+                        OnUpdatePerModelStruct(context);                   
                         if (drawMode == OutlineMode.Separated)
                         {
                             for (int i = 0; i < context.RenderHost.PerFrameNodesWithPostEffect.Count; ++i)
@@ -235,7 +235,6 @@ namespace HelixToolkit.UWP
                                 var mesh = context.RenderHost.PerFrameNodesWithPostEffect[i];
                                 deviceContext.SetRenderTarget(depthStencilBuffer, renderTargetBuffer, width, height, true,
                                     global::SharpDX.Color.Transparent, true, DepthStencilClearFlags.Stencil, 0, 0);
-                                modelCB.Upload(deviceContext, ref modelStruct);
                                 if (mesh.TryGetPostEffect(EffectName, out IEffectAttributes effect))
                                 {
                                     var color = Color;
@@ -295,9 +294,7 @@ namespace HelixToolkit.UWP
                                 DrawOutline(context, deviceContext, depthStencilBuffer, renderTargetBuffer, width, height);
                             }
                         }
-                    }
-            
-
+                    }           
                 }
             }
 
@@ -364,7 +361,7 @@ namespace HelixToolkit.UWP
             {
                 modelStruct.Param.M11 = scaleX;
                 modelStruct.Param.M12 = ScaleY;
-                modelStruct.Color = color;
+                modelStruct.Color = new Color4();
                 modelStruct.ViewportScale = (int)TextureSize;
             }
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/IViewportExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/IViewportExtensions.cs
@@ -99,6 +99,7 @@ namespace HelixToolkit.UWP
         /// <returns></returns>
         public static bool FindHits(this IViewport3DX viewport, Vector2 position, ref List<HitTestResult> hits)
         {
+            hits?.Clear();
             if (viewport.CameraCore is ProjectionCameraCore && viewport.RenderHost != null)
             {
                 if(!viewport.UnProject(position, out var ray))

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -100,6 +100,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interface\EventArguments.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IAnimation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\ICamera.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interface\IApplyPostEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IEffectsManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IGeometryBufferManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IGeometryBufferModel.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IApplyPostEffect.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IApplyPostEffect.cs
@@ -1,0 +1,15 @@
+﻿#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    public interface IApplyPostEffect
+    {
+        string PostEffects { set; get; }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
@@ -23,7 +23,7 @@ namespace HelixToolkit.UWP
         using Core;
         using Components;
 
-        public abstract class GeometryNode : SceneNode, IHitable, IThrowingShadow, IInstancing, IBoundable
+        public abstract class GeometryNode : SceneNode, IHitable, IThrowingShadow, IInstancing, IBoundable, IApplyPostEffect
         {
             #region Properties
 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BatchedMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BatchedMeshNode.cs
@@ -29,7 +29,7 @@ namespace HelixToolkit.UWP
         /// <see cref="Material"/> is used if <see cref="Materials"/> = null. And also used for shared material texture binding.
         /// </para>
         /// </summary>
-        public class BatchedMeshNode : SceneNode, IHitable, IThrowingShadow, IBoundable
+        public class BatchedMeshNode : SceneNode, IHitable, IThrowingShadow, IBoundable, IApplyPostEffect
         {
             #region Properties
             private BatchedMeshGeometryConfig[] geometries;

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/Abstract/GeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/Abstract/GeometryModel3D.cs
@@ -21,7 +21,7 @@ namespace HelixToolkit.Wpf.SharpDX
     /// <summary>
     /// Provides a base class for a scene model which contains geometry
     /// </summary>
-    public abstract class GeometryModel3D : Element3D, IHitable, IThrowingShadow
+    public abstract class GeometryModel3D : Element3D, IHitable, IThrowingShadow, IApplyPostEffect
     {
         #region DependencyProperties        
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/BatchedMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/BatchedMeshGeometryModel3D.cs
@@ -27,7 +27,7 @@ namespace HelixToolkit.Wpf.SharpDX
     /// <see cref="Material"/> is used if <see cref="BatchedMaterials"/> = null. And also used for shared material texture binding.
     /// </para>
     /// </summary>
-    public class BatchedMeshGeometryModel3D : Element3D, IHitable, IThrowingShadow
+    public class BatchedMeshGeometryModel3D : Element3D, IHitable, IThrowingShadow, IApplyPostEffect
     {
         #region Dependency Properties
         public IList<BatchedMeshGeometryConfig> BatchedGeometries

--- a/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
@@ -158,7 +158,7 @@ namespace HelixToolkit.UWP
         /// The nearest valid result during a hit test.
         /// </summary>
         private HitTestResult currentHit;
-
+        private List<HitTestResult> hits = new List<HitTestResult>();
         private bool enableMouseButtonHitTest = true;
         /// <summary>
         /// Occurs when each render frame finished rendering. Called directly from RenderHost after each frame. 
@@ -568,9 +568,8 @@ namespace HelixToolkit.UWP
             {
                 return;
             }
-
-            var hits = this.FindHits(pt);
-            if (hits.Count > 0)
+           
+            if (this.FindHits(pt.ToVector2(), ref hits) && hits.Count > 0)
             {
                 this.currentHit = hits.FirstOrDefault(x => x.IsValid);
                 if (this.currentHit != null)

--- a/Source/HelixToolkit.UWP/Model/Element3D/Abstract/GroupElement3D.cs
+++ b/Source/HelixToolkit.UWP/Model/Element3D/Abstract/GroupElement3D.cs
@@ -2,18 +2,16 @@
 The MIT License (MIT)
 Copyright (c) 2018 Helix Toolkit contributors
 */
-
+using System;
 using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using Windows.UI.Xaml.Markup;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Markup;
 namespace HelixToolkit.UWP
 {
     using Model.Scene;
-   
-
+    
     /// <summary>
     /// 
     /// </summary>
@@ -124,54 +122,59 @@ namespace HelixToolkit.UWP
 
         private void Items_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            if (e.OldItems != null)
-            {
-                DetachChildren(e.OldItems);
-            }           
-            if (e.Action == NotifyCollectionChangedAction.Reset)
-            {
-                Items.Clear();
-                var node = SceneNode as GroupNode;
-                node.Clear();
-                AttachChildren(sender as IList);
-                if (OctreeManager != null)
-                {
-                    Items.Add(OctreeManager);
-                }
-            }
-            else if (e.NewItems != null)
-            {
-                AttachChildren(e.NewItems);
-            }
-        }
-        /// <summary>
-        /// Attaches the children.
-        /// </summary>
-        /// <param name="children">The children.</param>
-        protected void AttachChildren(IList children)
-        {
             var node = SceneNode as GroupNode;
-            foreach (Element3D c in children)
+            switch (e.Action)
             {
-                if (node.AddChildNode(c.SceneNode))
-                {
-                    Items.Add(c);
-                }               
+                case NotifyCollectionChangedAction.Remove:
+                case NotifyCollectionChangedAction.Replace:
+                    if (e.OldItems != null)
+                    {
+                        foreach (Element3D item in e.OldItems)
+                        {
+                            if (node.RemoveChildNode(item.SceneNode))
+                            {
+                                Items.Remove(item);
+                            }
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Reset:
+                    Items.Clear();
+                    node.Clear();
+                    break;
             }
-        }
-        /// <summary>
-        /// Detaches the children.
-        /// </summary>
-        /// <param name="children">The children.</param>
-        protected void DetachChildren(IList children)
-        {
-            var node = SceneNode as GroupNode;
-            foreach (Element3D c in children)
-            {                
-                if(node.RemoveChildNode(c.SceneNode))
-                {
-                    Items.Remove(c);
-                }
+
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Reset:
+                    if (sender is IList list)
+                    {
+                        foreach (Element3D item in list)
+                        {
+                            if (node.AddChildNode(item.SceneNode))
+                            {
+                                Items.Add(item);
+                            }
+                        }
+                    }
+                    if (OctreeManager != null)
+                    {
+                        Items.Add(OctreeManager);
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Add:
+                case NotifyCollectionChangedAction.Replace:
+                    foreach (Element3D item in e.NewItems)
+                    {
+                        if (node.AddChildNode(item.SceneNode))
+                        {
+                            Items.Add(item);
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    node.MoveChildNode(e.OldStartingIndex, e.NewStartingIndex);
+                    break;
             }
         }
 
@@ -188,6 +191,11 @@ namespace HelixToolkit.UWP
                     Children.Remove(child);
                 }
             }
+            if(itemsSourceInternal == null && itemsSource != null && Children.Count > 0)
+            {
+                throw new InvalidOperationException("Children must be empty before using ItemsSource");
+            }
+            Children.Clear();
             itemsSourceInternal = itemsSource;
             if (itemsSourceInternal != null)
             {
@@ -204,19 +212,37 @@ namespace HelixToolkit.UWP
 
         private void S_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            if (e.OldItems != null)
+            switch (e.Action)
             {
-                foreach (Element3D item in e.OldItems)
-                {
-                    Children.Remove(item);
-                }
+                case NotifyCollectionChangedAction.Reset:
+                    Children.Clear();
+                    break;
+                case NotifyCollectionChangedAction.Remove:
+                case NotifyCollectionChangedAction.Replace:
+                    foreach (Element3D item in e.OldItems)
+                    {
+                        Children.Remove(item);
+                    }
+                    break;
             }
-            if (e.NewItems != null)
+            switch (e.Action)
             {
-                foreach (Element3D item in e.NewItems)
-                {
-                    Children.Add(item);
-                }
+                case NotifyCollectionChangedAction.Reset:
+                    foreach (Element3D item in itemsSourceInternal)
+                    {
+                        Children.Add(item);
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Add:
+                case NotifyCollectionChangedAction.Replace:
+                    foreach (Element3D item in e.NewItems)
+                    {
+                        Children.Add(item);
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    Children.Move(e.OldStartingIndex, e.NewStartingIndex);
+                    break;
             }
         }
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -1636,7 +1636,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 return;
             }
             
-            if (this.FindHitsInFrustum(pt.ToVector2(), ref hits))
+            if (this.FindHits(pt.ToVector2(), ref hits))
             {
                 // We can't capture Touch because that would disable the CameraController which uses Manipulation,
                 // but since Manipulation captures touch, we can be quite sure to get every relevant touch event.

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -3,15 +3,16 @@
 //   Copyright (c) 2014 Helix Toolkit contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Windows;
+using System.Windows.Markup;
 
 namespace HelixToolkit.Wpf.SharpDX
 {
-    using HelixToolkit.Wpf.SharpDX.Model.Scene;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Collections.Specialized;
-    using System.Windows;
-    using System.Windows.Markup;
+    using Model.Scene;
+    using System;
 
     /// <summary>
     /// Supports both ItemsSource binding and Xaml children. Binds with ObservableElement3DCollection 
@@ -72,17 +73,24 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private IOctreeBasic Octree
         {
-            get { return (SceneNode as GroupNode).OctreeManager == null ? null : (SceneNode as GroupNode).OctreeManager.Octree; }
+            get { return (SceneNode as GroupNode).OctreeManager?.Octree; }
         }
 
         private IList<Element3D> itemsSourceInternal;
-
+        /// <summary>
+        /// Gets the children.
+        /// </summary>
+        /// <value>
+        /// The children.
+        /// </value>
         public ObservableElement3DCollection Children
         {
             get;
         } = new ObservableElement3DCollection();
 
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GroupElement3D"/> class.
+        /// </summary>
         public GroupElement3D()
         {
             Children.CollectionChanged += Items_CollectionChanged;
@@ -91,14 +99,14 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private void GroupElement3D_Loaded(object sender, RoutedEventArgs e)
         {
-            foreach (Element3D c in Children)
+            foreach (var c in Children)
             {
                 if (c.Parent == this)
                 {
                     this.RemoveLogicalChild(c);
                 }
             }
-            foreach (Element3D c in Children)
+            foreach (var c in Children)
             {
                 if (c.Parent == null)
                 {
@@ -114,43 +122,67 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private void Items_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            if (e.OldItems != null)
-            {
-                DetachChildren(e.OldItems);
-            }            
-            if(e.Action == NotifyCollectionChangedAction.Reset)
-            {
-                AttachChildren(sender as IEnumerable);
+            var node = SceneNode as GroupNode;     
+            switch (e.Action)
+            {               
+                case NotifyCollectionChangedAction.Remove:
+                case NotifyCollectionChangedAction.Replace:
+                    if (e.OldItems != null)
+                    {
+                        foreach (Element3D item in e.OldItems)
+                        {
+                            if (item.Parent == this)
+                            {
+                                this.RemoveLogicalChild(item);
+                            }
+                            node.RemoveChildNode(item.SceneNode);
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Reset:
+                    if (e.OldItems != null)
+                    {
+                        foreach (Element3D item in e.OldItems)
+                        {
+                            if (item.Parent == this)
+                            {
+                                this.RemoveLogicalChild(item);
+                            }
+                        }
+                    }
+                    node.Clear();
+                    break;
             }
-            else if(e.NewItems != null)
-            {
-                AttachChildren(e.NewItems);
-            }
-        }
 
-        protected void AttachChildren(IEnumerable children)
-        {
-            var node = SceneNode as GroupNodeBase;
-            foreach (Element3D c in children)
+            switch (e.Action)
             {
-                if (c.Parent == null)
-                {
-                    this.AddLogicalChild(c);
-                }
-                node.AddChildNode(c.SceneNode);
-            }
-        }
-
-        protected void DetachChildren(IEnumerable children)
-        {
-            var node = SceneNode as GroupNodeBase;
-            foreach (Element3D c in children)
-            {
-                node.RemoveChildNode(c.SceneNode);
-                if (c.Parent == this)
-                {
-                    this.RemoveLogicalChild(c);
-                }
+                case NotifyCollectionChangedAction.Reset:
+                    if(sender is IList list)
+                    {
+                        foreach (Element3D item in list)
+                        {
+                            if (item.Parent == null)
+                            {
+                                this.AddLogicalChild(item);
+                            }
+                            node.AddChildNode(item.SceneNode);
+                        }
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Add:
+                case NotifyCollectionChangedAction.Replace:
+                    foreach (Element3D item in e.NewItems)
+                    {
+                        if (item.Parent == null)
+                        {
+                            this.AddLogicalChild(item);
+                        }
+                        node.AddChildNode(item.SceneNode);
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    node.MoveChildNode(e.OldStartingIndex, e.NewStartingIndex);
+                    break;
             }
         }
 
@@ -161,12 +193,14 @@ namespace HelixToolkit.Wpf.SharpDX
                 if (itemsSourceInternal is INotifyCollectionChanged s)
                 {
                     s.CollectionChanged -= S_CollectionChanged;
-                }
-                foreach(var child in itemsSourceInternal)
-                {
-                    Children.Remove(child);
-                }
+                }                
             }
+            //Must not use both ItemsSource and Children at the same time
+            if(itemsSourceInternal == null && Children.Count > 0 && itemsSource != null)
+            {
+                throw new InvalidOperationException("Children must be empty before using ItemsSource");
+            }
+            Children.Clear();
             itemsSourceInternal = itemsSource;
             if (itemsSourceInternal != null)
             {
@@ -174,28 +208,46 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     s.CollectionChanged += S_CollectionChanged;
                 }
-                foreach(var child in itemsSourceInternal)
+                foreach(Element3D item in itemsSourceInternal)
                 {
-                    Children.Add(child);
-                }    
+                    Children.Add(item);
+                }
             }
         }
 
         private void S_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            if (e.OldItems != null)
+            switch (e.Action)
             {
-                foreach(Element3D item in e.OldItems)
-                {
-                    Children.Remove(item);
-                }
+                case NotifyCollectionChangedAction.Reset:
+                    Children.Clear();
+                    break;
+                case NotifyCollectionChangedAction.Remove:
+                case NotifyCollectionChangedAction.Replace:
+                    foreach(Element3D item in e.OldItems)
+                    {
+                        Children.Remove(item);
+                    }
+                    break;
             }
-            if (e.NewItems != null)
+            switch (e.Action)
             {
-                foreach(Element3D item in e.NewItems)
-                {
-                    Children.Add(item);
-                }
+                case NotifyCollectionChangedAction.Reset:
+                    foreach(Element3D item in itemsSourceInternal)
+                    {
+                        Children.Add(item);
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Add:
+                case NotifyCollectionChangedAction.Replace:
+                    foreach(Element3D item in e.NewItems)
+                    {
+                        Children.Add(item);
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    Children.Move(e.OldStartingIndex, e.NewStartingIndex);
+                    break;
             }
         }
     }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/CompositeModel3D.cs
@@ -82,10 +82,8 @@ namespace HelixToolkit.Wpf.SharpDX
         private void ChildrenChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             var node = SceneNode as GroupNode;
-
             switch (e.Action)
             {
-                case NotifyCollectionChangedAction.Reset:
                 case NotifyCollectionChangedAction.Remove:
                 case NotifyCollectionChangedAction.Replace:
                     if (e.OldItems != null)
@@ -100,49 +98,48 @@ namespace HelixToolkit.Wpf.SharpDX
                         }
                     }
                     break;
+                case NotifyCollectionChangedAction.Reset:
+                    if (e.OldItems != null)
+                    {
+                        foreach (Element3D item in e.OldItems)
+                        {
+                            if (item.Parent == this)
+                            {
+                                this.RemoveLogicalChild(item);
+                            }
+                        }
+                    }
+                    node.Clear();
+                    break;
             }
 
-            if (e.NewItems != null)
+            switch (e.Action)
             {
-                switch (e.Action)
-                {
-                    case NotifyCollectionChangedAction.Reset:
-                        foreach (Element3D item in Children)
+                case NotifyCollectionChangedAction.Reset:
+                    foreach (Element3D item in Children)
+                    {
+                        if (item.Parent == null)
                         {
-                            if (item.Parent == null)
-                            {
-                                this.AddLogicalChild(item);
-                            }
-                            node.AddChildNode(item.SceneNode);
+                            this.AddLogicalChild(item);
                         }
-                        break;
-                    case NotifyCollectionChangedAction.Add:
-                    case NotifyCollectionChangedAction.Replace:
-                        foreach (Element3D item in e.NewItems)
+                        node.AddChildNode(item.SceneNode);
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Add:
+                case NotifyCollectionChangedAction.Replace:
+                    foreach (Element3D item in e.NewItems)
+                    {
+                        if (item.Parent == null)
                         {
-                            if (item.Parent == null)
-                            {
-                                this.AddLogicalChild(item);
-                            }
-                            node.AddChildNode(item.SceneNode);
+                            this.AddLogicalChild(item);
                         }
-                        break;
-                }
+                        node.AddChildNode(item.SceneNode);
+                    }
+                    break;
+                case NotifyCollectionChangedAction.Move:
+                    node.MoveChildNode(e.OldStartingIndex, e.NewStartingIndex);
+                    break;
             }
-        }
-
-        public virtual void Clear()
-        {
-            foreach (Element3D item in Children)
-            {
-                if (item.Parent == this)
-                {
-                    this.RemoveLogicalChild(item);
-                }
-            }
-            var node = SceneNode as GroupNode;
-            node.Clear();
-            Children.Clear();
         }
 
         protected override SceneNode OnCreateSceneNode()


### PR DESCRIPTION
1. Re-implement GroupModel3D and ItemsModel3D.  No longer support using both Children and ItemsSource at the same time (Consistent with other WPF controls). 
2. Supports observable collection Move operation.
3. Bug fixes.