### PR TITLE
WPF Transform3DHelper and Visual3DHelper bug fixes

### DIFF
--- a/Source/HelixToolkit.Wpf/Helpers/Transform3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Transform3DHelper.cs
@@ -37,9 +37,7 @@ namespace HelixToolkit.Wpf
                 return t2;
             if (t1 != null && t2 == null)
                 return t1;
-            var g = new Transform3DGroup();
-            g.Children.Add(t1);
-            g.Children.Add(t2);
+            var g = new MatrixTransform3D(t1.Value * t2.Value);
             return g;
         }
 

--- a/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
@@ -152,19 +152,9 @@ namespace HelixToolkit.Wpf
                 {
                     return totalTransform;
                 }          
-                else if (obj is ModelVisual3D mv)
+                else if (obj is Visual3D mv && mv.Transform != null)
                 {
-                    if (mv.Transform != null)
-                    {
-                        totalTransform.Append(mv.Transform.Value);
-                    }
-                }
-                else if(obj is UIElement3D ui)
-                {
-                    if(ui.Transform != null)
-                    {
-                        totalTransform.Append(ui.Transform.Value);
-                    }
+                    totalTransform.Append(mv.Transform.Value);
                 }
                 obj = VisualTreeHelper.GetParent(obj);
             }

--- a/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Visual3DHelper.cs
@@ -148,21 +148,24 @@ namespace HelixToolkit.Wpf
             DependencyObject obj = visual;
             while (obj != null)
             {
-                var viewport3DVisual = obj as Viewport3DVisual;
-                if (viewport3DVisual != null)
+                if (obj is Viewport3DVisual viewport3DVisual)
                 {
                     return totalTransform;
-                }
-
-                var mv = obj as ModelVisual3D;
-                if (mv != null)
+                }          
+                else if (obj is ModelVisual3D mv)
                 {
                     if (mv.Transform != null)
                     {
                         totalTransform.Append(mv.Transform.Value);
                     }
                 }
-
+                else if(obj is UIElement3D ui)
+                {
+                    if(ui.Transform != null)
+                    {
+                        totalTransform.Append(ui.Transform.Value);
+                    }
+                }
                 obj = VisualTreeHelper.GetParent(obj);
             }
 


### PR DESCRIPTION
1. Fix Transform3DHelper.CombineTransform creates too nested Transform3DGroup #1089
2. Fix local transform not getting calculated for UIElement3D in Visual3DHelper.GetTransform(). This solve mouse rotate getting reversed issue in Rotate Manipulator.