### PR TITLE
Fix nuget dependency resolution

### DIFF
--- a/Source/HelixToolkit.SharpDX.Assimp.nuspec
+++ b/Source/HelixToolkit.SharpDX.Assimp.nuspec
@@ -12,34 +12,44 @@
     <description>Provides Assimp Import/Export for HelixToolkit.SharpDX.</description>
     <tags>netstandard netcore Wpf UWP SharpDX 3D DirectX Assimp</tags>
     <dependencies>
-	  <group>
-		<dependency id="AssimpNet" version="4.1.0" />
-		<dependency id="SharpDX" version="4.2.0" />
-		<dependency id="SharpDX.Direct3D11" version="4.2.0" />
-		<dependency id="SharpDX.Mathematics" version="4.2.0" />
-	  </group>
-	  <group targetFramework="net45">		
-		<dependency id="HelixToolkit.Wpf.SharpDX" version="[$version$]" />
-	  </group>
-	  <group targetFramework="UAP10.0">
-		<dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.1.7" exclude="Build,Analyzers" />
-		<dependency id="HelixToolkit.UWP" version="[$version$]" />
+      <group targetFramework="net45">		
+        <dependency id="HelixToolkit.Wpf.SharpDX" version="[$version$]" />
+        <dependency id="AssimpNet" version="4.1.0" />
+        <dependency id="SharpDX" version="4.2.0" />
+        <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+        <dependency id="SharpDX.Mathematics" version="4.2.0" />
       </group>
-	  <group targetFramework="netcoreapp2.1">
-		<dependency id="HelixToolkit.SharpDX.Core" version="[$version$]" />
+      <group targetFramework="UAP10.0">
+        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.1.7" exclude="Build,Analyzers" />
+        <dependency id="HelixToolkit.UWP" version="[$version$]" />
+        <dependency id="AssimpNet" version="4.1.0" />
+        <dependency id="SharpDX" version="4.2.0" />
+        <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+        <dependency id="SharpDX.Mathematics" version="4.2.0" />
+      </group>
+      <group targetFramework="netcoreapp2.1">
+        <dependency id="HelixToolkit.SharpDX.Core" version="[$version$]" />
+        <dependency id="AssimpNet" version="4.1.0" />
+        <dependency id="SharpDX" version="4.2.0" />
+        <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+        <dependency id="SharpDX.Mathematics" version="4.2.0" />
       </group>	  
-	  <group targetFramework="netstandard1.3">
-		<dependency id="HelixToolkit.SharpDX.Core" version="[$version$]" />
+      <group targetFramework="netstandard1.3">
+        <dependency id="HelixToolkit.SharpDX.Core" version="[$version$]" />
+        <dependency id="AssimpNet" version="4.1.0" />
+        <dependency id="SharpDX" version="4.2.0" />
+        <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+        <dependency id="SharpDX.Mathematics" version="4.2.0" />
       </group>	  
     </dependencies>
   </metadata>
   <files>
     <file src="HelixToolkit.Wpf.SharpDX.Assimp\bin\Release\HelixToolkit.Wpf.SharpDX.Assimp.???" target="lib\net45" />
     <file src="HelixToolkit.UWP.Assimp\bin\Release\HelixToolkit.UWP.Assimp.???" target="lib\uap10.0" />
-  	<file src="HelixToolkit.SharpDX.Core.Assimp\bin\Release\netstandard1.3\HelixToolkit.SharpDX.Core.Assimp.???" target="lib\netstandard1.3" />
-	<file src="HelixToolkit.SharpDX.Core.Assimp\bin\Release\netstandard1.3\HelixToolkit.SharpDX.Core.Assimp.deps.json" target="lib\netstandard1.3" />
-	<file src="HelixToolkit.SharpDX.Core.Assimp\bin\Release\netcoreapp2.1\HelixToolkit.SharpDX.Core.Assimp.???" target="lib\netcoreapp2.1" />
-	<file src="HelixToolkit.SharpDX.Core.Assimp\bin\Release\netcoreapp2.1\HelixToolkit.SharpDX.Core.Assimp.deps.json" target="lib\netcoreapp2.1" />
+    <file src="HelixToolkit.SharpDX.Core.Assimp\bin\Release\netstandard1.3\HelixToolkit.SharpDX.Core.Assimp.???" target="lib\netstandard1.3" />
+    <file src="HelixToolkit.SharpDX.Core.Assimp\bin\Release\netstandard1.3\HelixToolkit.SharpDX.Core.Assimp.deps.json" target="lib\netstandard1.3" />
+    <file src="HelixToolkit.SharpDX.Core.Assimp\bin\Release\netcoreapp2.1\HelixToolkit.SharpDX.Core.Assimp.???" target="lib\netcoreapp2.1" />
+    <file src="HelixToolkit.SharpDX.Core.Assimp\bin\Release\netcoreapp2.1\HelixToolkit.SharpDX.Core.Assimp.deps.json" target="lib\netcoreapp2.1" />
     <file src="..\LICENSE" />
     <file src="..\AUTHORS" />
     <file src="..\CONTRIBUTORS" />

--- a/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.nuspec
+++ b/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.nuspec
@@ -12,34 +12,47 @@
     <description>Provides custom 3D controls for netstandard and netcore based on SharpDX.</description>
     <tags>netstandard netcore SharpDX 3D</tags>
     <dependencies>
-	   <group>
-		<dependency id="Cyotek.Drawing.BitmapFont" version="1.3.4" />
-		<dependency id="HelixToolkit" version="[$version$]" />
-		<dependency id="SharpDX" version="4.2.0" />
-		<dependency id="SharpDX.D3DCompiler" version="4.2.0" />
-		<dependency id="SharpDX.Direct2D1" version="4.2.0" />
-		<dependency id="SharpDX.Direct3D11" version="4.2.0" />
-		<dependency id="SharpDX.DXGI" version="4.2.0" />
-		<dependency id="SharpDX.Mathematics" version="4.2.0" />	 
-		<dependency id="System.ComponentModel.TypeConverter" version="4.3.0"/>
-		<dependency id="System.Drawing.Primitives" version="4.3.0"/>		
-		<dependency id="System.Private.DataContractSerialization" version="4.3.0"/>
-		<dependency id="System.Reflection.TypeExtensions" version="4.3.0"/>
-		<dependency id="System.Runtime.Serialization.Primitives" version="4.3.0"/>
-		<dependency id="System.Runtime.Serialization.Xml" version="4.3.0"/>
-		<dependency id="System.Threading.Tasks.Parallel" version="4.3.0"/>		
-	   </group>
-	   <group targetFramework="netcoreapp2.1">
+      <group targetFramework="netcoreapp2.1">
+        <dependency id="Cyotek.Drawing.BitmapFont" version="1.3.4" />
+        <dependency id="HelixToolkit" version="[$version$]" />
+        <dependency id="SharpDX" version="4.2.0" />
+        <dependency id="SharpDX.D3DCompiler" version="4.2.0" />
+        <dependency id="SharpDX.Direct2D1" version="4.2.0" />
+        <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+        <dependency id="SharpDX.DXGI" version="4.2.0" />
+        <dependency id="SharpDX.Mathematics" version="4.2.0" />	 
+        <dependency id="System.ComponentModel.TypeConverter" version="4.3.0"/>
+        <dependency id="System.Drawing.Primitives" version="4.3.0"/>		
+        <dependency id="System.Private.DataContractSerialization" version="4.3.0"/>
+        <dependency id="System.Reflection.TypeExtensions" version="4.3.0"/>
+        <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0"/>
+        <dependency id="System.Runtime.Serialization.Xml" version="4.3.0"/>
+        <dependency id="System.Threading.Tasks.Parallel" version="4.3.0"/>		
       </group>
-	  <group targetFramework="netstandard1.3">
+      <group targetFramework="netstandard1.3">
+        <dependency id="Cyotek.Drawing.BitmapFont" version="1.3.4" />
+        <dependency id="HelixToolkit" version="[$version$]" />
+        <dependency id="SharpDX" version="4.2.0" />
+        <dependency id="SharpDX.D3DCompiler" version="4.2.0" />
+        <dependency id="SharpDX.Direct2D1" version="4.2.0" />
+        <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+        <dependency id="SharpDX.DXGI" version="4.2.0" />
+        <dependency id="SharpDX.Mathematics" version="4.2.0" />	 
+        <dependency id="System.ComponentModel.TypeConverter" version="4.3.0"/>
+        <dependency id="System.Drawing.Primitives" version="4.3.0"/>		
+        <dependency id="System.Private.DataContractSerialization" version="4.3.0"/>
+        <dependency id="System.Reflection.TypeExtensions" version="4.3.0"/>
+        <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0"/>
+        <dependency id="System.Runtime.Serialization.Xml" version="4.3.0"/>
+        <dependency id="System.Threading.Tasks.Parallel" version="4.3.0"/>		
       </group>
     </dependencies>
   </metadata>
   <files>
-  	<file src="bin\Release\netstandard1.3\HelixToolkit.SharpDX.Core.???" target="lib\netstandard1.3" />
-	<file src="bin\Release\netstandard1.3\HelixToolkit.SharpDX.Core.deps.json" target="lib\netstandard1.3" />
-	<file src="bin\Release\netcoreapp2.1\HelixToolkit.SharpDX.Core.???" target="lib\netcoreapp2.1" />
-	<file src="bin\Release\netcoreapp2.1\HelixToolkit.SharpDX.Core.deps.json" target="lib\netcoreapp2.1" />
+    <file src="bin\Release\netstandard1.3\HelixToolkit.SharpDX.Core.???" target="lib\netstandard1.3" />
+    <file src="bin\Release\netstandard1.3\HelixToolkit.SharpDX.Core.deps.json" target="lib\netstandard1.3" />
+    <file src="bin\Release\netcoreapp2.1\HelixToolkit.SharpDX.Core.???" target="lib\netcoreapp2.1" />
+    <file src="bin\Release\netcoreapp2.1\HelixToolkit.SharpDX.Core.deps.json" target="lib\netcoreapp2.1" />
     <file src="..\..\LICENSE" />
     <file src="..\..\AUTHORS" />
     <file src="..\..\CONTRIBUTORS" />

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.nuspec
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.nuspec
@@ -12,27 +12,27 @@
     <description>Provides custom 3D controls for UWP and a scene graph based on SharpDX.</description>
     <tags>UWP SharpDX 3D</tags>
     <dependencies>
-	  <group targetFramework="UAP10.0">
-		<dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.1.7" exclude="Build,Analyzers" />
-		<dependency id="Cyotek.Drawing.BitmapFont" version="1.3.4" />
-		<dependency id="HelixToolkit" version="[$version$]" />
-		<dependency id="SharpDX" version="4.2.0" />
-		<dependency id="SharpDX.D3DCompiler" version="4.2.0" />
-		<dependency id="SharpDX.Direct2D1" version="4.2.0" />
-		<dependency id="SharpDX.Direct3D11" version="4.2.0" />
-		<dependency id="SharpDX.DXGI" version="4.2.0" />
-		<dependency id="SharpDX.Mathematics" version="4.2.0" />
-		<dependency id="System.ComponentModel.TypeConverter" version="4.3.0"/>
-		<dependency id="System.Drawing.Primitives" version="4.3.0"/>		
-		<dependency id="System.Private.DataContractSerialization" version="4.3.0"/>
+	    <group targetFramework="UAP10.0">
+		    <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.1.7" exclude="Build,Analyzers" />
+		    <dependency id="Cyotek.Drawing.BitmapFont" version="1.3.4" />
+		    <dependency id="HelixToolkit" version="[$version$]" />
+		    <dependency id="SharpDX" version="4.2.0" />
+		    <dependency id="SharpDX.D3DCompiler" version="4.2.0" />
+		    <dependency id="SharpDX.Direct2D1" version="4.2.0" />
+		    <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+		    <dependency id="SharpDX.DXGI" version="4.2.0" />
+		    <dependency id="SharpDX.Mathematics" version="4.2.0" />
+		    <dependency id="System.ComponentModel.TypeConverter" version="4.3.0"/>
+		    <dependency id="System.Drawing.Primitives" version="4.3.0"/>		
+		    <dependency id="System.Private.DataContractSerialization" version="4.3.0"/>
       </group>
     </dependencies>
   </metadata>
   <files>
-  	<file src="bin\Release\HelixToolkit.UWP.???" target="lib\uap10.0" />
-	<file src="bin\Release\HelixToolkit.UWP.??.xml" target="lib\uap10.0\HelixToolkit.UWP" />
-	<file src="bin\Release\Resources\*.*" target="lib\uap10.0\HelixToolkit.UWP\Resources" />
-	<file src="bin\Release\Themes\*.*" target="lib\uap10.0\HelixToolkit.UWP\Themes" />
+    <file src="bin\Release\HelixToolkit.UWP.???" target="lib\uap10.0" />
+    <file src="bin\Release\HelixToolkit.UWP.??.xml" target="lib\uap10.0\HelixToolkit.UWP" />
+    <file src="bin\Release\Resources\*.*" target="lib\uap10.0\HelixToolkit.UWP\Resources" />
+    <file src="bin\Release\Themes\*.*" target="lib\uap10.0\HelixToolkit.UWP\Themes" />
     <file src="..\..\LICENSE" />
     <file src="..\..\AUTHORS" />
     <file src="..\..\CONTRIBUTORS" />

--- a/Source/HelixToolkit.Wpf.Input/HelixToolkit.Wpf.Input.nuspec
+++ b/Source/HelixToolkit.Wpf.Input/HelixToolkit.Wpf.Input.nuspec
@@ -12,10 +12,8 @@
     <description>Provides SpaceNavigator decorator for custom controls and extensions for WPF 3D.</description>
     <tags>wpf wpf3d 3D input SpaceNavigator</tags>
     <dependencies>
-      <group>
-        <dependency id="HelixToolkit.Wpf" version="[$version$]" />
-      </group>
       <group targetFramework="net45">
+        <dependency id="HelixToolkit.Wpf" version="[$version$]" />
       </group>
     </dependencies>
   </metadata>

--- a/Source/HelixToolkit.Wpf.SharpDX.nuspec
+++ b/Source/HelixToolkit.Wpf.SharpDX.nuspec
@@ -12,24 +12,22 @@
     <description>Provides custom controls for WPF and a scene graph based on SharpDX.</description>
     <tags>wpf SharpDX DirectX 3D</tags>
     <dependencies>
-	  <group>
-		<dependency id="SharpDX" version="4.2.0" />
-		<dependency id="SharpDX.D3DCompiler" version="4.2.0" />
-		<dependency id="SharpDX.Direct2D1" version="4.2.0" />
-		<dependency id="SharpDX.Direct3D11" version="4.2.0" />
-		<dependency id="SharpDX.Direct3D9" version="4.2.0" />
-		<dependency id="SharpDX.DXGI" version="4.2.0" />
-		<dependency id="SharpDX.Mathematics" version="4.2.0" />	  
-		<dependency id="HelixToolkit" version="[$version$]" />	
-	  </group>
-	  <group targetFramework="net45">
-		<dependency id="Cyotek.Drawing.BitmapFont" version="1.3.4" />	  
+	    <group targetFramework="net45">
+		    <dependency id="HelixToolkit" version="[$version$]" />	
+		    <dependency id="Cyotek.Drawing.BitmapFont" version="1.3.4" />	  
+		    <dependency id="SharpDX" version="4.2.0" />
+		    <dependency id="SharpDX.D3DCompiler" version="4.2.0" />
+		    <dependency id="SharpDX.Direct2D1" version="4.2.0" />
+		    <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+		    <dependency id="SharpDX.Direct3D9" version="4.2.0" />
+		    <dependency id="SharpDX.DXGI" version="4.2.0" />
+		    <dependency id="SharpDX.Mathematics" version="4.2.0" />	  
       </group>	
     </dependencies>
   </metadata>
   <files>
     <file src="HelixToolkit.Wpf.SharpDX\bin\Release\HelixToolkit.Wpf.SharpDX.???" target="lib\net45" />
-	<file src="..\LICENSE" />
+    <file src="..\LICENSE" />
     <file src="..\AUTHORS" />
     <file src="..\CONTRIBUTORS" />
     <file src="..\README.md" />

--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.nuspec
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.nuspec
@@ -12,10 +12,8 @@
     <description>Provides custom controls and extensions for WPF 3D.</description>
     <tags>wpf wpf3d 3D</tags>
     <dependencies>
-      <group>
-        <dependency id="HelixToolkit" version="[$version$]" />
-      </group>
       <group targetFramework="net45">
+        <dependency id="HelixToolkit" version="[$version$]" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This pull request fixes a problem with nuget dependency resolution. In .nuspec files, `<group>` nodes without `targetFramework` are treated as fallback and *not* common dependencies (see: https://github.com/NuGet/Home/issues/1661).