### PR TITLE
Fix bitmap cache crash due to size is negative.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/SceneNode2DCache.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/SceneNode2DCache.cs
@@ -58,7 +58,7 @@ namespace HelixToolkit.UWP
             private void EnsureBitmapCache(RenderContext2D context, Size2 size, int maxSize)
             {
                 IsBitmapCacheValid = false;
-                if (size.Width == 0 || size.Height == 0 || !EnableBitmapCache || size.Width * size.Height < MinimumBitmapSize)
+                if (size.Width <= 0 || size.Height <= 0 || !EnableBitmapCache || size.Width * size.Height < MinimumBitmapSize)
                 {
                     Disposer.RemoveAndDispose(ref bitmapCache);
                 }


### PR DESCRIPTION
Fix bitmap cache crash due to size is negative. Ref: #1125