### PR TITLE
Fix #1130. Move to use source link. Deprecate git link.

### DIFF
--- a/Source/Examples/WPF.SharpDX/RenderTechniqueImportExport/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/RenderTechniqueImportExport/MainViewModel.cs
@@ -24,7 +24,7 @@ namespace RenderTechniqueImportExport
 
         public MainViewModel()
         {
-            EffectsManager = new DefaultEffectsManager();
+            EffectsManager = new EffectsManager();
 
             var builder = new MeshBuilder();
             builder.AddSphere(new Vector3(), 2);

--- a/Source/HelixToolkit.SharpDX.Core.Assimp/HelixToolkit.SharpDX.Core.Assimp.csproj
+++ b/Source/HelixToolkit.SharpDX.Core.Assimp/HelixToolkit.SharpDX.Core.Assimp.csproj
@@ -44,6 +44,11 @@
   <ItemGroup>
     <PackageReference Include="AssimpNet" Version="4.1.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
+    <PackageReference Include="GitLink">
+      <Version>3.1.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>	
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/HelixToolkit.SharpDX.Core.Assimp/HelixToolkit.SharpDX.Core.Assimp.csproj
+++ b/Source/HelixToolkit.SharpDX.Core.Assimp/HelixToolkit.SharpDX.Core.Assimp.csproj
@@ -43,12 +43,11 @@
     </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AssimpNet" Version="4.1.0" />
-    <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
-    <PackageReference Include="GitLink">
-      <Version>3.1.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05">
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>	
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
+++ b/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
@@ -262,6 +262,11 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
+    <PackageReference Include="GitLink">
+      <Version>3.1.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>	
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HelixToolkit\HelixToolkit.csproj" />

--- a/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
+++ b/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
@@ -250,6 +250,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="1.3.4" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
     <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
@@ -262,11 +266,6 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Include="GitLink">
-      <Version>3.1.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>	
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HelixToolkit\HelixToolkit.csproj" />

--- a/Source/HelixToolkit.SharpDX.Shared/Shaders/ShaderDescription.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Shaders/ShaderDescription.cs
@@ -51,9 +51,10 @@ namespace HelixToolkit.UWP
             /// <value>
             /// The level.
             /// </value>
+            [IgnoreDataMember]
             public FeatureLevel Level
             {
-                set; get;
+                private set; get;
             }
 
             private byte[] byteCode;
@@ -93,32 +94,32 @@ namespace HelixToolkit.UWP
             /// <value>
             /// The constant buffer mappings.
             /// </value>
-            [DataMember]
-            public ConstantBufferMapping[] ConstantBufferMappings { set; get; }
+            [IgnoreDataMember]
+            public ConstantBufferMapping[] ConstantBufferMappings { private set; get; }
             /// <summary>
             /// Gets or sets the texture mappings.
             /// </summary>
             /// <value>
             /// The texture mappings.
             /// </value>
-            [DataMember]
-            public TextureMapping[] TextureMappings { set; get; }
+            [IgnoreDataMember]
+            public TextureMapping[] TextureMappings { private set; get; }
             /// <summary>
             /// Gets or sets the uav mappings.
             /// </summary>
             /// <value>
             /// The uav mappings.
             /// </value>
-            [DataMember]
-            public UAVMapping[] UAVMappings { get; set; }
+            [IgnoreDataMember]
+            public UAVMapping[] UAVMappings { private set; get; }
             /// <summary>
             /// Gets or sets the sampler mappings.
             /// </summary>
             /// <value>
             /// The sampler mappings.
             /// </value>
-            [DataMember]
-            public SamplerMapping[] SamplerMappings { set; get; }
+            [IgnoreDataMember]
+            public SamplerMapping[] SamplerMappings { private set; get; }
 
             /// <summary>
             /// Gets or sets the shader reflector.
@@ -126,7 +127,8 @@ namespace HelixToolkit.UWP
             /// <value>
             /// The shader reflector.
             /// </value>
-            public IShaderReflector ShaderReflector { set; get; }
+            [IgnoreDataMember]
+            public IShaderReflector ShaderReflector { private set; get; }
 
             private readonly IShaderByteCodeReader byteCodeReader;
             #region GS Stream output Only
@@ -248,21 +250,20 @@ namespace HelixToolkit.UWP
                 {
                     return null;
                 }
-                if(ShaderReflector != null)
+                ShaderReflector = ShaderReflector ?? new ShaderReflector();
+                ShaderReflector.Parse(ByteCode, ShaderType);
+                Level = ShaderReflector.FeatureLevel;
+                if (Level > device.FeatureLevel)
                 {
-                    ShaderReflector.Parse(ByteCode, ShaderType);
-                    Level = ShaderReflector.FeatureLevel;
-                    if (Level > device.FeatureLevel)
-                    {
-                        logger?.Log(LogLevel.Warning, $"Shader {this.Name} requires FeatureLevel {Level}. Current device only supports FeatureLevel {device.FeatureLevel} and below.");
-                        return null;
-                        //throw new Exception($"Shader {this.Name} requires FeatureLevel {Level}. Current device only supports FeatureLevel {device.FeatureLevel} and below.");
-                    }
-                    this.ConstantBufferMappings = ShaderReflector.ConstantBufferMappings.Values.ToArray();
-                    this.TextureMappings = ShaderReflector.TextureMappings.Values.ToArray();
-                    this.UAVMappings = ShaderReflector.UAVMappings.Values.ToArray();
-                    this.SamplerMappings = ShaderReflector.SamplerMappings.Values.ToArray();
+                    logger?.Log(LogLevel.Warning, $"Shader {this.Name} requires FeatureLevel {Level}. Current device only supports FeatureLevel {device.FeatureLevel} and below.");
+                    return null;
+                    //throw new Exception($"Shader {this.Name} requires FeatureLevel {Level}. Current device only supports FeatureLevel {device.FeatureLevel} and below.");
                 }
+                this.ConstantBufferMappings = ShaderReflector.ConstantBufferMappings.Values.ToArray();
+                this.TextureMappings = ShaderReflector.TextureMappings.Values.ToArray();
+                this.UAVMappings = ShaderReflector.UAVMappings.Values.ToArray();
+                this.SamplerMappings = ShaderReflector.SamplerMappings.Values.ToArray();
+
                 ShaderBase shader = null;
                 switch (ShaderType)
                 {

--- a/Source/HelixToolkit.UWP.Assimp/HelixToolkit.UWP.Assimp.csproj
+++ b/Source/HelixToolkit.UWP.Assimp/HelixToolkit.UWP.Assimp.csproj
@@ -148,6 +148,11 @@
     <PackageReference Include="SharpDX.Mathematics">
       <Version>4.2.0</Version>
     </PackageReference>
+	<PackageReference Include="GitLink">
+      <Version>3.1.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\HelixToolkit.snk" />

--- a/Source/HelixToolkit.UWP.Assimp/HelixToolkit.UWP.Assimp.csproj
+++ b/Source/HelixToolkit.UWP.Assimp/HelixToolkit.UWP.Assimp.csproj
@@ -142,16 +142,16 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.2</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <Version>1.0.0-beta2-18618-05</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SharpDX.Direct3D11">
       <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="SharpDX.Mathematics">
       <Version>4.2.0</Version>
-    </PackageReference>
-	<PackageReference Include="GitLink">
-      <Version>3.1.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -232,6 +232,11 @@
     <PackageReference Include="System.Private.DataContractSerialization">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="GitLink">
+      <Version>3.1.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>	
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\csParticleInsert.cso">

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -205,6 +205,11 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.1.7</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <Version>1.0.0-beta2-18618-05</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SharpDX">
       <Version>4.2.0</Version>
     </PackageReference>
@@ -232,11 +237,6 @@
     <PackageReference Include="System.Private.DataContractSerialization">
       <Version>4.3.0</Version>
     </PackageReference>
-    <PackageReference Include="GitLink">
-      <Version>3.1.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>	
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\csParticleInsert.cso">

--- a/Source/HelixToolkit.Wpf.SharpDX.Assimp/HelixToolkit.Wpf.SharpDX.Assimp.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX.Assimp/HelixToolkit.Wpf.SharpDX.Assimp.csproj
@@ -79,8 +79,8 @@
     <PackageReference Include="AssimpNet">
       <Version>4.1.0</Version>
     </PackageReference>
-    <PackageReference Include="GitLink">
-      <Version>3.1.0</Version>
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <Version>1.0.0-beta2-18618-05</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/HelixToolkit.Wpf.SharpDX.Assimp/HelixToolkit.Wpf.SharpDX.Assimp.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX.Assimp/HelixToolkit.Wpf.SharpDX.Assimp.csproj
@@ -79,6 +79,11 @@
     <PackageReference Include="AssimpNet">
       <Version>4.1.0</Version>
     </PackageReference>
+    <PackageReference Include="GitLink">
+      <Version>3.1.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SharpDX.Direct3D11">
       <Version>4.2.0</Version>
     </PackageReference>

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -339,8 +339,8 @@
     <PackageReference Include="Cyotek.Drawing.BitmapFont">
       <Version>1.3.4</Version>
     </PackageReference>
-    <PackageReference Include="GitLink">
-      <Version>3.1.0</Version>
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <Version>1.0.0-beta2-18618-05</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -339,6 +339,11 @@
     <PackageReference Include="Cyotek.Drawing.BitmapFont">
       <Version>1.3.4</Version>
     </PackageReference>
+    <PackageReference Include="GitLink">
+      <Version>3.1.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="SharpDX.D3DCompiler">
       <Version>4.2.0</Version>
     </PackageReference>

--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
@@ -13,6 +13,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -325,6 +327,13 @@
       <Project>{7c0e987e-cc34-4b19-ba6b-b381aeabb530}</Project>
       <Name>HelixToolkit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="GitLink">
+      <Version>3.1.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="..\HelixToolkit.Shared\HelixToolkit.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
@@ -329,8 +329,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitLink">
-      <Version>3.1.0</Version>
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <Version>1.0.0-beta2-18618-05</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Source/HelixToolkit/HelixToolkit.csproj
+++ b/Source/HelixToolkit/HelixToolkit.csproj
@@ -17,4 +17,10 @@
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
       <DocumentationFile>bin\Release\netstandard1.1\HelixToolkit.xml</DocumentationFile>
     </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="GitLink" Version="3.1.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
 </Project>

--- a/Source/HelixToolkit/HelixToolkit.csproj
+++ b/Source/HelixToolkit/HelixToolkit.csproj
@@ -18,7 +18,7 @@
       <DocumentationFile>bin\Release\netstandard1.1\HelixToolkit.xml</DocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="GitLink" Version="3.1.0">
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,12 @@ build_script:
   - msbuild Source/HelixToolkit.AppVeyor.sln "/property:Platform=Any CPU" "/property:Version=%GitVersion_NuGetVersion%" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:SourceLinkCreate=true
 
 after_build:
-  - nuget pack Source\HelixToolkit\HelixToolkit.nuspec -version "%GitVersion_NuGetVersion%"
-  - nuget pack Source\HelixToolkit.Wpf\HelixToolkit.Wpf.nuspec -version "%GitVersion_NuGetVersion%"
-  - nuget pack Source\HelixToolkit.Wpf.SharpDX\HelixToolkit.Wpf.Sharpdx.nuspec -version "%GitVersion_NuGetVersion%"
-  - nuget pack Source\HelixToolkit.UWP\HelixToolkit.UWP.nuspec -version "%GitVersion_NuGetVersion%"
-  - nuget pack Source\HelixToolkit.SharpDX.Core\HelixToolkit.SharpDX.Core.nuspec -version "%GitVersion_NuGetVersion%"
-  - nuget pack Source\HelixToolkit.SharpDX.Assimp.nuspec -version "%GitVersion_NuGetVersion%"
+  - nuget pack Source\HelixToolkit\HelixToolkit.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
+  - nuget pack Source\HelixToolkit.Wpf\HelixToolkit.Wpf.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
+  - nuget pack Source\HelixToolkit.Wpf.SharpDX\HelixToolkit.Wpf.Sharpdx.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
+  - nuget pack Source\HelixToolkit.UWP\HelixToolkit.UWP.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
+  - nuget pack Source\HelixToolkit.SharpDX.Core\HelixToolkit.SharpDX.Core.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
+  - nuget pack Source\HelixToolkit.SharpDX.Assimp.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - if "%APPVEYOR_REPO_NAME%" == "helix-toolkit/helix-toolkit" Source\build-dist-examples.cmd
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,9 @@ artifacts:
   - path: '*.nupkg'
     name: HelixToolkit-packages-$(GitVersion_SemVer)
     type: zip
+  - path: '*.snupkg'
+    name: HelixToolkit-packages-symbols-$(GitVersion_SemVer)
+    type: zip
   - path: Source\dist-examples
     name: HelixToolkit-Examples-$(GitVersion_SemVer)
     type: zip


### PR DESCRIPTION
1. Fix RenderTechnicsExample SharpDX crash #1130
2. Move to use source link. Deprecate git link.