### PR TITLE
Create NuGet package for HelixToolkit.Wpf.Input

### DIFF
--- a/Source/AssemblyInfo.cs
+++ b/Source/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyProduct("Helix Toolkit")]
 [assembly: AssemblyCompany("Helix Toolkit")]
-[assembly: AssemblyCopyright("Copyright (C) Helix Toolkit 2018.")]
+[assembly: AssemblyCopyright("Copyright (C) Helix Toolkit 2019.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Source/HelixToolkit.Wpf.Input/HelixToolkit.Wpf.Input.csproj
+++ b/Source/HelixToolkit.Wpf.Input/HelixToolkit.Wpf.Input.csproj
@@ -57,6 +57,9 @@
       <Name>HelixToolkit.Wpf</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="HelixToolkit.Wpf.Input.nuspec" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/HelixToolkit.Wpf.Input/HelixToolkit.Wpf.Input.nuspec
+++ b/Source/HelixToolkit.Wpf.Input/HelixToolkit.Wpf.Input.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>HelixToolkit.Wpf.Input</id>
+    <version>$version$</version>
+    <title>Helix Toolkit SpaceNavigator Decorator for WPF</title>
+    <authors>objo</authors>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/helix-toolkit/helix-toolkit</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/helix-toolkit/helix-toolkit/master/Images/helixtoolkit.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Provides SpaceNavigator decorator for custom controls and extensions for WPF 3D.</description>
+    <tags>wpf wpf3d 3D input SpaceNavigator</tags>
+    <dependencies>
+      <group>
+        <dependency id="HelixToolkit.Wpf" version="[$version$]" />
+        <dependency id="TDx.TDxInput" version="1.1" />
+      </group>
+      <group targetFramework="net45">
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\HelixToolkit.Wpf.Input.???" target="lib\net45" />
+    <file src="..\..\LICENSE" />
+    <file src="..\..\AUTHORS" />
+    <file src="..\..\CONTRIBUTORS" />
+    <file src="..\..\README.md" />
+  </files>
+</package>

--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
@@ -90,6 +90,7 @@
     </EmbeddedResource>
     <AppDesigner Include="Properties\" />
     <Resource Include="ShaderEffects\AnaglyphEffect.ps" />
+    <None Include="HelixToolkit.Wpf.nuspec" />
     <None Include="ShaderEffects\compileEffects.cmd" />
     <Resource Include="ShaderEffects\InterlacedEffect.ps" />
   </ItemGroup>

--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.nuspec
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.nuspec
@@ -12,18 +12,18 @@
     <description>Provides custom controls and extensions for WPF 3D.</description>
     <tags>wpf wpf3d 3D</tags>
     <dependencies>
-	  <group>
-        <dependency id="HelixToolkit" version="[$version$]" />	  
-	  </group>
-	  <group targetFramework="net45">
-      </group>	
+      <group>
+        <dependency id="HelixToolkit" version="[$version$]" />
+      </group>
+      <group targetFramework="net45">
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="HelixToolkit.Wpf\bin\Release\HelixToolkit.Wpf.???" target="lib\net45" />
-    <file src="..\LICENSE" />
-    <file src="..\AUTHORS" />
-    <file src="..\CONTRIBUTORS" />
-    <file src="..\README.md" />
+    <file src="bin\Release\HelixToolkit.Wpf.???" target="lib\net45" />
+    <file src="..\..\LICENSE" />
+    <file src="..\..\AUTHORS" />
+    <file src="..\..\CONTRIBUTORS" />
+    <file src="..\..\README.md" />
   </files>
 </package>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
 
 after_build:
   - nuget pack Source\HelixToolkit\HelixToolkit.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
-  - nuget pack Source\HelixToolkit.Wpf.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
+  - nuget pack Source\HelixToolkit.Wpf\HelixToolkit.Wpf.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.Wpf.Sharpdx.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.UWP\HelixToolkit.UWP.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.SharpDX.Core\HelixToolkit.SharpDX.Core.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ build_script:
 after_build:
   - nuget pack Source\HelixToolkit\HelixToolkit.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.Wpf\HelixToolkit.Wpf.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
+  - nuget pack Source\HelixToolkit.Wpf.Input\HelixToolkit.Wpf.Input.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.Wpf.Sharpdx.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.UWP\HelixToolkit.UWP.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.SharpDX.Core\HelixToolkit.SharpDX.Core.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg


### PR DESCRIPTION
I really wanted to be able to use this as a NuGet package, but found there was an outstanding open issue ( #99 ) for the missing package so I'm attempting to do the groundwork to get it added. Hopefully this can get incorporated soon. The library works as needed for my purposes, but it is really difficult for me to build with proper assembly version numbers since I have no experience with AppVeyor which seems to be managing the assembly versions. It would be so much cleaner for the package to be provided by the main project.