### PR TITLE
Fix Geometry bound too small causes hit test fail.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingBoxExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingBoxExtensions.cs
@@ -42,8 +42,15 @@ namespace HelixToolkit.UWP
                 Vector3.Min(ref min, ref point, out min);
                 Vector3.Max(ref max, ref point, out max);
             }
-
-            return new BoundingBox(min, max);
+            var diff = max - min;
+            if (diff.AnySmallerOrEqual(0.0001f)) // Avoid bound too small on one dimension.
+            {
+                return new BoundingBox(min - new Vector3(0.1f), max + new Vector3(0.1f));
+            }
+            else
+            {
+                return new BoundingBox(min, max);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Avoid bound too small on one dimension. Such as bound for single axis align line. Causes line hit test failed.