### PR TITLE
Ensure ColorArea rect in ColorAxis does not have negative width or height

### DIFF
--- a/Source/HelixToolkit.Wpf/Controls/ColorAxis/ColorAxis.cs
+++ b/Source/HelixToolkit.Wpf/Controls/ColorAxis/ColorAxis.cs
@@ -227,14 +227,14 @@ namespace HelixToolkit.Wpf
                         this.Padding.Left,
                         this.Padding.Top,
                         this.BarWidth,
-                        this.ActualHeight - this.Padding.Bottom - this.Padding.Top);
+                        System.Math.Max(0, this.ActualHeight - this.Padding.Bottom - this.Padding.Top));
                     break;
                 case ColorAxisPosition.Right:
                     this.ColorArea = new Rect(
-                        this.ActualWidth - this.Padding.Right - this.BarWidth,
+                        System.Math.Max(0, this.ActualWidth - this.Padding.Right - this.BarWidth),
                         this.Padding.Top,
                         this.BarWidth,
-                        this.ActualHeight - this.Padding.Bottom - this.Padding.Top);
+                        System.Math.Max(0, this.ActualHeight - this.Padding.Bottom - this.Padding.Top));
                     break;
             }
 


### PR DESCRIPTION
Ensure ColorArea rect in ColorAxis does not have negative width or height. Bug can be seen in ColorAxisDemo when resizing the window, which makes the program crash because for example this.ActualHeight - this.Padding.Bottom < 0.