### PR TITLE
Bug fix and improvements

### DIFF
--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/Exporter.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/Exporter.cs
@@ -169,6 +169,53 @@ namespace HelixToolkit.UWP
                 }
                 return ErrorCode.Failed;
             }
+            /// <summary>
+            /// Exports to BLOB.
+            /// </summary>
+            /// <param name="root">The root.</param>
+            /// <param name="formatId">The format identifier.</param>
+            /// <param name="blob">The BLOB.</param>
+            /// <returns></returns>
+            public ErrorCode ExportToBlob(HxScene.SceneNode root, string formatId, out ExportDataBlob blob)
+            {
+                Clear();
+                AssimpContext exporter = null;
+                var useExtern = false;
+                if (Configuration.ExternalContext != null)
+                {
+                    exporter = Configuration.ExternalContext;
+                    useExtern = true;
+                }
+                else
+                {
+                    exporter = new AssimpContext();
+                }
+                var scene = CreateScene(root);
+                var postProcessing = configuration.PostProcessing;
+                if (configuration.FlipWindingOrder)
+                {
+                    postProcessing |= PostProcessSteps.FlipWindingOrder;
+                }
+                blob = null;
+                try
+                {
+                    blob = exporter.ExportToBlob(scene, formatId, postProcessing);
+                    return ErrorCode.Succeed;
+                }
+                catch (Exception ex)
+                {
+                    Log(LogLevel.Error, ex.Message);
+                }
+                finally
+                {
+                    if (!useExtern)
+                    {
+                        exporter.Dispose();
+                    }
+                }
+                
+                return ErrorCode.Failed;
+            }
 
             /// <summary>
             /// Convert a HelixToolkit scene graph to the assimp scene.
@@ -178,6 +225,7 @@ namespace HelixToolkit.UWP
             /// <returns></returns>
             public ErrorCode ToAssimpScene(HxScene.SceneNode root, out Scene assimpScene)
             {
+                Clear();
                 assimpScene = CreateScene(root);
                 return ErrorCode.Succeed;
             }

--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/Exporter.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/Exporter.cs
@@ -170,6 +170,18 @@ namespace HelixToolkit.UWP
                 return ErrorCode.Failed;
             }
 
+            /// <summary>
+            /// Convert a HelixToolkit scene graph to the assimp scene.
+            /// </summary>
+            /// <param name="root">The HelixToolkit scene graph root node.</param>
+            /// <param name="assimpScene">The assimp scene.</param>
+            /// <returns></returns>
+            public ErrorCode ToAssimpScene(HxScene.SceneNode root, out Scene assimpScene)
+            {
+                assimpScene = CreateScene(root);
+                return ErrorCode.Succeed;
+            }
+
             private Scene CreateScene(HxScene.SceneNode root)
             {
                 CollectAllGeometriesAndMaterials(root);

--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/Importer.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/Importer.cs
@@ -243,6 +243,17 @@ namespace HelixToolkit.UWP
             }
 
             /// <summary>
+            /// Converts HelixToolkit Scene directly from assimp scene. User is responsible for providing the assimp scene.
+            /// </summary>
+            /// <param name="assimpScene">The assimp scene.</param>
+            /// <param name="helixScene">The helix scene.</param>
+            /// <returns></returns>
+            public ErrorCode ToHelixToolkitScene(Scene assimpScene, out HelixToolkitScene helixScene)
+            {
+                return BuildScene(assimpScene, out helixScene);
+            }
+
+            /// <summary>
             /// Loads the specified file stream. User must provider custom texture loader to load texture files.
             /// </summary>
             /// <param name="fileStream">The file stream.</param>

--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/ImporterPartial_Mesh.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/ImporterPartial_Mesh.cs
@@ -127,7 +127,7 @@ namespace HelixToolkit.UWP
                 var hMesh = new MeshGeometry3D { Positions = hVertices, Indices = builder.TriangleIndices };
                 if (mesh.HasNormals && mesh.Normals.Count == hMesh.Positions.Count)
                 {
-                    hMesh.Normals = new Vector3Collection(mesh.Normals.Select(x => x.ToSharpDXVector3()));
+                    hMesh.Normals = new Vector3Collection(mesh.Normals.Select(x => Vector3.Normalize(x.ToSharpDXVector3())));
                 }
                 else
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
@@ -213,6 +213,14 @@ namespace HelixToolkit.UWP
         }
 
         /// <summary>
+        /// Call to manually update vertex color buffer. Use with <see cref="ObservableObject.DisablePropertyChangedEvent"/>
+        /// </summary>
+        public void UpdateColors()
+        {
+            RaisePropertyChanged(nameof(Colors));
+        }
+
+        /// <summary>
         /// Create Octree for current model.
         /// </summary>
         public void UpdateOctree(bool force = false)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
@@ -229,6 +229,14 @@ namespace HelixToolkit.UWP
             }
             return isHit;
         }
+
+        /// <summary>
+        /// Call to manually update texture coordinate buffer. Use with <see cref="ObservableObject.DisablePropertyChangedEvent"/>
+        /// </summary>
+        public void UpdateTextureCoordinates()
+        {
+            RaisePropertyChanged(nameof(TextureCoordinates));
+        }
     }
 
 

--- a/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/Composite/ViewCubeVisual3D.cs
@@ -405,7 +405,6 @@ namespace HelixToolkit.Wpf
             {
                 var element = new ModelUIElement3D();
                 EdgeModels.Add(element);
-                Children.Add(EdgeModels[i]);
                 element.MouseLeftButtonDown += FaceMouseLeftButtonDown;
                 element.MouseEnter += EdggesMouseEnters;
                 element.MouseLeave += EdgesMouseLeaves;
@@ -415,7 +414,6 @@ namespace HelixToolkit.Wpf
             {
                 var element = new ModelUIElement3D();
                 CornerModels.Add(element);
-                Children.Add(CornerModels[i]);
                 element.MouseLeftButtonDown += FaceMouseLeftButtonDown;
                 element.MouseEnter += EdggesMouseEnters;
                 element.MouseLeave += EdgesMouseLeaves;
@@ -495,48 +493,25 @@ namespace HelixToolkit.Wpf
 
         private void EnableDisableEdgeClicks()
         {
+            foreach (var item in EdgeModels)
+            {
+                Children.Remove(item);
+            }
+            foreach (var item in CornerModels)
+            {
+                Children.Remove(item);
+            }
             if (EnableEdgeClicks)
             {
                 foreach (var item in EdgeModels)
                 {
-                    item.MouseLeftButtonDown -= FaceMouseLeftButtonDown;
-                    item.MouseEnter -= EdggesMouseEnters;
-                    item.MouseLeave -= EdgesMouseLeaves;
-                    item.MouseLeftButtonDown += FaceMouseLeftButtonDown;
-                    item.MouseEnter += EdggesMouseEnters;
-                    item.MouseLeave += EdgesMouseLeaves;
-                    item.Visibility = Visibility.Visible;
-                    ModelUIElement3D s = item as ModelUIElement3D;
-                    (s.Model as GeometryModel3D).Material = MaterialHelper.CreateMaterial(EdgeBrush);
+                    (item.Model as GeometryModel3D).Material = MaterialHelper.CreateMaterial(EdgeBrush);
+                    Children.Add(item);
                 }
                 foreach (var item in CornerModels)
                 {
-                    item.MouseLeftButtonDown -= FaceMouseLeftButtonDown;
-                    item.MouseEnter -= CornersMouseEnters;
-                    item.MouseLeave -= CornersMouseLeave;
-                    item.MouseLeftButtonDown += FaceMouseLeftButtonDown;
-                    item.MouseEnter += CornersMouseEnters;
-                    item.MouseLeave += CornersMouseLeave;
-                    item.Visibility = Visibility.Visible;
-                    ModelUIElement3D s = item as ModelUIElement3D;
-                    (s.Model as GeometryModel3D).Material = MaterialHelper.CreateMaterial(CornerBrush);
-                }
-            }
-            else
-            {
-                foreach (var item in EdgeModels)
-                {
-                    item.MouseLeftButtonDown -= FaceMouseLeftButtonDown;
-                    item.MouseEnter -= EdggesMouseEnters;
-                    item.MouseLeave -= EdgesMouseLeaves;
-                    item.Visibility = Visibility.Collapsed;
-                }
-                foreach (var item in CornerModels)
-                {
-                    item.MouseLeftButtonDown -= FaceMouseLeftButtonDown;
-                    item.MouseEnter -= CornersMouseEnters;
-                    item.MouseLeave -= CornersMouseLeave;
-                    item.Visibility = Visibility.Collapsed;
+                    (item.Model as GeometryModel3D).Material = MaterialHelper.CreateMaterial(CornerBrush);
+                    Children.Add(item);
                 }
             }
         }
@@ -694,8 +669,10 @@ namespace HelixToolkit.Wpf
 
             var bmp = new RenderTargetBitmap((int)grid.Width, (int)grid.Height, 96, 96, PixelFormats.Default);
             bmp.Render(grid);
-
-            return MaterialHelper.CreateMaterial(new ImageBrush(bmp));
+            bmp.Freeze();
+            var m = MaterialHelper.CreateMaterial(new ImageBrush(bmp));
+            m.Freeze();
+            return m;
         }
 
         /// <summary>


### PR DESCRIPTION
1.  Add function to manuall trigger Vertex Color update and Texture update.  If user want to change content of Geometry3D.Colors or MeshGeometry3D.TextureCoordinates directly, user must manually call UpdateColors or UpdateTextureCoordinates function manually. (SharpDX)

2. Normalize normal data read from model file during Assimp import.(SharpDX)

3. Expose function to convert from assimp scene to helixtoolkit scene or verse versa.(SharpDX)

4. Add Assimp exporter ExportToBlob function.(SharpDX) (Ref #1113)

5. Fix viewcube threading issue if viewport is created in different ui thread. (WPF)