### PR TITLE
Fix look direction reverted. Ref #1068.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/ZoomHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/ZoomHandler.cs
@@ -279,10 +279,6 @@ namespace HelixToolkit.Wpf.SharpDX
             var f = (float)Math.Pow(2.5, delta);
             var newRelativePosition = relativePosition * f;
             var newRelativeTarget = relativeTarget * f;
-            if(Controller.ZoomAroundMouseDownPoint && relativeTarget.LengthSquared() > 1e-3)
-            {
-                newRelativeTarget = CalcNewRelativeTargetOrthogonalToLookDirection(newRelativeTarget, relativeTarget);
-            }
             var newTarget = zoomAround - newRelativeTarget;
             var newPosition = zoomAround - newRelativePosition;
 
@@ -323,29 +319,6 @@ namespace HelixToolkit.Wpf.SharpDX
             this.Camera.LookDirection = newLookDirection.ToVector3D();
             this.Camera.Position = newPosition.ToPoint3D();
             return true;
-        }
-
-        /// <summary>
-        /// changes in lookdirection set the rotation point to wrong position
-        /// Ref: https://github.com/helix-toolkit/helix-toolkit/issues/1068
-        /// </summary>
-        /// <param name="newRelativeTarget"></param>
-        /// <param name="relativeTarget"></param>
-        /// <returns></returns>
-        private Vector3 CalcNewRelativeTargetOrthogonalToLookDirection(Vector3 newRelativeTarget, Vector3 relativeTarget)
-        {
-            var relativeTargetDiff = newRelativeTarget - relativeTarget;
-            var lookDir = Camera.CameraInternal.LookDirection;
-
-            var crossProduct = Vector3.Cross(lookDir, relativeTargetDiff);
-            var orthogonalRelativeTargetDiff = Vector3.Cross(crossProduct, lookDir).Normalized();
-
-            // correct length
-            var angle = orthogonalRelativeTargetDiff.AngleBetween(relativeTargetDiff);
-            orthogonalRelativeTargetDiff *= (float)(Math.Cos(angle) * relativeTargetDiff.Length());
-            newRelativeTarget = relativeTarget + orthogonalRelativeTargetDiff;
-
-            return newRelativeTarget;
         }
     }
 }


### PR DESCRIPTION
Note: Remove CalcNewRelativeTargetOrthogonalToLookDirection. Did not notice there is any differences except introducing camera look dir reverted bug.