### PR TITLE
Supports absolute 3D position mode for screen spaced node. Ref #1165

### DIFF
--- a/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/MainWindow.xaml
@@ -32,10 +32,11 @@
                     Mouse3DDown="MeshGeometryModel3D_Mouse3DDown" />
             </hx:ScreenSpacedGroup3D>
             <hx:ScreenSpacedGroup3D RelativeScreenLocationX="0">
-                <hx:MeshGeometryModel3D RenderWireframe="True"
+                <hx:MeshGeometryModel3D
                     Geometry="{Binding ViewCubeGeometry2}"
                     Material="{Binding ViewCubeMaterial2}"
-                    Mouse3DDown="MeshGeometryModel3D_Mouse3DDown" />
+                    Mouse3DDown="MeshGeometryModel3D_Mouse3DDown"
+                    RenderWireframe="True" />
             </hx:ScreenSpacedGroup3D>
             <hx:ScreenSpacedGroup3D RelativeScreenLocationX="0.8" RelativeScreenLocationY="0">
                 <hx:MeshGeometryModel3D
@@ -44,12 +45,22 @@
                     Mouse3DDown="MeshGeometryModel3D_Mouse3DDown"
                     Transform="{Binding ViewCubeTransform3}" />
             </hx:ScreenSpacedGroup3D>
-            <hx:ScreenSpacedGroup3D RelativeScreenLocationX="-0.8" RelativeScreenLocationY="0" SizeScale="2">
+            <hx:ScreenSpacedGroup3D
+                RelativeScreenLocationX="-0.8"
+                RelativeScreenLocationY="0"
+                SizeScale="2">
                 <hx:MeshGeometryModel3D
                     Geometry="{Binding Geometry}"
                     Material="{Binding ViewCubeMaterial4}"
                     Mouse3DDown="MeshGeometryModel3D_Mouse3DDown"
                     Transform="{Binding ViewCubeTransform3}" />
+            </hx:ScreenSpacedGroup3D>
+            <hx:ScreenSpacedGroup3D
+                AbsolutePosition3D="0, 2, 0"
+                Mode="AbsolutePosition3D"
+                SizeScale="2">
+                <hx:LineGeometryModel3D Geometry="{Binding Coordinate}" Color="White" />
+                <hx:BillboardTextModel3D Geometry="{Binding CoordinateText}" />
             </hx:ScreenSpacedGroup3D>
         </hx:Viewport3DX>
     </Grid>

--- a/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/MainWindowViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/MainWindowViewModel.cs
@@ -18,6 +18,8 @@ namespace CustomViewCubeDemo
         public Material ViewCubeMaterial2 { private set; get; }
         public Material ViewCubeMaterial3 { private set; get; }
         public Material ViewCubeMaterial4 { private set; get; }
+        public LineGeometry3D Coordinate { private set; get; }
+        public BillboardText3D CoordinateText { private set; get; }
 
         public System.Windows.Media.Media3D.Transform3D ViewCubeTransform3 { private set; get; }
 
@@ -32,6 +34,7 @@ namespace CustomViewCubeDemo
             };
             InitializeModels();
             InitializeViewCubes();
+            InitializeCoordinates();
         }
 
         private void InitializeModels()
@@ -61,6 +64,24 @@ namespace CustomViewCubeDemo
             //Center the model first and do scaling
             var transform = Matrix.Translation(0, -2, 0) * Matrix.Scaling(3.5f);
             ViewCubeTransform3 = new System.Windows.Media.Media3D.MatrixTransform3D(transform.ToMatrix3D());
+        }
+
+        private void InitializeCoordinates()
+        {
+            var builder = new LineBuilder();
+            builder.AddLine(Vector3.Zero, Vector3.UnitX * 5);
+            builder.AddLine(Vector3.Zero, Vector3.UnitY * 5);
+            builder.AddLine(Vector3.Zero, Vector3.UnitZ * 5);
+            Coordinate = builder.ToLineGeometry3D();
+            Coordinate.Colors = new Color4Collection(Enumerable.Repeat<Color4>(Color.White, 6));
+            Coordinate.Colors[0] = Coordinate.Colors[1] = Color.Red;
+            Coordinate.Colors[2] = Coordinate.Colors[3] = Color.Green;
+            Coordinate.Colors[4] = Coordinate.Colors[5] = Color.Blue;
+
+            CoordinateText = new BillboardText3D();
+            CoordinateText.TextInfo.Add(new TextInfo("X", Vector3.UnitX * 6));
+            CoordinateText.TextInfo.Add(new TextInfo("Y", Vector3.UnitY * 6));
+            CoordinateText.TextInfo.Add(new TextInfo("Z", Vector3.UnitZ * 6));
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/Enums.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/Enums.cs
@@ -201,4 +201,10 @@ namespace HelixToolkit.UWP
     {
         High, Low
     }
+
+    public enum ScreenSpacedMode
+    {
+        RelativeScreenSpaced,
+        AbsolutePosition3D
+    }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenSpacedNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenSpacedNode.cs
@@ -85,6 +85,40 @@ namespace HelixToolkit.UWP
                     return (RenderCore as IScreenSpacedRenderParams).SizeScale;
                 }
             }
+            /// <summary>
+            /// Gets or sets the mode. Includes <see cref="ScreenSpacedMode.RelativeScreenSpaced"/> and <see cref="ScreenSpacedMode.AbsolutePosition3D"/>
+            /// </summary>
+            /// <value>
+            /// The mode.
+            /// </value>
+            public ScreenSpacedMode Mode
+            {
+                set
+                {
+                    (RenderCore as IScreenSpacedRenderParams).Mode = value;
+                }
+                get
+                {
+                    return (RenderCore as IScreenSpacedRenderParams).Mode;
+                }
+            }
+            /// <summary>
+            /// Gets or sets the absolute position in 3d. Use by <see cref="Mode"/> = <see cref="ScreenSpacedMode.AbsolutePosition3D"/>
+            /// </summary>
+            /// <value>
+            /// The absolute position3 d.
+            /// </value>
+            public Vector3 AbsolutePosition3D
+            {
+                set
+                {
+                    (RenderCore as IScreenSpacedRenderParams).AbsolutePosition3D = value;
+                }
+                get
+                {
+                    return (RenderCore as IScreenSpacedRenderParams).AbsolutePosition3D;
+                }
+            }
             #endregion
             /// <summary>
             /// Gets or sets a value indicating whether [need clear depth buffer].
@@ -155,10 +189,23 @@ namespace HelixToolkit.UWP
                 var p = Vector3.TransformCoordinate(ray.Position, context.ScreenViewProjectionMatrix);
                 var screenSpaceCore = RenderCore as ScreenSpacedMeshRenderCore;
                 float viewportSize = screenSpaceCore.Size * screenSpaceCore.SizeScale;
-                var offx = (float)(context.ActualWidth / 2 * (1 + screenSpaceCore.RelativeScreenLocationX) - viewportSize / 2);
-                var offy = (float)(context.ActualHeight / 2 * (1 + screenSpaceCore.RelativeScreenLocationY) - viewportSize / 2);
-                offx = Math.Max(0, Math.Min(offx, (int)(context.ActualWidth - viewportSize)));
-                offy = Math.Max(0, Math.Min(offy, (int)(context.ActualHeight - viewportSize)));
+                float offx = 0;
+                float offy = 0;
+                switch (Mode)
+                {
+                    case ScreenSpacedMode.RelativeScreenSpaced:
+                        offx = (float)(context.ActualWidth / 2 * (1 + screenSpaceCore.RelativeScreenLocationX) - viewportSize / 2);
+                        offy = (float)(context.ActualHeight / 2 * (1 + screenSpaceCore.RelativeScreenLocationY) - viewportSize / 2);
+                        offx = Math.Max(0, Math.Min(offx, (int)(context.ActualWidth - viewportSize)));
+                        offy = Math.Max(0, Math.Min(offy, (int)(context.ActualHeight - viewportSize)));
+                        break;
+                    case ScreenSpacedMode.AbsolutePosition3D:
+                        var abs = Vector3.TransformCoordinate(AbsolutePosition3D, context.ScreenViewProjectionMatrix);
+                        offx = (float)(abs.X - viewportSize / 2);
+                        offy = (float)(abs.Y - viewportSize / 2);
+                        break;
+                }
+
                 var px = p.X - offx;
                 var py = p.Y - offy;
 

--- a/Source/HelixToolkit.UWP/Model/Element3D/Abstract/ScreenSpaceMeshGeometry3D.cs
+++ b/Source/HelixToolkit.UWP/Model/Element3D/Abstract/ScreenSpaceMeshGeometry3D.cs
@@ -8,9 +8,11 @@ Copyright (c) 2018 Helix Toolkit contributors
 */
 #if NETFX_CORE
 using Windows.UI.Xaml;
+using Point3D = SharpDX.Vector3;
 namespace HelixToolkit.UWP
 #else
 using System.Windows;
+using Point3D = System.Windows.Media.Media3D.Point3D;
 namespace HelixToolkit.Wpf.SharpDX
 #endif
 {
@@ -59,12 +61,35 @@ namespace HelixToolkit.Wpf.SharpDX
                     ((d as Element3DCore).SceneNode as ScreenSpacedNode).SizeScale = (float)(double)e.NewValue;
                 }));
 
-
         /// <summary>
         /// The enable mover property
         /// </summary>
         public static readonly DependencyProperty EnableMoverProperty =
             DependencyProperty.Register("EnableMover", typeof(bool), typeof(ScreenSpacedElement3D), new PropertyMetadata(true));
+
+        /// <summary>
+        /// The mode property
+        /// </summary>
+        public static readonly DependencyProperty ModeProperty =
+            DependencyProperty.Register("Mode", typeof(ScreenSpacedMode), typeof(ScreenSpacedElement3D), new PropertyMetadata(ScreenSpacedMode.RelativeScreenSpaced,
+                (d,e)=> 
+                {
+                    ((d as Element3DCore).SceneNode as ScreenSpacedNode).Mode = (ScreenSpacedMode)e.NewValue;
+                }));
+
+
+        /// <summary>
+        /// The absolute position3 d property
+        /// </summary>
+        public static readonly DependencyProperty AbsolutePosition3DProperty =
+            DependencyProperty.Register("AbsolutePosition3D", typeof(Point3D), typeof(ScreenSpacedElement3D), new PropertyMetadata(new Point3D(), (d, e) =>
+            {
+#if NETFX_CORE
+                ((d as Element3DCore).SceneNode as ScreenSpacedNode).AbsolutePosition3D = (Point3D)e.NewValue;
+#else
+                ((d as Element3DCore).SceneNode as ScreenSpacedNode).AbsolutePosition3D = ((Point3D)e.NewValue).ToVector3();
+#endif
+            }));
 
         /// <summary>
         /// Relative Location X on screen. Range from -1~1
@@ -110,7 +135,28 @@ namespace HelixToolkit.Wpf.SharpDX
                 return (double)GetValue(SizeScaleProperty);
             }
         }
-
+        /// <summary>
+        /// Gets or sets the mode.
+        /// </summary>
+        /// <value>
+        /// The mode.
+        /// </value>
+        public ScreenSpacedMode Mode
+        {
+            get { return (ScreenSpacedMode)GetValue(ModeProperty); }
+            set { SetValue(ModeProperty, value); }
+        }
+        /// <summary>
+        /// Gets or sets the absolute position in 3d. Use by <see cref="Mode"/> = <see cref="ScreenSpacedMode.AbsolutePosition3D"/>
+        /// </summary>
+        /// <value>
+        /// The absolute position3 d.
+        /// </value>
+        public Point3D AbsolutePosition3D
+        {
+            get { return (Point3D)GetValue(AbsolutePosition3DProperty); }
+            set { SetValue(AbsolutePosition3DProperty, value); }
+        }
 
         protected override void AssignDefaultValuesToSceneNode(SceneNode node)
         {
@@ -119,6 +165,12 @@ namespace HelixToolkit.Wpf.SharpDX
                 n.RelativeScreenLocationX = (float)this.RelativeScreenLocationX;
                 n.RelativeScreenLocationY = (float)this.RelativeScreenLocationY;
                 n.SizeScale = (float)this.SizeScale;
+                n.Mode = Mode;
+#if NETFX_CORE
+                n.AbsolutePosition3D = AbsolutePosition3D;
+#else
+                n.AbsolutePosition3D = AbsolutePosition3D.ToVector3();
+#endif
             }
             base.AssignDefaultValuesToSceneNode(node);
         }

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/ScreenSpaceMeshGeometry3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/ScreenSpaceMeshGeometry3D.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Data;
 
 using Media3D = System.Windows.Media.Media3D;
+using Point3D = System.Windows.Media.Media3D.Point3D;
 #if COREWPF
 using HelixToolkit.SharpDX.Core.Model.Scene;
 #endif
@@ -61,6 +62,25 @@ namespace HelixToolkit.Wpf.SharpDX
         public static readonly DependencyProperty EnableMoverProperty =
             DependencyProperty.Register("EnableMover", typeof(bool), typeof(ScreenSpacedElement3D), new PropertyMetadata(true));
 
+        /// <summary>
+        /// The mode property
+        /// </summary>
+        public static readonly DependencyProperty ModeProperty =
+            DependencyProperty.Register("Mode", typeof(ScreenSpacedMode), typeof(ScreenSpacedElement3D), new PropertyMetadata(ScreenSpacedMode.RelativeScreenSpaced,
+                (d, e) =>
+                {
+                    ((d as Element3DCore).SceneNode as ScreenSpacedNode).Mode = (ScreenSpacedMode)e.NewValue;
+                }));
+
+
+        /// <summary>
+        /// The absolute position3 d property
+        /// </summary>
+        public static readonly DependencyProperty AbsolutePosition3DProperty =
+            DependencyProperty.Register("AbsolutePosition3D", typeof(Point3D), typeof(ScreenSpacedElement3D), new PropertyMetadata(new Point3D(), (d, e) =>
+            {
+                ((d as Element3DCore).SceneNode as ScreenSpacedNode).AbsolutePosition3D = ((Point3D)e.NewValue).ToVector3();
+            }));
         /// <summary>
         /// Gets or sets a value indicating whether [enable mover].
         /// </summary>
@@ -117,12 +137,28 @@ namespace HelixToolkit.Wpf.SharpDX
                 return (double)GetValue(SizeScaleProperty);
             }
         }
-
-        //protected override SceneNode OnCreateSceneNode()
-        //{
-            
-        //    return new ScreenSpacedNode();
-        //}
+        /// <summary>
+        /// Gets or sets the mode.
+        /// </summary>
+        /// <value>
+        /// The mode.
+        /// </value>
+        public ScreenSpacedMode Mode
+        {
+            get { return (ScreenSpacedMode)GetValue(ModeProperty); }
+            set { SetValue(ModeProperty, value); }
+        }
+        /// <summary>
+        /// Gets or sets the absolute position in 3d. Use by <see cref="Mode"/> = <see cref="ScreenSpacedMode.AbsolutePosition3D"/>
+        /// </summary>
+        /// <value>
+        /// The absolute position3 d.
+        /// </value>
+        public Point3D AbsolutePosition3D
+        {
+            get { return (Point3D)GetValue(AbsolutePosition3DProperty); }
+            set { SetValue(AbsolutePosition3DProperty, value); }
+        }
 
         protected override void AssignDefaultValuesToSceneNode(SceneNode node)
         {
@@ -131,6 +167,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 n.RelativeScreenLocationX = (float)this.RelativeScreenLocationX;
                 n.RelativeScreenLocationY = (float)this.RelativeScreenLocationY;
                 n.SizeScale = (float)this.SizeScale;
+                n.AbsolutePosition3D = AbsolutePosition3D.ToVector3();
+                n.Mode = Mode;
             }
             base.AssignDefaultValuesToSceneNode(node);
             InitializeMover();


### PR DESCRIPTION
Supports absolute 3D position mode for screen spaced node. Ref #1165.
This helps to implement multiple coordinate system in world space. Zooming does not affect coordinate system size.