### PR TITLE
Small improvements to project files

### DIFF
--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj
@@ -70,17 +70,17 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>$(ProjectDir)\$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>$(ProjectDir)\$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>$(SolutionDir)$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>$(ProjectDir)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>$(SolutionDir)$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>$(ProjectDir)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -91,9 +91,9 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <PostBuildEvent>
-      <Command>xcopy /y /f /i $(SolutionDir)HelixToolkit.Native.ShaderBuilder\$(Platform)\$(Configuration)\*.cso "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources"
-xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(SolutionDir)HelixToolkit.UWP\Resources"
-xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(SolutionDir)HelixToolkit.SharpDX.Core\Resources"</Command>
+      <Command>xcopy /y /f /i "$(ProjectDir)$(Platform)\$(Configuration)\*.cso" "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources"
+xcopy /y /q /i "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(ProjectDir)..\HelixToolkit.UWP\Resources"
+xcopy /y /q /i "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(ProjectDir)..\HelixToolkit.SharpDX.Core\Resources"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -104,9 +104,9 @@ xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(Solut
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <PostBuildEvent>
-      <Command>xcopy /y /f /i $(SolutionDir)HelixToolkit.Native.ShaderBuilder\$(Platform)\$(Configuration)\*.cso "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources"
-xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(SolutionDir)HelixToolkit.UWP\Resources"
-xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(SolutionDir)HelixToolkit.SharpDX.Core\Resources"</Command>
+      <Command>xcopy /y /f /i "$(ProjectDir)$(Platform)\$(Configuration)\*.cso" "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources"
+xcopy /y /q /i "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(ProjectDir)..\HelixToolkit.UWP\Resources"
+xcopy /y /q /i "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(ProjectDir)..\HelixToolkit.SharpDX.Core\Resources"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -123,9 +123,9 @@ xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(Solut
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y /f /i $(SolutionDir)HelixToolkit.Native.ShaderBuilder\$(Platform)\$(Configuration)\*.cso "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources"
-xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(SolutionDir)HelixToolkit.UWP\Resources"
-xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(SolutionDir)HelixToolkit.SharpDX.Core\Resources"</Command>
+      <Command>xcopy /y /f /i "$(ProjectDir)$(Platform)\$(Configuration)\*.cso" "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources"
+xcopy /y /q /i "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(ProjectDir)..\HelixToolkit.UWP\Resources"
+xcopy /y /q /i "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(ProjectDir)..\HelixToolkit.SharpDX.Core\Resources"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -142,9 +142,9 @@ xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(Solut
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /y /f /i $(SolutionDir)HelixToolkit.Native.ShaderBuilder\$(Platform)\$(Configuration)\*.cso "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources"
-xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(SolutionDir)HelixToolkit.UWP\Resources"
-xcopy /y /q /i "$(SolutionDir)HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(SolutionDir)HelixToolkit.SharpDX.Core\Resources"</Command>
+      <Command>xcopy /y /f /i "$(ProjectDir)$(Platform)\$(Configuration)\*.cso" "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources"
+xcopy /y /q /i "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(ProjectDir)..\HelixToolkit.UWP\Resources"
+xcopy /y /q /i "$(ProjectDir)..\HelixToolkit.Wpf.SharpDX\Resources\*.cso" "$(ProjectDir)..\HelixToolkit.SharpDX.Core\Resources"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj.filters
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.vcxproj.filters
@@ -317,11 +317,17 @@
     <FxCompile Include="VS\vsSSAO.hlsl">
       <Filter>VS</Filter>
     </FxCompile>
-    <FxCompile Include="VS\vsMeshBatchedSSAO.hlsl" />
     <FxCompile Include="PS\psEffectOutlineSmooth.hlsl">
       <Filter>PS</Filter>
     </FxCompile>
-    <FxCompile Include="GS\gsLineArrowHead.hlsl" />
-    <FxCompile Include="GS\gsLineArrowHeadTail.hlsl" />
+    <FxCompile Include="GS\gsLineArrowHead.hlsl">
+      <Filter>GS</Filter>
+    </FxCompile>
+    <FxCompile Include="GS\gsLineArrowHeadTail.hlsl">
+      <Filter>GS</Filter>
+    </FxCompile>
+    <FxCompile Include="VS\vsMeshBatchedSSAO.hlsl">
+      <Filter>VS</Filter>
+    </FxCompile>
   </ItemGroup>
 </Project>

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -56,6 +56,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>


### PR DESCRIPTION
This pull request provides small improvements to some project files:

HelixToolkit.Native.ShaderBuilder.vcxproj:
- Use relative to project directories for compile and copy task to allow the use of helixtoolkit projects inside of solutions on a directory level 

HelixToolkit.Native.ShaderBuilder.vcxproj.filters:
- Use correct "filter" for shader type

HelixToolkit.Wpf.SharpDX.csproj:
- Allow unsafe code in all platform/configuration 
