### PR TITLE
Add assimp metadata support for import/export. Ref #1195

### DIFF
--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/Exporter.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/Exporter.cs
@@ -272,6 +272,13 @@ namespace HelixToolkit.UWP
                             Log(LogLevel.Warning, $"Current node type does not support yet. Type: {s.GetType().Name}");
                         }
                     }
+                    if(group.Metadata != null)
+                    {
+                        foreach(var metadata in group.Metadata.ToAssimpMetadata())
+                        {
+                            node.Metadata.Add(metadata.Key, metadata.Value);
+                        }
+                    }
                 }
                 else if(current is HxScene.GeometryNode geo)
                 {
@@ -284,7 +291,7 @@ namespace HelixToolkit.UWP
                 else
                 {
                     Log(LogLevel.Warning, $"Current node type does not support yet. Type: {current.GetType().Name}");
-                }
+                }                
                 return node;
             }
 

--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/Extensions.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/Extensions.cs
@@ -1,7 +1,6 @@
 ﻿using Assimp;
-using SharpDX.IO;
 using System;
-using System.IO;
+using System.Collections.Generic;
 
 #if !NETFX_CORE
 namespace HelixToolkit.Wpf.SharpDX
@@ -155,6 +154,90 @@ namespace HelixToolkit.UWP
             public static UVTransform ToHelixUVTransform(this global::Assimp.UVTransform transform)
             {
                 return new UVTransform(transform.Rotation, transform.Scaling.ToSharpDXVector2(), transform.Translation.ToSharpDXVector2());
+            }
+
+            /// <summary>
+            /// To the type of the helix metadata.
+            /// </summary>
+            /// <param name="type">The type.</param>
+            /// <returns></returns>
+            /// <exception cref="NotSupportedException">Type {type} is not supported.</exception>
+            public static Model.MetaDataType ToHelixMetadataType(this global::Assimp.MetaDataType type)
+            {
+                switch(type)
+                {
+                    case MetaDataType.Bool:
+                        return Model.MetaDataType.Bool;
+                    case MetaDataType.Double:
+                        return Model.MetaDataType.Double;
+                    case MetaDataType.Float:
+                        return Model.MetaDataType.Float;
+                    case MetaDataType.Int32:
+                        return Model.MetaDataType.Int32;
+                    case MetaDataType.String:
+                        return Model.MetaDataType.String;
+                    case MetaDataType.UInt64:
+                        return Model.MetaDataType.UInt64;
+                    case MetaDataType.Vector3D:
+                        return Model.MetaDataType.Vector3D;
+                    default:
+                        throw new NotSupportedException($"Type {type} is not supported.");
+                }
+            }
+
+            /// <summary>
+            /// To the type of the assimp metadata.
+            /// </summary>
+            /// <param name="type">The type.</param>
+            /// <returns></returns>
+            /// <exception cref="NotSupportedException">Type {type} is not supported.</exception>
+            public static MetaDataType ToAssimpMetadataType(this Model.MetaDataType type)
+            {
+                switch (type)
+                {
+                    case Model.MetaDataType.Bool:
+                        return MetaDataType.Bool;
+                    case Model.MetaDataType.Double:
+                        return MetaDataType.Double;
+                    case Model.MetaDataType.Float:
+                        return MetaDataType.Float;
+                    case Model.MetaDataType.Int32:
+                        return MetaDataType.Int32;
+                    case Model.MetaDataType.String:
+                        return MetaDataType.String;
+                    case Model.MetaDataType.UInt64:
+                        return MetaDataType.UInt64;
+                    case Model.MetaDataType.Vector3D:
+                        return MetaDataType.Vector3D;
+                    default:
+                        throw new NotSupportedException($"Type {type} is not supported.");
+                }
+            }
+
+            /// <summary>
+            /// To the helix metadata.
+            /// </summary>
+            /// <param name="m">The m.</param>
+            /// <returns></returns>
+            public static IEnumerable<KeyValuePair<string, Model.Metadata.Entry>> ToHelixMetadata(this Metadata m)
+            {
+                foreach(var d in m)
+                {
+                    yield return new KeyValuePair<string, Model.Metadata.Entry>(d.Key, new Model.Metadata.Entry(d.Value.DataType.ToHelixMetadataType(), d.Value.Data));
+                }
+            }
+
+            /// <summary>
+            /// To the assimp metadata.
+            /// </summary>
+            /// <param name="m">The m.</param>
+            /// <returns></returns>
+            public static IEnumerable<KeyValuePair<string, Metadata.Entry>> ToAssimpMetadata(this Model.Metadata m)
+            {
+                foreach (var d in m)
+                {
+                    yield return new KeyValuePair<string, Metadata.Entry>(d.Key, new Metadata.Entry(d.Value.DataType.ToAssimpMetadataType(), d.Value.Data));
+                }
             }
         }
     }

--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/Importer.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/Importer.cs
@@ -455,6 +455,14 @@ namespace HelixToolkit.UWP
                         group.AddChildNode(hxNode);
                     }
                 }
+                if(node.Metadata.Count > 0)
+                {
+                    group.Metadata = new Metadata();
+                    foreach (var metadata in node.Metadata.ToHelixMetadata())
+                    {
+                        group.Metadata.Add(metadata.Key, metadata.Value);
+                    }
+                }
                 return group;
             }
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -174,6 +174,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\PointMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\Variables\VolumeMaterialVariable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Material\VolumeTextureMaterial.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Metadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\OrderKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\Abstract\ParametricSurface3DNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\BatchedMeshNode.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Metadata.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Metadata.cs
@@ -1,0 +1,179 @@
+﻿/*
+* Copyright (c) 2012-2018 AssimpNet - Nicholas Woodfield
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+using System;
+using System.Collections.Generic;
+using SharpDX;
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    namespace Model
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public enum MetaDataType
+        {
+            Bool = 0,
+            Int32 = 1,
+            UInt64 = 2,
+            Float = 3,
+            Double = 4,
+            String = 5,
+            Vector3D = 6
+        }
+
+        /// <summary>
+        /// Represents a container for holding metadata, representing as key-value pairs.
+        /// </summary>
+        public sealed class Metadata : Dictionary<string, Metadata.Entry>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Metadata"/> class.
+            /// </summary>
+            public Metadata()
+            {
+
+            }
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Metadata"/> class.
+            /// </summary>
+            /// <param name="capacity">The capacity.</param>
+            public Metadata(int capacity) : base(capacity)
+            {
+
+            }
+            /// <summary>
+            /// 
+            /// </summary>
+            public struct Entry : IEquatable<Entry>
+            {
+                /// <summary>
+                /// Initializes a new instance of the <see cref="Entry"/> struct.
+                /// </summary>
+                /// <param name="dataType">Type of the data.</param>
+                /// <param name="data">The data.</param>
+                public Entry(MetaDataType dataType, object data)
+                {
+                    DataType = dataType;
+                    Data = data;
+                }
+                /// <summary>
+                /// Gets the type of the data.
+                /// </summary>
+                /// <value>
+                /// The type of the data.
+                /// </value>
+                public MetaDataType DataType { get; }
+                /// <summary>
+                /// Gets the data.
+                /// </summary>
+                /// <value>
+                /// The data.
+                /// </value>
+                public object Data { get; }
+
+                public T? DataAs<T>() where T : struct
+                {
+                    Type dataTypeType = null;
+                    switch (DataType)
+                    {
+                        case MetaDataType.Bool:
+                            dataTypeType = typeof(bool);
+                            break;
+                        case MetaDataType.Float:
+                            dataTypeType = typeof(float);
+                            break;
+                        case MetaDataType.Double:
+                            dataTypeType = typeof(double);
+                            break;
+                        case MetaDataType.Int32:
+                            dataTypeType = typeof(int);
+                            break;
+                        case MetaDataType.String:
+                            dataTypeType = typeof(String);
+                            break;
+                        case MetaDataType.UInt64:
+                            dataTypeType = typeof(UInt64);
+                            break;
+                        case MetaDataType.Vector3D:
+                            dataTypeType = typeof(Vector3);
+                            break;
+                    }
+
+                    if (dataTypeType == typeof(T))
+                        return (T)Data;
+
+                    return null;
+                }
+
+                public override bool Equals(object obj)
+                {
+                    if(obj is Entry e)
+                    {
+                        return e.Equals(this);
+                    }
+                    return false;
+                }
+
+                public bool Equals(Entry other)
+                {
+                    return other.DataType == DataType && other.Data.Equals(Data);
+                }
+
+                public override int GetHashCode()
+                {
+                    unchecked
+                    {
+                        int hash = 17;
+                        hash = (hash * 31) + Data.GetHashCode();
+                        hash = (hash * 31) + ((Data == null) ? 0 : Data.GetHashCode());
+
+                        return hash;
+                    }
+                }
+
+                public override string ToString()
+                {
+                    return $"Type:{DataType}; Value:{Data.ToString()}";
+                }
+
+                public static bool operator ==(Entry a, Entry b)
+                {
+                    return a.Equals(b);
+                }
+
+                public static bool operator !=(Entry a, Entry b)
+                {
+                    return !a.Equals(b);
+                }
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GroupNodeBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GroupNodeBase.cs
@@ -59,6 +59,14 @@ namespace HelixToolkit.UWP
                 public static implicit operator SceneNode(OnChildNodeChangedArgs args) { return args.Node; }
             }
             protected readonly Dictionary<Guid, SceneNode> itemHashSet = new Dictionary<Guid, SceneNode>();
+            /// <summary>
+            /// Gets or sets the metadata.
+            /// Metadata is used to store additional data to describe the scene node.
+            /// </summary>
+            /// <value>
+            /// The metadata.
+            /// </value>
+            public Metadata Metadata { set; get; }
 
             public event EventHandler<OnChildNodeChangedArgs> ChildNodeAdded;
             public event EventHandler<OnChildNodeChangedArgs> ChildNodeRemoved;


### PR DESCRIPTION
Helixtoolkit will only support metadata on group node which is similar to the assimp node structure.