### PR TITLE
Fixed a bug with ShadowMap3D resetting the LightCameraProperty

### DIFF
--- a/Source/HelixToolkit.SharpDX.SharedModel/Light3D/ShadowMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Light3D/ShadowMap3D.cs
@@ -55,7 +55,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty LightCameraProperty =
                 DependencyProperty.Register("LightCamera", typeof(IProjectionCameraModel), typeof(ShadowMap3D), new PropertyMetadata(null, (d, e) =>
                 {
-                    ((d as Element3DCore).SceneNode as ShadowMapNode).LightCamera = (e.NewValue as Camera).CameraInternal as ProjectionCameraCore;
+                    ((d as Element3DCore).SceneNode as ShadowMapNode).LightCamera = (e.NewValue as Camera)?.CameraInternal as ProjectionCameraCore;
                 }));
 
         /// <summary>


### PR DESCRIPTION
When resetting a ShadowMap3D, there is a NullReferenceException thrown