### PR TITLE
Fixed exception in Closest3DPointHitTester

### DIFF
--- a/Source/HelixToolkit.Wpf/Controls/CameraController/Closest3DPointHitTester.cs
+++ b/Source/HelixToolkit.Wpf/Controls/CameraController/Closest3DPointHitTester.cs
@@ -94,7 +94,8 @@ namespace HelixToolkit.Wpf
                 (model, transform) =>
                 {
                     MeshGeometry3D geometry = model.Geometry as MeshGeometry3D;
-                    if (geometry == null || geometry.Positions == null || geometry.TriangleIndices == null)
+                    if (geometry == null || geometry.Positions == null || geometry.TriangleIndices == null ||
+                        geometry.Positions.Count == 0 || geometry.TriangleIndices.Count == 0))
                     {
                         return;
                     }


### PR DESCRIPTION
IndexOutOfBoundsException is thrown if model is empty