### PR TITLE
Bug fix

### DIFF
--- a/Source/HelixToolkit.SharpDX.Core/Controls/CameraController.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/CameraController.cs
@@ -515,7 +515,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
 
             if (this.IsInertiaEnabled)
             {
-                this.panSpeed += pan * 40;
+                this.panSpeed += pan;
             }
             else
             {
@@ -876,7 +876,17 @@ namespace HelixToolkit.SharpDX.Core.Controls
             var axis1 = Vector3.Normalize(Vector3.Cross(this.CameraLookDirection, this.CameraUpDirection));
             var axis2 = Vector3.Normalize(Vector3.Cross(axis1, this.CameraLookDirection));
             axis1 *= (ActualCamera.CreateLeftHandSystem ? -1 : 1);
-            var l = this.CameraLookDirection.Length();
+            float l = 0;
+            if (ActualCamera is PerspectiveCameraCore)
+            {
+                // this should be dependent on distance to target?
+                l = this.CameraLookDirection.Length();
+            }
+            else if (ActualCamera is OrthographicCameraCore orth)
+            {
+                // this should be dependent on width
+                l = orth.Width;
+            }
             var f = l * 0.001f;
             var move = (-axis1 * f * dx) + (axis2 * f * dy);
             // this should be dependent on distance to target?

--- a/Source/HelixToolkit.SharpDX.Core/Controls/CameraController.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/CameraController.cs
@@ -895,6 +895,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
             }
             var time = (float)(ticks - this.lastTick) / Stopwatch.Frequency;
             time = time == 0 ? 0.016f : time;
+            time = Math.Min(time, 0.05f); // Clamp the maximum time elapse to prevent over shooting
             // should be independent of time
             var factor = this.IsInertiaEnabled ? Clamp((float)Math.Pow(this.InertiaFactor, time / 0.02f), 0.1f, 1) : 0;
             bool needUpdate = false;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Camera/Camera.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Camera/Camera.cs
@@ -342,7 +342,7 @@ namespace HelixToolkit.UWP
                 }
                 else
                 {
-                    Width = oldWidth + (newWidth - oldWidth) / (accumTime / aniTime);
+                    Width = oldWidth + (newWidth - oldWidth) * (accumTime / aniTime);
                     return true;
                 }
             }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/ProjectionCamera.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/ProjectionCamera.cs
@@ -71,7 +71,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public static readonly DependencyProperty NearPlaneDistanceProperty =
             DependencyProperty.Register(
-                "NearPlaneDistance", typeof(double), typeof(ProjectionCamera), new PropertyMetadata(1e-1, (d, e) =>
+                "NearPlaneDistance", typeof(double), typeof(ProjectionCamera), new PropertyMetadata(0.01, (d, e) =>
                 {
                     ((d as Camera).CameraInternal as ProjectionCameraCore).NearPlaneDistance = (float)(double)e.NewValue;
                 }));

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
@@ -7,6 +7,7 @@ using Vector3D = SharpDX.Vector3;
 
 namespace HelixToolkit.UWP
 {
+    using Cameras;
     using System.Diagnostics;
     using Utilities;
     using Windows.UI.Core;
@@ -829,7 +830,7 @@ namespace HelixToolkit.UWP
             this.PushCameraSetting();
             if (this.Viewport.IsInertiaEnabled)
             {
-                this.panSpeed += pan * 40;
+                this.panSpeed += pan;
             }
             else
             {
@@ -1365,7 +1366,17 @@ namespace HelixToolkit.UWP
             axis1.Normalize();
             axis2.Normalize();
             axis1 *= (ActualCamera.CreateLeftHandSystem ? -1 : 1);
-            var l = this.CameraLookDirection.Length();
+            float l = 0;
+            if (ActualCamera is PerspectiveCamera)
+            {
+                // this should be dependent on distance to target?
+                l = this.CameraLookDirection.Length();
+            }
+            else if (ActualCamera.CameraInternal is OrthographicCameraCore orth)
+            {
+                // this should be dependent on width
+                l = orth.Width;
+            }
             var f = l * 0.001f;
             var move = (-axis1 * f * (float)dx) + (axis2 * f * (float)dy);
 

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
@@ -1387,6 +1387,7 @@ namespace HelixToolkit.UWP
             }
             var time = (float)(ticks - this.lastTick) / Stopwatch.Frequency;
             time = time == 0 ? 0.016f : time;
+            time = Math.Min(time, 0.05f); // Clamp the maximum time elapse to prevent over shooting
             // should be independent of time
             var factor = Viewport.IsInertiaEnabled ? (float)Clamp(Math.Pow(Viewport.CameraInertiaFactor, time / 0.02f), 0.1f, 1) : 0;
             bool needUpdate = false;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
@@ -1422,6 +1422,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             var time = (float)(ticks - this.lastTick) / Stopwatch.Frequency;
             time = time == 0 ? 0.016f : time;
+            time = Math.Min(time, 0.05f); // Clamp the maximum time elapse to prevent over shooting
             // should be independent of time
             var factor = this.IsInertiaEnabled ? (float)Clamp(Math.Pow(this.InertiaFactor, time / 0.02f), 0.1f, 1) : 0;
             bool needUpdate = false;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
@@ -17,9 +17,13 @@ using Vector2 = global::SharpDX.Vector2;
 #if COREWPF
 using HelixToolkit.SharpDX.Core;
 using HelixToolkit.SharpDX.Core.Utilities;
+using HelixToolkit.SharpDX.Model.Cameras;
+#else
+using HelixToolkit.Wpf.SharpDX.Cameras;
 #endif
 namespace HelixToolkit.Wpf.SharpDX
 {
+
 #if !COREWPF
     using Utilities;
 #endif
@@ -616,7 +620,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.PushCameraSetting();
             if (this.IsInertiaEnabled)
             {
-                this.panSpeed += pan * 40;
+                this.panSpeed += pan;
             }
             else
             {
@@ -1212,10 +1216,19 @@ namespace HelixToolkit.Wpf.SharpDX
             var axis1 = Vector3.Normalize(Vector3.Cross(this.CameraLookDirection, this.CameraUpDirection));
             var axis2 = Vector3.Normalize(Vector3.Cross(axis1, this.CameraLookDirection));
             axis1 *= (ActualCamera.CreateLeftHandSystem ? -1 : 1);
-            var l = this.CameraLookDirection.Length();
+            float l = 0;
+            if(actualCamera is PerspectiveCamera)
+            {
+                // this should be dependent on distance to target?
+                l = this.CameraLookDirection.Length();
+            }
+            else if (actualCamera.CameraInternal is OrthographicCameraCore orth)
+            {
+                // this should be dependent on width
+                l = orth.Width;
+            }
             var f = l * 0.001f;
             var move = (-axis1 * f * dx) + (axis2 * f * dy);
-            // this should be dependent on distance to target?
             return move;
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
@@ -17,7 +17,7 @@ using Vector2 = global::SharpDX.Vector2;
 #if COREWPF
 using HelixToolkit.SharpDX.Core;
 using HelixToolkit.SharpDX.Core.Utilities;
-using HelixToolkit.SharpDX.Model.Cameras;
+using HelixToolkit.SharpDX.Core.Cameras;
 #else
 using HelixToolkit.Wpf.SharpDX.Cameras;
 #endif


### PR DESCRIPTION
1. Fix camera animation width calculation.
2. Clamp maximum time elapse for camera inertia update. Avoid over moving due to frame rate drop.
3. Fix negative near plane distance in camera property by default.
4. Fix panning speed too huge causes object flying too far on Orthographic camera. Ref #1161