### PR TITLE
Bug fixes.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Core/Controls/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/MouseGestureHandler.cs
@@ -99,7 +99,13 @@ namespace HelixToolkit.SharpDX.Core.Controls
         /// Gets or sets the mouse down Vector2 at the nearest hit element (3D world coordinates).
         /// </summary>
         protected Vector3? MouseDownNearestPoint3D;
-
+        /// <summary>
+        /// Gets or sets the mouse down nearest hit model bounding box center.
+        /// </summary>
+        /// <value>
+        /// The mouse down nearest model bound center.
+        /// </value>
+        protected Vector3? MouseDownNearestModelBoundCenter { set; get; }
         /// <summary>
         /// Gets or sets the mouse down Vector2 (2D screen coordinates).
         /// </summary>
@@ -324,14 +330,19 @@ namespace HelixToolkit.SharpDX.Core.Controls
 
             if (!this.Controller.FixedRotationPointEnabled && this.Controller.Viewport.FindHitsInFrustum(this.MouseDownPoint, ref hits))
             {
-                if (hits.Count > 0 && hits[0].ModelHit is Model.Scene.SceneNode node)
+                if (hits.Count > 0)
                 {
-                    MouseDownNearestPoint3D = node.BoundsWithTransform.Center;
+                    MouseDownNearestPoint3D = hits[0].PointHit;
+                    if (hits[0].ModelHit is Model.Scene.SceneNode node)
+                    {
+                        MouseDownNearestModelBoundCenter = node.BoundsWithTransform.Center;
+                    }
                 }
             }
             else
             {
-                this.MouseDownNearestPoint3D = null;
+                MouseDownNearestModelBoundCenter = null;
+                MouseDownNearestPoint3D = null;
             }
 
             this.MouseDownPoint3D = this.UnProject(position);

--- a/Source/HelixToolkit.SharpDX.Core/Controls/PanHandler.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/PanHandler.cs
@@ -21,10 +21,10 @@ namespace HelixToolkit.SharpDX.Core.Controls
         public override void Delta(Vector2 e)
         {
             base.Delta(e);
-            if (Camera.LookDirection.LengthSquared() < 1f && MouseDownNearestPoint3D.HasValue)
+            if (Camera.LookDirection.LengthSquared() < 1f && MouseDownNearestModelBoundCenter.HasValue)
             {
                 var look = Camera.LookDirection.Normalized();
-                var v = MouseDownNearestPoint3D.Value - Camera.Position;
+                var v = MouseDownNearestModelBoundCenter.Value - Camera.Position;
                 Camera.LookDirection = look * Vector3.Dot(v, look);
             }
             var thisPoint3D = this.UnProject(e, this.panPoint3D, this.Camera.LookDirection);
@@ -105,9 +105,9 @@ namespace HelixToolkit.SharpDX.Core.Controls
         {
             base.Started(e);
             this.panPoint3D = this.Camera.Target;
-            if (this.MouseDownNearestPoint3D.HasValue)
+            if (this.MouseDownNearestModelBoundCenter.HasValue)
             {
-                this.panPoint3D = this.MouseDownNearestPoint3D.Value;
+                this.panPoint3D = this.MouseDownNearestModelBoundCenter.Value;
             }
 
             this.LastPoint3D = this.UnProject(this.MouseDownPoint, this.panPoint3D, this.Camera.LookDirection);

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/MouseGestureHandler.cs
@@ -113,7 +113,13 @@ namespace HelixToolkit.UWP
         /// Gets or sets the mouse down point at the nearest hit element (3D world coordinates).
         /// </summary>
         protected Point3D? MouseDownNearestPoint3D;
-
+        /// <summary>
+        /// Gets or sets the mouse down nearest hit model bounding box center.
+        /// </summary>
+        /// <value>
+        /// The mouse down nearest model bound center.
+        /// </value>
+        protected Vector3? MouseDownNearestModelBoundCenter { set; get; }
         /// <summary>
         /// Gets or sets the mouse down point (2D screen coordinates).
         /// </summary>
@@ -404,19 +410,21 @@ namespace HelixToolkit.UWP
             {
                 if (hits.Count > 0)
                 {
+                    MouseDownNearestPoint3D = hits[0].PointHit;
                     if (hits[0].ModelHit is Element3D ele)
                     {
-                        this.MouseDownNearestPoint3D = ele.BoundsWithTransform.Center;
+                        MouseDownNearestModelBoundCenter = ele.BoundsWithTransform.Center;
                     }
                     else if (hits[0].ModelHit is Model.Scene.SceneNode node)
                     {
-                        MouseDownNearestPoint3D = node.BoundsWithTransform.Center;
+                        MouseDownNearestModelBoundCenter = node.BoundsWithTransform.Center;
                     }
                 }
             }
             else
             {
-                this.MouseDownNearestPoint3D = null;
+                MouseDownNearestModelBoundCenter = null;
+                MouseDownNearestPoint3D = null;
             }
 
             this.MouseDownPoint3D = this.UnProject(position);

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/PanHandler.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/PanHandler.cs
@@ -44,10 +44,10 @@ namespace HelixToolkit.UWP
         public override void Delta(Vector2 e)
         {
             base.Delta(e);
-            if (Camera.CameraInternal.LookDirection.LengthSquared() < 1f && MouseDownNearestPoint3D.HasValue)
+            if (Camera.CameraInternal.LookDirection.LengthSquared() < 1f && MouseDownNearestModelBoundCenter.HasValue)
             {
                 var look = Camera.CameraInternal.LookDirection.Normalized();
-                var v = MouseDownNearestPoint3D.Value - Camera.CameraInternal.Position;
+                var v = MouseDownNearestModelBoundCenter.Value - Camera.CameraInternal.Position;
                 Camera.CameraInternal.LookDirection = look * Math.Max(1, Vector3.Dot(v, look));
             }
             var thisPoint3D = this.UnProject(e, this.panPoint3D, this.Camera.CameraInternal.LookDirection);
@@ -127,9 +127,9 @@ namespace HelixToolkit.UWP
         {
             base.Started(e);
             this.panPoint3D = this.Camera.CameraInternal.Target;
-            if (this.MouseDownNearestPoint3D != null)
+            if (this.MouseDownNearestModelBoundCenter.HasValue)
             {
-                this.panPoint3D = this.MouseDownNearestPoint3D.Value;
+                this.panPoint3D = this.MouseDownNearestModelBoundCenter.Value;
             }
 
             this.LastPoint3D = this.UnProject(this.MouseDownPoint, this.panPoint3D, this.Camera.CameraInternal.LookDirection);

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/MouseHandlers/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/MouseHandlers/MouseGestureHandler.cs
@@ -111,6 +111,13 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Gets or sets the mouse down point at the nearest hit element (3D world coordinates).
         /// </summary>
         protected Vector3? MouseDownNearestPoint3D { get; set; }
+        /// <summary>
+        /// Gets or sets the mouse down nearest hit model bounding box center.
+        /// </summary>
+        /// <value>
+        /// The mouse down nearest model bound center.
+        /// </value>
+        protected Vector3? MouseDownNearestModelBoundCenter { set; get; }
 
         /// <summary>
         /// Gets or sets the mouse down point (2D screen coordinates).
@@ -399,19 +406,21 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 if(hits.Count > 0)
                 {
+                    MouseDownNearestPoint3D = hits[0].PointHit;
                     if(hits[0].ModelHit is Element3D ele)
                     {
-                        this.MouseDownNearestPoint3D = ele.BoundsWithTransform.Center;
+                        MouseDownNearestModelBoundCenter = ele.BoundsWithTransform.Center;
                     }
                     else if(hits[0].ModelHit is Model.Scene.SceneNode node)
                     {
-                        MouseDownNearestPoint3D = node.BoundsWithTransform.Center;
+                        MouseDownNearestModelBoundCenter = node.BoundsWithTransform.Center;
                     }
                 }               
             }
             else
             {
-                this.MouseDownNearestPoint3D = null;
+                MouseDownNearestModelBoundCenter = null;
+                MouseDownNearestPoint3D = null;
             }
 
             this.MouseDownPoint3D = this.UnProject(this.MouseDownPoint);

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/MouseHandlers/PanHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/MouseHandlers/PanHandler.cs
@@ -44,10 +44,10 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             base.Delta(e);
             var thisPoint3D = this.UnProject(e, this.panPoint3D, this.Camera.CameraInternal.LookDirection);
-            if (Camera.CameraInternal.LookDirection.LengthSquared() < 1f && MouseDownNearestPoint3D.HasValue)
+            if (Camera.CameraInternal.LookDirection.LengthSquared() < 1f && MouseDownNearestModelBoundCenter.HasValue)
             {
                 var look = Camera.CameraInternal.LookDirection.Normalized();
-                var v = MouseDownNearestPoint3D.Value - Camera.CameraInternal.Position;
+                var v = MouseDownNearestModelBoundCenter.Value - Camera.CameraInternal.Position;
                 Camera.CameraInternal.LookDirection = look * Math.Max(1, Vector3.Dot(v, look));
             }
             if (this.LastPoint3D == null || thisPoint3D == null)
@@ -127,9 +127,9 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             base.Started(e);
             this.panPoint3D = this.Camera.CameraInternal.Target;
-            if (this.MouseDownNearestPoint3D != null)
+            if (this.MouseDownNearestModelBoundCenter.HasValue)
             {
-                this.panPoint3D = this.MouseDownNearestPoint3D.Value;
+                this.panPoint3D = this.MouseDownNearestModelBoundCenter.Value;
             }
 
             this.LastPoint3D = this.UnProject(this.MouseDownPoint, this.panPoint3D, this.Camera.CameraInternal.LookDirection);

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
@@ -1249,6 +1249,7 @@ namespace HelixToolkit.Wpf
             }
         }
 
+
         /// <summary>
         /// Efficiency option, lower values decrease computation time for camera interaction when
         /// RotateAroundMouseDownPoint or ZoomAroundMouseDownPoint is set to true in inspect mode.
@@ -1300,6 +1301,10 @@ namespace HelixToolkit.Wpf
             }
         }
 
+        #region Private Variables
+        public bool LimitFPS = true;
+        private TimeSpan prevTime;
+        #endregion
         /// <summary>
         /// Adds the specified move force.
         /// </summary>
@@ -2140,6 +2145,11 @@ namespace HelixToolkit.Wpf
         /// </param>
         private void OnCompositionTargetRendering(object sender, RenderingEventArgs e)
         {
+            if (LimitFPS && prevTime == e.RenderingTime)
+            {
+                return;
+            }
+            prevTime = e.RenderingTime;
             var ticks = e.RenderingTime.Ticks;
             var time = 100e-9 * (ticks - this.lastTick);
 

--- a/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/CameraController.cs
@@ -1300,9 +1300,14 @@ namespace HelixToolkit.Wpf
                 return this.ActualCamera as PerspectiveCamera;
             }
         }
-
+        /// <summary>
+        /// Gets or sets a value indicating whether [limit FPS].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [limit FPS]; otherwise, <c>false</c>.
+        /// </value>
+        public bool LimitFPS { set; get; } = true;
         #region Private Variables
-        public bool LimitFPS = true;
         private TimeSpan prevTime;
         #endregion
         /// <summary>

--- a/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
+++ b/Source/HelixToolkit.Wpf/Controls/HelixViewport3D.cs
@@ -859,6 +859,15 @@ namespace HelixToolkit.Wpf
             "ZoomedByRectangle", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(HelixViewport3D));
 
         /// <summary>
+        /// The limit FPS property
+        /// </summary>
+        public static readonly DependencyProperty LimitFPSProperty =
+            DependencyProperty.Register("LimitFPS", typeof(bool), typeof(HelixViewport3D), new PropertyMetadata(true, (d,e)=> 
+            {
+                (d as HelixViewport3D).limitFPS = (bool)e.NewValue;
+            }));
+
+        /// <summary>
         /// The adorner layer name.
         /// </summary>
         private const string PartAdornerLayer = "PART_AdornerLayer";
@@ -3080,6 +3089,22 @@ namespace HelixToolkit.Wpf
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether [limit FPS].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [limit FPS]; otherwise, <c>false</c>.
+        /// </value>
+        public bool LimitFPS
+        {
+            get { return (bool)GetValue(LimitFPSProperty); }
+            set { SetValue(LimitFPSProperty, value); }
+        }
+
+        #region Private Variables
+        private bool limitFPS = true;
+        private TimeSpan prevTime;
+        #endregion
+        /// <summary>
         /// Changes the camera direction.
         /// </summary>
         /// <param name="newDirection">
@@ -3263,6 +3288,7 @@ namespace HelixToolkit.Wpf
                 if (this.cameraController != null)
                 {
                     this.cameraController.Viewport = this.Viewport;
+                    this.cameraController.LimitFPS = this.limitFPS;
                     this.cameraController.LookAtChanged += (s, e) => this.OnLookAtChanged();
                     this.cameraController.ZoomedByRectangle += (s, e) => this.OnZoomedByRectangle();
                 }
@@ -3646,8 +3672,13 @@ namespace HelixToolkit.Wpf
         /// </summary>
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The <see cref="System.EventArgs" /> instance containing the event data.</param>
-        private void CompositionTargetRendering(object sender, EventArgs e)
+        private void CompositionTargetRendering(object sender, RenderingEventArgs e)
         {
+            if (limitFPS && prevTime == e.RenderingTime)
+            {
+                return;
+            }
+            prevTime = e.RenderingTime;
             this.frameCounter++;
             if (this.ShowFrameRate && this.fpsWatch.ElapsedMilliseconds > 500)
             {


### PR DESCRIPTION
1. Add LimitPFS option in HelixToolkit.WPF to prevent FPS over shoot on mouse move. Default set to true.
2. Fix #1068. Zoom at mouse down point not working