### PR TITLE
Check both DataContext and EffectsManager are null before EndD3D.

### DIFF
--- a/Source/HelixToolkit.UWP/CommonDX/SwapChainRenderHost.cs
+++ b/Source/HelixToolkit.UWP/CommonDX/SwapChainRenderHost.cs
@@ -55,7 +55,7 @@ namespace HelixToolkit.UWP
 
         private void SwapChainRenderHost_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            if (DataContext == null)
+            if (DataContext == null && renderHost.EffectsManager == null)
             {
                 EndD3D();
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFCanvas.cs
@@ -151,7 +151,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 parentWindow.Closed -= ParentWindow_Closed;
             }
-            if (DataContext == null)
+            if (DataContext == null && RenderHost.EffectsManager == null)
             {
                 EndD3D();
             }

--- a/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Controls/DPFSurfaceSwapChain.cs
@@ -126,7 +126,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 parentWindow.Closed -= ParentWindow_Closed;
             }
-            if (DataContext == null)
+            if (DataContext == null && RenderHost.EffectsManager == null)
             {
                 EndD3D();
             }


### PR DESCRIPTION
Check both DataContext and EffectsManager are null before EndD3D. Ref #1120