### PR TITLE
Fix render exception handling to prevent MessageBox.Show()

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/IRenderCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/IRenderCanvas.cs
@@ -5,6 +5,9 @@ namespace HelixToolkit.Wpf.SharpDX
 {
     namespace Controls
     {
+        using System;
+        using Utilities;
+
         /// <summary>
         /// Canvas holds the RenderHost. Provide entry point or render surface for RenderHost to render to.
         /// </summary>
@@ -17,6 +20,11 @@ namespace HelixToolkit.Wpf.SharpDX
             /// The render host.
             /// </value>
             IRenderHost RenderHost { get; }
+
+            /// <summary>
+            /// Fired whenever an exception occurred on this object.
+            /// </summary>
+            event EventHandler<RelayExceptionEventArgs> ExceptionOccurred;
         }
     }
 

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
@@ -624,6 +624,11 @@ namespace HelixToolkit.Wpf.SharpDX
             Disposer.RemoveAndDispose(ref renderHostInternal);
             hostPresenter = this.GetTemplateChild("PART_Canvas") as ContentPresenter;
 
+            if (this.hostPresenter?.Content is IRenderCanvas renderCanvas)
+            {
+                renderCanvas.ExceptionOccurred -= this.HandleRenderException;
+            }
+
             if (EnableSwapChainRendering)
             {
                 double dpiXScale = 1;
@@ -647,7 +652,9 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.renderHostInternal.ExceptionOccurred -= this.HandleRenderException;
             }
 
-            renderHostInternal = (hostPresenter.Content as IRenderCanvas).RenderHost;
+            renderCanvas = (IRenderCanvas)this.hostPresenter.Content;
+            this.renderHostInternal = renderCanvas.RenderHost;
+            renderCanvas.ExceptionOccurred += this.HandleRenderException;
             if (this.renderHostInternal != null)
             {
                 this.renderHostInternal.Rendered += this.RaiseRenderHostRendered;

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Controls/CanvasMock.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Controls/CanvasMock.cs
@@ -14,9 +14,13 @@ using SharpDX.Direct3D11;
 
 namespace HelixToolkit.Wpf.SharpDX.Tests.Controls
 {
+    using SharpDX.Utilities;
+
     class CanvasMock : IRenderCanvas
     {
         public IRenderHost RenderHost { private set; get; } = new DefaultRenderHost();
+
+        public event EventHandler<RelayExceptionEventArgs> ExceptionOccurred;
 
         public CanvasMock()
         {


### PR DESCRIPTION
This pull request fixes render exception handling to prevent MessageBox.Show() if custom handling is desired.

![2019-09-11_Perforex_CncVisX_HxTkDx](https://user-images.githubusercontent.com/8622962/64680126-788cba80-d47d-11e9-8a45-5fa87856f06a.jpg)
