### PR TITLE
Add the original EventArgs to Mouse3DEventArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 2. ManipulationBinding allows to map ManipulationGesture for UWP (UWP)
 
 ### Improvement and Changes
+1. Mouse3DEventArgs now also store the mouse/touch/pen event that caused the Mouse3DEvent #1111 (WPF.SharpDX/UWP)
 
 ### Fixed
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,6 +21,7 @@ christophano@hotmail.com
 Christof Konstantinopoulos <chrkon@web.de>
 Christof <chrkon@mail.de>
 ck <konstantinopoulos@glm-laser.com>
+Clement Bellot <clementbellot@gmail.com>
 cureos
 dgwaldo <don.g.waldo@gmail.com>
 dturvey_bhc

--- a/Source/Examples/WPF.SharpDX/LineShadingDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/LineShadingDemo/MainWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace LineShadingDemo
                 {
                     foreach (var hit in hits.Where(h => h.IsValid))
                     {
-                        (hit.ModelHit as Element3D).RaiseEvent(new MouseDown3DEventArgs(hit.ModelHit, hit, e.GetPosition(this.view1) ));
+                        (hit.ModelHit as Element3D).RaiseEvent(new MouseDown3DEventArgs(hit.ModelHit, hit, e.GetPosition(this.view1), null, e));
                         if (e.Handled)
                         {
                             break;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
@@ -979,19 +979,19 @@ namespace HelixToolkit.UWP
                 return RenderOrderKey.CompareTo(other.RenderOrderKey);
             }
 
-            public void RaiseMouseDownEvent(IViewport3DX viewport, Vector2 pos, HitTestResult hit)
+            public void RaiseMouseDownEvent(IViewport3DX viewport, Vector2 pos, HitTestResult hit, object originalInputEventArgs = null)
             {
-                MouseDown?.Invoke(this, new SceneNodeMouseDownArgs(viewport, pos, this, hit));
+                MouseDown?.Invoke(this, new SceneNodeMouseDownArgs(viewport, pos, this, hit, originalInputEventArgs));
             }
 
-            public void RaiseMouseMoveEvent(IViewport3DX viewport, Vector2 pos, HitTestResult hit)
+            public void RaiseMouseMoveEvent(IViewport3DX viewport, Vector2 pos, HitTestResult hit, object originalInputEventArgs = null)
             {
-                MouseMove?.Invoke(this, new SceneNodeMouseMoveArgs(viewport, pos, this, hit));
+                MouseMove?.Invoke(this, new SceneNodeMouseMoveArgs(viewport, pos, this, hit, originalInputEventArgs));
             }
 
-            public void RaiseMouseUpEvent(IViewport3DX viewport, Vector2 pos, HitTestResult hit)
+            public void RaiseMouseUpEvent(IViewport3DX viewport, Vector2 pos, HitTestResult hit, object originalInputEventArgs = null)
             {
-                MouseUp?.Invoke(this, new SceneNodeMouseUpArgs(viewport, pos, this, hit));
+                MouseUp?.Invoke(this, new SceneNodeMouseUpArgs(viewport, pos, this, hit, originalInputEventArgs));
             }
 
 
@@ -1051,12 +1051,14 @@ namespace HelixToolkit.UWP
             public SceneNode Source { get; }
             public IViewport3DX Viewport { get; }
             public Vector2 Position { get; }
-            public SceneNodeMouseDownArgs(IViewport3DX viewport, Vector2 pos, SceneNode node, HitTestResult hit)
+            public object OriginalInputEventArgs { get; }
+            public SceneNodeMouseDownArgs(IViewport3DX viewport, Vector2 pos, SceneNode node, HitTestResult hit, object originalInputEventArgs = null)
             {
                 Viewport = viewport;
                 Position = pos;
                 Source = node;
                 HitResult = hit;
+                OriginalInputEventArgs = originalInputEventArgs;
             }
         }
 
@@ -1066,12 +1068,14 @@ namespace HelixToolkit.UWP
             public SceneNode Source { get; }
             public IViewport3DX Viewport { get; }
             public Vector2 Position { get; }
-            public SceneNodeMouseMoveArgs(IViewport3DX viewport, Vector2 pos, SceneNode node, HitTestResult hit)
+            public object OriginalInputEventArgs { get; }
+            public SceneNodeMouseMoveArgs(IViewport3DX viewport, Vector2 pos, SceneNode node, HitTestResult hit, object originalInputEventArgs = null)
             {
                 Viewport = viewport;
                 Position = pos;
                 Source = node;
                 HitResult = hit;
+                OriginalInputEventArgs = originalInputEventArgs;
             }
         }
 
@@ -1081,12 +1085,14 @@ namespace HelixToolkit.UWP
             public SceneNode Source { get; }
             public IViewport3DX Viewport { get; }
             public Vector2 Position { get; }
-            public SceneNodeMouseUpArgs(IViewport3DX viewport, Vector2 pos, SceneNode node, HitTestResult hit)
+            public object OriginalInputEventArgs { get; }
+            public SceneNodeMouseUpArgs(IViewport3DX viewport, Vector2 pos, SceneNode node, HitTestResult hit, object originalInputEventArgs = null)
             {
                 Viewport = viewport;
                 Position = pos;
                 Source = node;
                 HitResult = hit;
+                OriginalInputEventArgs = originalInputEventArgs;
             }
         }
         #endregion

--- a/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.UWP/Controls/Viewport3DX.cs
@@ -568,7 +568,7 @@ namespace HelixToolkit.UWP
         /// </summary>
         /// <param name="pt">The hit point.</param>
         /// <param name="originalInputEventArgs">
-        /// The original input event for future use (which mouse button pressed?)
+        /// The original input event (which mouse button pressed?)
         /// </param>
         private void MouseDownHitTest(Point pt, PointerRoutedEventArgs originalInputEventArgs = null)
         {
@@ -584,11 +584,11 @@ namespace HelixToolkit.UWP
                 {
                     if (currentHit.ModelHit is Element3D ele)
                     {
-                        ele.RaiseMouseDownEvent(this.currentHit, pt, this);
+                        ele.RaiseMouseDownEvent(this.currentHit, pt, this, originalInputEventArgs);
                     }
                     else if(currentHit.ModelHit is SceneNode node)
                     {
-                        node.RaiseMouseDownEvent(this, pt.ToVector2(), currentHit);
+                        node.RaiseMouseDownEvent(this, pt.ToVector2(), currentHit, originalInputEventArgs);
                     }
                 }
             }
@@ -596,14 +596,14 @@ namespace HelixToolkit.UWP
             {
                 currentHit = null;               
             }
-            this.OnMouse3DDown?.Invoke(this, new MouseDown3DEventArgs(currentHit, pt, this));
+            this.OnMouse3DDown?.Invoke(this, new MouseDown3DEventArgs(currentHit, pt, this, originalInputEventArgs));
         }
         /// <summary>
         /// Handles hit testing on mouse move.
         /// </summary>
         /// <param name="pt">The hit point.</param>
         /// <param name="originalInputEventArgs">
-        /// The original input event for future use (which mouse button pressed?)
+        /// The original input (which mouse button pressed?)
         /// </param>
         private void MouseMoveHitTest(Point pt, PointerRoutedEventArgs originalInputEventArgs = null)
         {
@@ -615,21 +615,21 @@ namespace HelixToolkit.UWP
             {
                 if (currentHit.ModelHit is Element3D ele)
                 {
-                    ele.RaiseMouseMoveEvent(this.currentHit, pt, this);
+                    ele.RaiseMouseMoveEvent(this.currentHit, pt, this, originalInputEventArgs);
                 }
                 else if(currentHit.ModelHit is SceneNode node)
                 {
-                    node.RaiseMouseMoveEvent(this, pt.ToVector2(), currentHit);
+                    node.RaiseMouseMoveEvent(this, pt.ToVector2(), currentHit, originalInputEventArgs);
                 }
             }
-            this.OnMouse3DMove?.Invoke(this, new MouseMove3DEventArgs(currentHit, pt, this));
+            this.OnMouse3DMove?.Invoke(this, new MouseMove3DEventArgs(currentHit, pt, this, originalInputEventArgs));
         }
         /// <summary>
         /// Handles hit testing on mouse up.
         /// </summary>
         /// <param name="pt">The hit point.</param>
         /// <param name="originalInputEventArgs">
-        /// The original input event for future use (which mouse button pressed?)
+        /// The original input event (which mouse button pressed?)
         /// </param>
         private void MouseUpHitTest(Point pt, PointerRoutedEventArgs originalInputEventArgs = null)
         {
@@ -641,15 +641,15 @@ namespace HelixToolkit.UWP
             {
                 if (currentHit.ModelHit is Element3D ele)
                 {
-                    ele.RaiseMouseUpEvent(this.currentHit, pt, this);
+                    ele.RaiseMouseUpEvent(this.currentHit, pt, this, originalInputEventArgs);
                 }
                 else if(currentHit.ModelHit is SceneNode node)
                 {
-                    node.RaiseMouseUpEvent(this, pt.ToVector2(), currentHit);
+                    node.RaiseMouseUpEvent(this, pt.ToVector2(), currentHit, originalInputEventArgs);
                 }
                 currentHit = null;
             }
-            this.OnMouse3DUp?.Invoke(this, new MouseUp3DEventArgs(currentHit, pt, this));
+            this.OnMouse3DUp?.Invoke(this, new MouseUp3DEventArgs(currentHit, pt, this, originalInputEventArgs));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Source/HelixToolkit.UWP/Model/Element3D/Abstract/Element3D.cs
+++ b/Source/HelixToolkit.UWP/Model/Element3D/Abstract/Element3D.cs
@@ -8,6 +8,7 @@ using System;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Point = Windows.Foundation.Point;
 
 namespace HelixToolkit.UWP
@@ -111,17 +112,17 @@ namespace HelixToolkit.UWP
 
         private void Node_MouseMove(object sender, Model.Scene.SceneNodeMouseMoveArgs e)
         {
-            RaiseMouseMoveEvent(e.HitResult, e.Position.ToPoint(), e.Viewport as Viewport3DX);
+            RaiseMouseMoveEvent(e.HitResult, e.Position.ToPoint(), e.Viewport as Viewport3DX, e.OriginalInputEventArgs as PointerRoutedEventArgs);
         }
 
         private void Node_MouseUp(object sender, Model.Scene.SceneNodeMouseUpArgs e)
         {
-            RaiseMouseUpEvent(e.HitResult, e.Position.ToPoint(), e.Viewport as Viewport3DX);
+            RaiseMouseUpEvent(e.HitResult, e.Position.ToPoint(), e.Viewport as Viewport3DX, e.OriginalInputEventArgs as PointerRoutedEventArgs);
         }
 
         private void Node_MouseDown(object sender, Model.Scene.SceneNodeMouseDownArgs e)
         {
-            RaiseMouseDownEvent(e.HitResult, e.Position.ToPoint(), e.Viewport as Viewport3DX);
+            RaiseMouseDownEvent(e.HitResult, e.Position.ToPoint(), e.Viewport as Viewport3DX, e.OriginalInputEventArgs as PointerRoutedEventArgs);
         }
 
         protected override Size ArrangeOverride(Size finalSize)
@@ -151,19 +152,19 @@ namespace HelixToolkit.UWP
 
         public event EventHandler<MouseMove3DEventArgs> OnMouse3DMove;
 
-        internal void RaiseMouseDownEvent(HitTestResult hitTestResult, Point p, Viewport3DX viewport = null)
+        internal void RaiseMouseDownEvent(HitTestResult hitTestResult, Point p, Viewport3DX viewport = null, PointerRoutedEventArgs originalInputEventArgs = null)
         {
-            OnMouse3DDown?.Invoke(this, new MouseDown3DEventArgs(hitTestResult, p, viewport));
+            OnMouse3DDown?.Invoke(this, new MouseDown3DEventArgs(hitTestResult, p, viewport, originalInputEventArgs));
         }
 
-        internal void RaiseMouseUpEvent(HitTestResult hitTestResult, Point p, Viewport3DX viewport = null)
+        internal void RaiseMouseUpEvent(HitTestResult hitTestResult, Point p, Viewport3DX viewport = null, PointerRoutedEventArgs originalInputEventArgs = null)
         {
-            OnMouse3DUp?.Invoke(this, new MouseUp3DEventArgs(hitTestResult, p, viewport));
+            OnMouse3DUp?.Invoke(this, new MouseUp3DEventArgs(hitTestResult, p, viewport, originalInputEventArgs));
         }
 
-        internal void RaiseMouseMoveEvent(HitTestResult hitTestResult, Point p, Viewport3DX viewport = null)
+        internal void RaiseMouseMoveEvent(HitTestResult hitTestResult, Point p, Viewport3DX viewport = null, PointerRoutedEventArgs originalInputEventArgs = null)
         {
-            OnMouse3DMove?.Invoke(this, new MouseMove3DEventArgs(hitTestResult, p, viewport));
+            OnMouse3DMove?.Invoke(this, new MouseMove3DEventArgs(hitTestResult, p, viewport, originalInputEventArgs));
         }
         #endregion
     }
@@ -173,33 +174,40 @@ namespace HelixToolkit.UWP
         public HitTestResult HitTestResult { get; private set; }
         public Viewport3DX Viewport { get; private set; }
         public Point Position { get; private set; }
+        /// <summary>
+        /// The original mouse/touch event that generated this one.
+        /// 
+        /// Useful for knowing what mouse button got pressed.
+        /// </summary>
+        public PointerRoutedEventArgs OriginalInputEventArgs { get; private set; }
 
-        public Mouse3DEventArgs(HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
+        public Mouse3DEventArgs(HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, PointerRoutedEventArgs originalInputEventArgs = null)
         {
             this.HitTestResult = hitTestResult;
             this.Position = position;
             this.Viewport = viewport;
+            this.OriginalInputEventArgs = originalInputEventArgs;
         }
     }
 
     public sealed class MouseDown3DEventArgs : Mouse3DEventArgs
     {
-        public MouseDown3DEventArgs(HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
-            : base(hitTestResult, position, viewport)
+        public MouseDown3DEventArgs(HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, PointerRoutedEventArgs originalInputEventArgs = null)
+            : base(hitTestResult, position, viewport, originalInputEventArgs)
         { }
     }
 
     public sealed class MouseUp3DEventArgs : Mouse3DEventArgs
     {
-        public MouseUp3DEventArgs(HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
-            : base(hitTestResult, position, viewport)
+        public MouseUp3DEventArgs(HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, PointerRoutedEventArgs originalInputEventArgs = null)
+            : base(hitTestResult, position, viewport, originalInputEventArgs)
         { }
     }
 
     public sealed class MouseMove3DEventArgs : Mouse3DEventArgs
     {
-        public MouseMove3DEventArgs(HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
-            : base(hitTestResult, position, viewport)
+        public MouseMove3DEventArgs(HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, PointerRoutedEventArgs originalInputEventArgs = null)
+            : base(hitTestResult, position, viewport, originalInputEventArgs)
         { }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/Viewport3DX.cs
@@ -1615,7 +1615,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         /// <param name="pt">The hit point.</param>
         /// <param name="originalInputEventArgs">
-        /// The original input event for future use (which mouse button pressed?)
+        /// The original input event (which mouse button pressed?)
         /// </param>
         private void MouseDownHitTest(Point pt, InputEventArgs originalInputEventArgs = null)
         {
@@ -1628,7 +1628,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
                 return;
             }
-            if (ViewBoxHitTest(pt))
+            if (ViewBoxHitTest(pt, originalInputEventArgs))
             {
                 originalInputEventArgs.Handled = true;
                 return;
@@ -1652,12 +1652,12 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     if(currentHit.ModelHit is Element3D ele)
                     {
-                        ele.RaiseEvent(new MouseDown3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                        ele.RaiseEvent(new MouseDown3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this, originalInputEventArgs));
                     }
                     else if(currentHit.ModelHit is SceneNode sceneNode)
                     {
-                        sceneNode.RaiseMouseDownEvent(this, pt.ToVector2(), currentHit);
-                        RaiseEvent(new MouseDown3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                        sceneNode.RaiseMouseDownEvent(this, pt.ToVector2(), currentHit, originalInputEventArgs);
+                        RaiseEvent(new MouseDown3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this, originalInputEventArgs));
                     }
                 }
             }
@@ -1665,17 +1665,17 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 currentHit = null;
                 // Raise event from Viewport3DX if there's no hit
-                this.RaiseEvent(new MouseDown3DEventArgs(this, null, pt, this));
+                this.RaiseEvent(new MouseDown3DEventArgs(this, null, pt, this, originalInputEventArgs));
             }
         }
 
-        private bool ViewBoxHitTest(Point p)
+        private bool ViewBoxHitTest(Point p, InputEventArgs originalInputEventArgs = null)
         {
             var ray = this.UnProject(p.ToVector2());
             var hits = new List<HitTestResult>();
             if(viewCube.HitTest(RenderContext, ray, ref hits))
             {
-                viewCube.RaiseEvent(new MouseDown3DEventArgs(viewCube, this.currentHit, p, this));
+                viewCube.RaiseEvent(new MouseDown3DEventArgs(viewCube, this.currentHit, p, this, originalInputEventArgs));
                 var normal = hits[0].NormalAtHit;              
                 if (Vector3.Cross(normal, ModelUpDirection.ToVector3()).LengthSquared() < 1e-5)
                 {
@@ -1699,7 +1699,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         /// <param name="pt">The hit point.</param>
         /// <param name="originalInputEventArgs">
-        /// The original input event for future use (which mouse button pressed?)
+        /// The original input event (which mouse button pressed?)
         /// </param>
         private void MouseMoveHitTest(Point pt, InputEventArgs originalInputEventArgs = null)
         {
@@ -1723,18 +1723,18 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     if (currentHit.ModelHit is Element3D ele)
                     {
-                        ele.RaiseEvent(new MouseMove3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                        ele.RaiseEvent(new MouseMove3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this, originalInputEventArgs));
                     }
                     else if(currentHit.ModelHit is SceneNode sceneNode)
                     {
-                        sceneNode.RaiseMouseMoveEvent(this, pt.ToVector2(), currentHit);
-                        RaiseEvent(new MouseMove3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                        sceneNode.RaiseMouseMoveEvent(this, pt.ToVector2(), currentHit, originalInputEventArgs);
+                        RaiseEvent(new MouseMove3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this, originalInputEventArgs));
                     }
                 }
                 else
                 {
                     // Raise event from Viewport3DX if there's no hit
-                    this.RaiseEvent(new MouseMove3DEventArgs(this, null, pt, this));
+                    this.RaiseEvent(new MouseMove3DEventArgs(this, null, pt, this, originalInputEventArgs));
                 }
             }
         }
@@ -1744,7 +1744,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         /// <param name="pt">The hit point.</param>
         /// <param name="originalInputEventArgs">
-        /// The original input event for future use (which mouse button pressed?)
+        /// The original input event (which mouse button pressed?)
         /// </param>
         private void MouseUpHitTest(Point pt, InputEventArgs originalInputEventArgs = null)
         {            
@@ -1762,12 +1762,12 @@ namespace HelixToolkit.Wpf.SharpDX
                 {               
                     if(currentHit.ModelHit is Element3D ele)
                     {
-                        ele.RaiseEvent(new MouseUp3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                        ele.RaiseEvent(new MouseUp3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this, originalInputEventArgs));
                     }
                     else if(currentHit.ModelHit is SceneNode sceneNode)
                     {
-                        sceneNode.RaiseMouseUpEvent(this, pt.ToVector2(), currentHit);
-                        RaiseEvent(new MouseUp3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this));
+                        sceneNode.RaiseMouseUpEvent(this, pt.ToVector2(), currentHit, originalInputEventArgs);
+                        RaiseEvent(new MouseUp3DEventArgs(this.currentHit.ModelHit, this.currentHit, pt, this, originalInputEventArgs));
                     }
 
                     this.currentHit = null;
@@ -1776,7 +1776,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 else
                 {
                     // Raise event from Viewport3DX if there's no hit
-                    this.RaiseEvent(new MouseUp3DEventArgs(this, null, pt, this));
+                    this.RaiseEvent(new MouseUp3DEventArgs(this, null, pt, this, originalInputEventArgs));
                 }
             }
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -14,6 +14,8 @@ namespace HelixToolkit.Wpf.SharpDX
     using Transform3D = System.Windows.Media.Media3D.Transform3D;
     using System;
     using Model;
+    using System.Windows.Input;
+
     /// <summary>
     /// Base class for renderable elements.
     /// </summary>    
@@ -206,17 +208,17 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private void Node_MouseUp(object sender, Model.Scene.SceneNodeMouseUpArgs e)
         {
-            RaiseEvent(new MouseUp3DEventArgs(this, e.HitResult, new Point(e.Position.X, e.Position.Y), e.Viewport as Viewport3DX));
+            RaiseEvent(new MouseUp3DEventArgs(this, e.HitResult, new Point(e.Position.X, e.Position.Y), e.Viewport as Viewport3DX, e.OriginalInputEventArgs as InputEventArgs));
         }
 
         private void Node_MouseMove(object sender, Model.Scene.SceneNodeMouseMoveArgs e)
         {
-            RaiseEvent(new MouseMove3DEventArgs(this, e.HitResult, new Point(e.Position.X, e.Position.Y), e.Viewport as Viewport3DX));
+            RaiseEvent(new MouseMove3DEventArgs(this, e.HitResult, new Point(e.Position.X, e.Position.Y), e.Viewport as Viewport3DX, e.OriginalInputEventArgs as InputEventArgs));
         }
 
         private void Node_MouseDown(object sender, Model.Scene.SceneNodeMouseDownArgs e)
         {
-            RaiseEvent(new MouseDown3DEventArgs(this, e.HitResult, new Point(e.Position.X, e.Position.Y), e.Viewport as Viewport3DX));
+            RaiseEvent(new MouseDown3DEventArgs(this, e.HitResult, new Point(e.Position.X, e.Position.Y), e.Viewport as Viewport3DX, e.OriginalInputEventArgs as InputEventArgs));
         }
 
         /// <summary>
@@ -266,34 +268,41 @@ namespace HelixToolkit.Wpf.SharpDX
         public HitTestResult HitTestResult { get; private set; }
         public Viewport3DX Viewport { get; private set; }
         public Point Position { get; private set; }
+        /// <summary>
+        /// The original mouse/touch event that generated this one.
+        /// 
+        /// Useful for knowing what mouse button got pressed.
+        /// </summary>
+        public InputEventArgs OriginalInputEventArgs { get; private set; }
 
-        public Mouse3DEventArgs(RoutedEvent routedEvent, object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
+        public Mouse3DEventArgs(RoutedEvent routedEvent, object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, InputEventArgs originalInputEventArgs = null)
             : base(routedEvent, source)
         {
             this.HitTestResult = hitTestResult;
             this.Position = position;
             this.Viewport = viewport;
+            this.OriginalInputEventArgs = originalInputEventArgs;
         }
     }
 
     public class MouseDown3DEventArgs : Mouse3DEventArgs
     {
-        public MouseDown3DEventArgs(object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
-            : base(Element3D.MouseDown3DEvent, source, hitTestResult, position, viewport)
+        public MouseDown3DEventArgs(object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, InputEventArgs originalInputEventArgs = null)
+            : base(Element3D.MouseDown3DEvent, source, hitTestResult, position, viewport, originalInputEventArgs)
         { }
     }
 
     public class MouseUp3DEventArgs : Mouse3DEventArgs
     {
-        public MouseUp3DEventArgs(object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
-            : base(Element3D.MouseUp3DEvent, source, hitTestResult, position, viewport)
+        public MouseUp3DEventArgs(object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, InputEventArgs originalInputEventArgs = null)
+            : base(Element3D.MouseUp3DEvent, source, hitTestResult, position, viewport, originalInputEventArgs)
         { }
     }
 
     public class MouseMove3DEventArgs : Mouse3DEventArgs
     {
-        public MouseMove3DEventArgs(object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null)
-            : base(Element3D.MouseMove3DEvent, source, hitTestResult, position, viewport)
+        public MouseMove3DEventArgs(object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, InputEventArgs originalInputEventArgs = null)
+            : base(Element3D.MouseMove3DEvent, source, hitTestResult, position, viewport, originalInputEventArgs)
         { }
     }
 }


### PR DESCRIPTION
Issue #1111 

All tests passing.

The CoreTest example crashes when quitted for some reason, but it crashes in the same way on helix-toolkit/helix-toolkit/develop, so it's unrelated to my changes.