### PR TITLE
Add GPU generated arrow head/tail for line rendering

### DIFF
--- a/Source/Examples/WPF.SharpDX/DynamicTextureDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/DynamicTextureDemo/MainViewModel.cs
@@ -89,6 +89,8 @@ namespace DynamicTextureDemo
         public PointGeometry3D PointModel { private set; get; }
         public LineGeometry3D LineModel { private set; get; }
 
+        public LineMaterial LineMaterial { private set; get; }
+
         //public MeshGeometry3D Other { get; private set; }
         public Color AmbientLightColor { get; set; }
         DispatcherTimer timer = new DispatcherTimer();
@@ -218,6 +220,7 @@ namespace DynamicTextureDemo
             }
             colors.Add(Colors.Blue.ToColor4());
             LineModel.Colors = colors;
+            LineMaterial = new LineArrowHeadMaterial() { Color = Colors.White, Thickness = 0.5, ArrowSize = 0.02};
             #endregion
             var token = cts.Token;
             Task.Run(() =>

--- a/Source/Examples/WPF.SharpDX/DynamicTextureDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/DynamicTextureDemo/MainWindow.xaml
@@ -64,14 +64,11 @@
                     <TranslateTransform3D OffsetX="-10" />
                 </hx:PointGeometryModel3D.Transform>
             </hx:PointGeometryModel3D>
-            <hx:LineGeometryModel3D
-                Geometry="{Binding LineModel}"
-                Thickness="0.5"
-                Color="White">
-                <hx:LineGeometryModel3D.Transform>
+            <hx:LineMaterialGeometryModel3D Geometry="{Binding LineModel}" Material="{Binding LineMaterial}">
+                <hx:LineMaterialGeometryModel3D.Transform>
                     <TranslateTransform3D OffsetX="10" />
-                </hx:LineGeometryModel3D.Transform>
-            </hx:LineGeometryModel3D>
+                </hx:LineMaterialGeometryModel3D.Transform>
+            </hx:LineMaterialGeometryModel3D>
         </hx:Viewport3DX>
         <StackPanel
             Grid.Column="1"

--- a/Source/Examples/WPF.SharpDX/LineShadingDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/LineShadingDemo/MainViewModel.cs
@@ -39,18 +39,35 @@ namespace LineShadingDemo
         public PhongMaterial Material1 { get; private set; }
         public PhongMaterial Material2 { get; private set; }
         public PhongMaterial Material3 { get; private set; }        
+        public LineMaterial LineMaterial { get; private set; }
         public Color GridColor { get; private set; }
 
         public Transform3D Model1Transform { get; private set; }
         public Transform3D Model2Transform { get; private set; }
         public Transform3D Model3Transform { get; private set; }
+        public Transform3D Model4Transform { get; private set; }
         public Transform3D GridTransform { get; private set; }
 
         public Vector3D DirectionalLightDirection { get; private set; }
         public Color DirectionalLightColor { get; private set; }
         public Color AmbientLightColor { get; private set; }
 
-      
+        private bool enableArrowHeadTail = false;
+        public bool EnableArrowHeadTail
+        {
+            set
+            {
+                if(SetValue(ref enableArrowHeadTail, value))
+                {
+                    LineMaterial = value ?
+                        new LineArrowHeadTailMaterial() { ArrowSize = 0.04, Color = Colors.White } 
+                    : new LineArrowHeadMaterial() { ArrowSize = 0.04, Color = Colors.White };
+                    OnPropertyChanged(nameof(LineMaterial));
+                }
+            }
+            get { return enableArrowHeadTail; }
+        }
+
         public MainViewModel()
         {
             EffectsManager = new DefaultEffectsManager();
@@ -100,11 +117,12 @@ namespace LineShadingDemo
             this.Model1Transform = new TranslateTransform3D(0, 0, 0);
             this.Model2Transform = new TranslateTransform3D(-2, 0, 0);
             this.Model3Transform = new TranslateTransform3D(+2, 0, 0);
-
+            this.Model4Transform = new TranslateTransform3D(0, 2, 0);
             // model materials
             this.Material1 = PhongMaterials.PolishedGold;
             this.Material2 = PhongMaterials.Copper;
-            this.Material3 = PhongMaterials.Glass;                        
+            this.Material3 = PhongMaterials.Glass;
+            this.LineMaterial = new LineArrowHeadMaterial() { ArrowSize = 0.04, Color = Colors.White};
         }
     }
 }

--- a/Source/Examples/WPF.SharpDX/LineShadingDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/LineShadingDemo/MainWindow.xaml
@@ -92,6 +92,10 @@
                 Thickness="{Binding LineThickness}"
                 Transform="{Binding GridTransform}"
                 Color="{Binding GridColor}" />
+            <hx:LineMaterialGeometryModel3D
+                Geometry="{Binding Lines}"
+                Material="{Binding LineMaterial}"
+                Transform="{Binding Model4Transform}" />
         </hx:Viewport3DX>
         <StackPanel Grid.Row="1">
             <Expander
@@ -126,6 +130,7 @@
                         Maximum="20"
                         Minimum="0"
                         Value="{Binding LineSmoothness}" />
+                    <CheckBox IsChecked="{Binding EnableArrowHeadTail}">Arrow Head and Tail</CheckBox>
                 </StackPanel>
             </Expander>
         </StackPanel>

--- a/Source/HelixToolkit.Native.ShaderBuilder/GS/gsLineArrowHead.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/GS/gsLineArrowHead.hlsl
@@ -1,0 +1,106 @@
+#ifndef GSLINEARROWHEAD_HLSL
+#define GSLINEARROWHEAD_HLSL
+#define POINTLINE
+#include"..\GS\gsLine.hlsl"
+
+const static float default_cone_w = 0.5;
+const static float default_cone_h = 1.5;
+const static float4 cone[10] =
+{
+    float4(-default_cone_w, -default_cone_h, -default_cone_w, default_cone_w),
+    float4(default_cone_w, -default_cone_h, -default_cone_w, default_cone_w),
+    float4(-default_cone_w, -default_cone_h, default_cone_w, default_cone_w),
+    float4(default_cone_w, -default_cone_h, default_cone_w, default_cone_w),
+    float4(0, 0, 0, default_cone_w),
+    float4(default_cone_w, -default_cone_h, -default_cone_w, default_cone_w),
+    float4(-default_cone_w, -default_cone_h, -default_cone_w, default_cone_w),
+    float4(-default_cone_w, -default_cone_h, -default_cone_w, default_cone_w),
+    float4(-default_cone_w, -default_cone_h, default_cone_w, default_cone_w),
+    float4(0, 0, 0, default_cone_w)
+};
+
+void makeCone(out float4 points[10], in float4 posA, in float4 posB, in float scale)
+{
+    float3 dir = normalize(posA.xyz - posB.xyz);
+    float3 axis = cross(float3(0, 1, 0), dir);
+    float cosA = dot(float3(0, 1, 0), dir);
+    float4x4 transform = float4x4(scale, 0, 0, 0, 0, scale, 0, 0, 0, 0, scale, 0, 0, 0, 0, 1);
+    if (1 - abs(cosA) > 1e-3)
+    {
+        float sinA = sin(acos(cosA));
+        float x = axis.x;
+        float y = axis.y;
+        float z = axis.z;
+        float xy = axis.x * axis.y;
+        float xz = axis.x * axis.z;
+        float yz = axis.y * axis.z;
+        float xx = axis.x * axis.x;
+        float yy = axis.y * axis.y;
+        float zz = axis.z * axis.z;
+        transform = mul(transform, float4x4(
+            (xx + cosA * (1 - xx)), (xy - (cosA * xy)) + sinA * z, (xz - (cosA * xz)) - y * sinA, 0,
+            (xy - (cosA * xy)) - z * sinA, (yy + (cosA * (1 - yy))), (yz - (cosA * yz)) + sinA * x, 0,
+            (xz - (cosA * xz)) + sinA * y, (yz - (cosA * yz)) - sinA * x, (zz + (cosA * (1 - zz))), 0,
+            0, 0, 0, 1));
+    }
+    else // Parallel to the arrow direction
+    {
+        float d = sign(cosA);
+        transform._m00_m11_m22 *= d;
+    }
+    transform._m30_m31_m32 = posA.xyz;
+    [unroll]
+    for (int i = 0; i < 10; ++i)
+    {
+        points[i] = mul(cone[i], transform);
+    }
+}
+
+[maxvertexcount(14)]
+void mainArrowHead(line GSInputPS input[2], inout TriangleStream<PSInputPS> outStream)
+{
+    PSInputPS output = (PSInputPS) 0;
+		
+    float4 lineCorners[4] = { (float4) 0, (float4) 0, (float4) 0, (float4) 0 };
+    if (fixedSize)
+        makeLine(lineCorners, input[0].p, input[1].p, pfParams.x);
+    else
+        makeLineNonFixed(lineCorners, mul(input[0].wp, mView), mul(input[1].wp, mView), pfParams.x);
+    output.vEye = input[0].vEye;
+    output.c = input[0].c;
+    output.p = lineCorners[0];
+    output.t = float3(1, 1, 1);
+    outStream.Append(output);
+	
+    output.p = lineCorners[1];
+    output.c = input[0].c;
+    output.t = float3(1, -1, 1);
+    outStream.Append(output);
+ 
+    output.vEye = input[1].vEye;
+    output.c = input[1].c;
+    output.p = lineCorners[2];
+    output.t = float3(-1, 1, 1);
+    outStream.Append(output);
+	
+    output.p = lineCorners[3];
+    output.t = float3(-1, -1, 1);
+    outStream.Append(output);
+	
+    outStream.RestartStrip();
+
+    output.vEye = input[1].vEye;
+    output.t = float3(0, 0, 0);
+    output.c = input[1].c;
+    float4 cone[10];
+    makeCone(cone, input[1].wp, input[0].wp, pfParams.z);
+
+    [unroll]
+    for (int i = 0; i < 10; ++i)
+    {
+        output.p = mul(cone[i], mViewProjection);
+        outStream.Append(output);
+    }
+    outStream.RestartStrip();
+}
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/GS/gsLineArrowHeadTail.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/GS/gsLineArrowHeadTail.hlsl
@@ -1,0 +1,66 @@
+#ifndef GSLINEARROWTAIL_HLSL
+#define GSLINEARROWTAIL_HLSL
+#define POINTLINE
+#include"..\GS\gsLineArrowHead.hlsl"
+
+[maxvertexcount(24)]
+void mainArrowHeadTail(line GSInputPS input[2], inout TriangleStream<PSInputPS> outStream)
+{
+    PSInputPS output = (PSInputPS) 0;
+		
+    float4 lineCorners[4] = { (float4) 0, (float4) 0, (float4) 0, (float4) 0 };
+    if (fixedSize)
+        makeLine(lineCorners, input[0].p, input[1].p, pfParams.x);
+    else
+        makeLineNonFixed(lineCorners, mul(input[0].wp, mView), mul(input[1].wp, mView), pfParams.x);
+    output.vEye = input[0].vEye;
+    output.c = input[0].c;
+    output.p = lineCorners[0];
+    output.t = float3(1, 1, 1);
+    outStream.Append(output);
+	
+    output.p = lineCorners[1];
+    output.c = input[0].c;
+    output.t = float3(1, -1, 1);
+    outStream.Append(output);
+ 
+    output.vEye = input[1].vEye;
+    output.c = input[1].c;
+    output.p = lineCorners[2];
+    output.t = float3(-1, 1, 1);
+    outStream.Append(output);
+	
+    output.p = lineCorners[3];
+    output.t = float3(-1, -1, 1);
+    outStream.Append(output);
+	
+    outStream.RestartStrip();
+
+    output.vEye = input[1].vEye;
+    output.t = float3(0, 0, 0);
+    output.c = input[1].c;
+    float4 cone[10];
+    makeCone(cone, input[1].wp, input[0].wp, pfParams.z);
+    // Make head
+    [unroll]
+    for (int i = 0; i < 10; ++i)
+    {
+        output.p = mul(cone[i], mViewProjection);
+        outStream.Append(output);
+    }
+    outStream.RestartStrip();
+    // Make tail
+    output.vEye = input[0].vEye;
+    output.t = float3(0, 0, 0);
+    output.c = input[0].c;
+    makeCone(cone, input[0].wp, input[1].wp, pfParams.z);
+
+    [unroll]
+    for (int i = 0; i < 10; ++i)
+    {
+        output.p = mul(cone[i], mViewProjection);
+        outStream.Append(output);
+    }
+    outStream.RestartStrip();
+}
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj
@@ -216,6 +216,34 @@ xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(Solut
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Geometry</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
     </FxCompile>
+    <FxCompile Include="GS\gsLineArrowHead.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">mainArrowHead</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mainArrowHead</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mainArrowHead</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mainArrowHead</EntryPointName>
+    </FxCompile>
+    <FxCompile Include="GS\gsLineArrowHeadTail.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Geometry</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">mainArrowHeadTail</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">mainArrowHeadTail</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">mainArrowHeadTail</EntryPointName>
+      <EntryPointName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">mainArrowHeadTail</EntryPointName>
+    </FxCompile>
     <FxCompile Include="GS\gsMeshNormalVector.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Geometry</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>

--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj.filters
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj.filters
@@ -321,5 +321,7 @@
     <FxCompile Include="PS\psEffectOutlineSmooth.hlsl">
       <Filter>PS</Filter>
     </FxCompile>
+    <FxCompile Include="GS\gsLineArrowHead.hlsl" />
+    <FxCompile Include="GS\gsLineArrowHeadTail.hlsl" />
   </ItemGroup>
 </Project>

--- a/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
+++ b/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
@@ -57,6 +57,8 @@
     <None Remove="Resources\dsMeshTriTessellation.cso" />
     <None Remove="Resources\gsBillboard.cso" />
     <None Remove="Resources\gsLine.cso" />
+    <None Remove="Resources\gsLineArrowHead.cso" />
+    <None Remove="Resources\gsLineArrowHeadTail.cso" />
     <None Remove="Resources\gsMeshNormalVector.cso" />
     <None Remove="Resources\gsMeshSkinnedOut.cso" />
     <None Remove="Resources\gsParticle.cso" />
@@ -152,6 +154,8 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\arial.dds" />
+    <EmbeddedResource Include="Resources\gsLineArrowHead.cso" />
+    <EmbeddedResource Include="Resources\gsLineArrowHeadTail.cso" />
     <EmbeddedResource Include="Resources\psEffectOutlineSmooth.cso" />
     <EmbeddedResource Include="Resources\psMeshPBROIT.cso" />
   </ItemGroup>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
@@ -222,8 +222,6 @@ namespace HelixToolkit.UWP
             /// </summary>
             public float Fov { get; } = (float)(45 * Math.PI / 180);
 
-            internal Vector3 OrthoTranslation;
-
             /// <summary>
             /// Initializes a new instance of the <see cref="ScreenSpacedMeshRenderCore"/> class.
             /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultGeometryShaders.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultGeometryShaders.cs
@@ -37,6 +37,26 @@ namespace HelixToolkit.UWP
                 get;
             } = "gsLine";
             /// <summary>
+            /// Gets the gs line arrow head.
+            /// </summary>
+            /// <value>
+            /// The gs line arrow head.
+            /// </value>
+            public static string GSLineArrowHead
+            {
+                get;
+            } = "gsLineArrowHead";
+            /// <summary>
+            /// Gets the gs line arrow tail.
+            /// </summary>
+            /// <value>
+            /// The gs line arrow tail.
+            /// </value>
+            public static string GSLineArrowHeadTail
+            {
+                get;
+            } = "gsLineArrowHeadTail";
+            /// <summary>
             /// 
             /// </summary>
             public static string GSBillboard
@@ -84,6 +104,16 @@ namespace HelixToolkit.UWP
             /// </summary>
             public static readonly ShaderDescription GSLine = new ShaderDescription(nameof(GSLine), ShaderStage.Geometry, new ShaderReflector(),
                 DefaultGSShaderByteCodes.GSLine);
+            /// <summary>
+            /// 
+            /// </summary>
+            public static readonly ShaderDescription GSLineArrowHead = new ShaderDescription(nameof(GSLineArrowHead), ShaderStage.Geometry, new ShaderReflector(),
+                DefaultGSShaderByteCodes.GSLineArrowHead);
+            /// <summary>
+            /// 
+            /// </summary>
+            public static readonly ShaderDescription GSLineArrowHeadTail = new ShaderDescription(nameof(GSLineArrowHeadTail), ShaderStage.Geometry, new ShaderReflector(),
+                DefaultGSShaderByteCodes.GSLineArrowHeadTail);
             /// <summary>
             /// 
             /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -134,6 +134,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Geometry\BillboardImage3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\BillboardMaterialCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\GenericMaterialCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Material\LineArrowMaterialCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\LineMaterialCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\PBRMaterialCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\PointMaterialCore.cs" />
@@ -142,6 +143,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\ColorStripeMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\DiffuseMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\GenericMaterialVariable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\LineArrowMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\LineMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\PassOnlyMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\ContextSharedResource.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/LineArrowMaterialCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/LineArrowMaterialCore.cs
@@ -1,0 +1,48 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+using SharpDX;
+using System.Runtime.Serialization;
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    namespace Model
+    {
+        public class LineArrowHeadMaterialCore : LineMaterialCore
+        {
+            private float arrowSize = 0.1f;
+            /// <summary>
+            /// Gets or sets the size of the arrow.
+            /// </summary>
+            /// <value>
+            /// The size of the arrow.
+            /// </value>
+            public float ArrowSize
+            {
+                set { Set(ref arrowSize, value); }
+                get { return arrowSize; }
+            }
+
+            public override MaterialVariable CreateMaterialVariables(IEffectsManager manager, IRenderTechnique technique)
+            {
+                return new LineArrowMaterialVariable(manager, manager.GetTechnique(DefaultRenderTechniqueNames.LinesArrowHead), this);
+            }
+        }
+
+        public class LineArrowHeadTailMaterialCore : LineArrowHeadMaterialCore
+        {
+            public override MaterialVariable CreateMaterialVariables(IEffectsManager manager, IRenderTechnique technique)
+            {
+                return new LineArrowMaterialVariable(manager, manager.GetTechnique(DefaultRenderTechniqueNames.LinesArrowHeadTail), this);
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/LineMaterialCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/LineMaterialCore.cs
@@ -18,7 +18,7 @@ namespace HelixToolkit.UWP
     {
         using Core;
         [DataContract]
-        public sealed class LineMaterialCore : MaterialCore, ILineRenderParams
+        public class LineMaterialCore : MaterialCore, ILineRenderParams
         {
             #region Properties
             private float thickness = 0.5f;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineArrowMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineArrowMaterialVariable.cs
@@ -1,0 +1,47 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+using SharpDX;
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    namespace Model
+    {
+        using Shaders;
+        public class LineArrowMaterialVariable : LineMaterialVariable
+        {
+            private readonly LineArrowHeadMaterialCore material;
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LineMaterialVariable"/> class.
+            /// </summary>
+            /// <param name="manager">The manager.</param>
+            /// <param name="technique">The technique.</param>
+            /// <param name="materialCore">The material core.</param>
+            /// <param name="linePassName">Name of the line pass.</param>
+            /// <param name="shadowPassName">Name of the shadow pass.</param>
+            /// <param name="depthPassName">Name of the depth pass</param>
+            public LineArrowMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineArrowHeadMaterialCore materialCore,
+                string linePassName = DefaultPassNames.Default, string shadowPassName = DefaultPassNames.ShadowPass,
+                string depthPassName = DefaultPassNames.DepthPrepass)
+                : base(manager, technique, materialCore, linePassName, shadowPassName, depthPassName)
+            {
+                this.material = materialCore;          
+            }
+
+            protected override void OnInitialPropertyBindings()
+            {
+                base.OnInitialPropertyBindings();
+                AddPropertyBinding(nameof(LineArrowHeadMaterialCore.ArrowSize),
+                    () => { WriteValue(PointLineMaterialStruct.ParamsStr, new Vector3(material.Thickness, material.Smoothness, material.ArrowSize)); });
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineMaterialVariable.cs
@@ -20,7 +20,7 @@ namespace HelixToolkit.UWP
         /// <summary>
         /// 
         /// </summary>
-        public sealed class LineMaterialVariable : MaterialVariable
+        public class LineMaterialVariable : MaterialVariable
         {
             private readonly LineMaterialCore material;
 

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
@@ -1124,6 +1124,230 @@ namespace HelixToolkit.UWP
                 }
             };
 
+            var renderLineArrowHead = new TechniqueDescription(DefaultRenderTechniqueNames.LinesArrowHead)
+            {
+                InputLayoutDescription = new InputLayoutDescription(DefaultVSShaderByteCodes.VSPoint, DefaultInputLayout.VSInputPoint),
+                PassDescriptions = new[]
+                {
+                    new ShaderPassDescription(DefaultPassNames.Default)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSLine
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual
+                    },
+                    new ShaderPassDescription(DefaultPassNames.DepthPrepass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSShadow
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess
+                    },
+                    new ShaderPassDescription(DefaultPassNames.ShadowPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPointShadow,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSShadow
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectOutlineP1)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSMeshOutlineQuadStencil
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSSourceAlways,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSMeshOutlineP1,
+                        StencilRef = 1
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP1)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSDepthStencilOnly
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP1,
+                        StencilRef = 1
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP2)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSDepthStencilOnly
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP2,
+                        StencilRef = 1
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP3)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSEffectXRayGrid
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP3,
+                        StencilRef = 1
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayP1)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSDepthStencilOnly
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayP1,
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayP2)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHead,
+                            DefaultPSShaderDescriptions.PSLine
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOverlayBlending,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayP2,
+                        StencilRef = 1
+                    },
+                }
+            };
+
+            var renderLineArrowHeadTail = new TechniqueDescription(DefaultRenderTechniqueNames.LinesArrowHeadTail)
+            {
+                InputLayoutDescription = new InputLayoutDescription(DefaultVSShaderByteCodes.VSPoint, DefaultInputLayout.VSInputPoint),
+                PassDescriptions = new[]
+                {
+                    new ShaderPassDescription(DefaultPassNames.Default)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSLine
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLessEqual
+                    },
+                    new ShaderPassDescription(DefaultPassNames.DepthPrepass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSShadow
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess
+                    },
+                    new ShaderPassDescription(DefaultPassNames.ShadowPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPointShadow,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSShadow
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectOutlineP1)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSMeshOutlineQuadStencil
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSSourceAlways,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSMeshOutlineP1,
+                        StencilRef = 1
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP1)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSDepthStencilOnly
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP1,
+                        StencilRef = 1
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP2)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSDepthStencilOnly
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP2,
+                        StencilRef = 1
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayGridP3)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSEffectXRayGrid
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSAlphaBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayGridP3,
+                        StencilRef = 1
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayP1)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSDepthStencilOnly
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayP1,
+                    },
+                    new ShaderPassDescription(DefaultPassNames.EffectMeshXRayP2)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSPoint,
+                            DefaultGSShaderDescriptions.GSLineArrowHeadTail,
+                            DefaultPSShaderDescriptions.PSLine
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOverlayBlending,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSEffectMeshXRayP2,
+                        StencilRef = 1
+                    },
+                }
+            };
+
             var renderBillboardText = new TechniqueDescription(DefaultRenderTechniqueNames.BillboardText)
             {
                 InputLayoutDescription = new InputLayoutDescription(DefaultVSShaderByteCodes.VSBillboard, DefaultInputLayout.VSInputBillboard),
@@ -1897,6 +2121,8 @@ namespace HelixToolkit.UWP
             yield return renderMeshInstancing;
             yield return renderPoint;
             yield return renderLine;
+            yield return renderLineArrowHead;
+            yield return renderLineArrowHeadTail;
             yield return renderBillboardText;
             yield return renderBillboardInstancing;
             yield return renderMeshBlinnClipPlane;

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
@@ -32,6 +32,14 @@ namespace HelixToolkit.UWP
         /// <summary>
         /// 
         /// </summary>
+        public const string LinesArrowHead = "RenderLinesArrowHead";
+        /// <summary>
+        /// 
+        /// </summary>
+        public const string LinesArrowHeadTail = "RenderLinesArrowHeadTail";
+        /// <summary>
+        /// 
+        /// </summary>
         public const string Points = "RenderPoints";
         /// <summary>
         /// 

--- a/Source/HelixToolkit.SharpDX.SharedModel/HelixToolkit.SharpDX.SharedModel.projitems
+++ b/Source/HelixToolkit.SharpDX.SharedModel/HelixToolkit.SharpDX.SharedModel.projitems
@@ -58,6 +58,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Light3D\ShadowMap3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Material\ColorStripeMaterial.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Material\DiffuseMaterial.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Material\LineArrowHeadMaterial.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Material\LineMaterial.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Material\NormalVectorMaterial.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Material\PBRMaterial.cs" />

--- a/Source/HelixToolkit.SharpDX.SharedModel/Material/LineArrowHeadMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Material/LineArrowHeadMaterial.cs
@@ -1,0 +1,67 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+#if NETFX_CORE
+using Windows.UI.Xaml;
+using Media = Windows.UI;
+namespace HelixToolkit.UWP
+#else
+using System.Windows;
+using Media = System.Windows.Media;
+#if COREWPF
+using HelixToolkit.SharpDX.Core.Model;
+#endif
+namespace HelixToolkit.Wpf.SharpDX
+#endif
+{
+    using Model;
+    public class LineArrowHeadMaterial : LineMaterial
+    {
+        public double ArrowSize
+        {
+            get { return (double)GetValue(ArrowSizeProperty); }
+            set { SetValue(ArrowSizeProperty, value); }
+        }
+
+        public static readonly DependencyProperty ArrowSizeProperty =
+            DependencyProperty.Register("ArrowSize", typeof(double), typeof(LineArrowHeadMaterial), new PropertyMetadata(0.1, (d, e)=>
+            {
+                ((d as LineMaterial).Core as LineArrowHeadMaterialCore).ArrowSize = (float)(double)e.NewValue;
+            }));
+
+
+        protected override MaterialCore OnCreateCore()
+        {
+            return new LineArrowHeadMaterialCore()
+            {
+                Name = Name,
+                LineColor = Color.ToColor4(),
+                Smoothness = (float)Smoothness,
+                Thickness = (float)Thickness,
+                EnableDistanceFading = EnableDistanceFading,
+                FadingNearDistance = (float)FadingNearDistance,
+                FadingFarDistance = (float)FadingFarDistance,
+                ArrowSize = (float)ArrowSize,
+            };
+        }
+    }
+
+    public class LineArrowHeadTailMaterial : LineArrowHeadMaterial
+    {
+        protected override MaterialCore OnCreateCore()
+        {
+            return new LineArrowHeadTailMaterialCore()
+            {
+                Name = Name,
+                LineColor = Color.ToColor4(),
+                Smoothness = (float)Smoothness,
+                Thickness = (float)Thickness,
+                EnableDistanceFading = EnableDistanceFading,
+                FadingNearDistance = (float)FadingNearDistance,
+                FadingFarDistance = (float)FadingFarDistance,
+                ArrowSize = (float)ArrowSize,
+            };
+        }
+    }
+}

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -522,6 +522,12 @@
     <Content Include="Resources\psEffectOutlineSmooth.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Resources\gsLineArrowHead.cso">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\gsLineArrowHeadTail.cso">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup />
   <Import Project="..\HelixToolkit.Shared\HelixToolkit.Shared.projitems" Label="Shared" />

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/ScreenSpaceMeshGeometry3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/ScreenSpaceMeshGeometry3D.cs
@@ -10,6 +10,7 @@ using System.Windows.Data;
 using Media3D = System.Windows.Media.Media3D;
 using Point3D = System.Windows.Media.Media3D.Point3D;
 #if COREWPF
+using HelixToolkit.SharpDX.Core;
 using HelixToolkit.SharpDX.Core.Model.Scene;
 #endif
 namespace HelixToolkit.Wpf.SharpDX

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -134,6 +134,8 @@
     <None Include="Resources\dsMeshTriTessellation.cso" />
     <None Include="Resources\gsBillboard.cso" />
     <None Include="Resources\gsLine.cso" />
+    <None Include="Resources\gsLineArrowHead.cso" />
+    <None Include="Resources\gsLineArrowHeadTail.cso" />
     <None Include="Resources\gsMeshNormalVector.cso" />
     <None Include="Resources\gsMeshSkinnedOut.cso" />
     <None Include="Resources\gsParticle.cso" />

--- a/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.resx
+++ b/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.resx
@@ -397,4 +397,10 @@
   <data name="psEffectOutlineSmooth" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\pseffectoutlinesmooth.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="gsLineArrowHead" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gslinearrowhead.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="gsLineArrowHeadTail" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gslinearrowheadtail.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>


### PR DESCRIPTION
Add GPU generated arrow head/tail for line rendering.
Usage: 
SharpDX.WPF:
LineMaterialGeometryModel3D with LineArrowHeadMaterial/LineArrowHeadTailMaterial.

SceneNode:
LineNode with LineArrowHeadMaterialCore/LineArrowHeadTailMaterialCore.

Added example in [LineShadingDemo](../tree/develop/Source/Examples/WPF.SharpDX/LineShadingDemo)