### PR TITLE
Add support to only allow rotate on x or y direction. Ref: #1239

### DIFF
--- a/Source/HelixToolkit.SharpDX.Core/Controls/CameraController.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/CameraController.cs
@@ -443,6 +443,19 @@ namespace HelixToolkit.SharpDX.Core.Controls
         }
 
         /// <summary>
+        /// Gets or sets to allow rotate x direction and y direction globally. X, Y is screen space.
+        /// <para>X = 1: Allow left/right rotation. Y = 1: Allow up/down rotation</para>
+        /// <para>Default is (1, 1)</para>
+        /// </summary>
+        /// <value>
+        /// The allow rotate xy.
+        /// </value>
+        public Vector2 AllowRotateXY
+        {
+            set; get;
+        } = Vector2.One;
+
+        /// <summary>
         /// Gets or sets Viewport.
         /// </summary>
         public ViewportCore Viewport

--- a/Source/HelixToolkit.SharpDX.Core/Controls/RotateHandler.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/RotateHandler.cs
@@ -107,6 +107,8 @@ namespace HelixToolkit.SharpDX.Core.Controls
                 Controller.StopZooming();
                 Controller.StopPanning();
             }
+            p0 = Vector2.Multiply(p0, Controller.AllowRotateXY);
+            p1 = Vector2.Multiply(p1, Controller.AllowRotateXY);
             var newPos = Camera.Position;
             var newLook = Camera.LookDirection;
             var newUp = Vector3.Normalize(Camera.UpDirection);

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
@@ -514,6 +514,19 @@ namespace HelixToolkit.UWP
             set; get;
         } = new Point3D();
 
+        /// <summary>
+        /// Gets or sets to allow rotate x direction and y direction globally. X, Y is screen space.
+        /// <para>X = 1: Allow left/right rotation. Y = 1: Allow up/down rotation</para>
+        /// <para>Default is (1, 1)</para>
+        /// </summary>
+        /// <value>
+        /// The allow rotate xy.
+        /// </value>
+        public Vector2 AllowRotateXY
+        {
+            set; get;
+        } = Vector2.One;
+
         internal int Width;
         internal int Height;
         #endregion

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/RotateHandler.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/RotateHandler.cs
@@ -139,6 +139,8 @@ namespace HelixToolkit.UWP
                 Controller.StopZooming();
                 Controller.StopPanning();
             }
+            p0 = Vector2.Multiply(p0, Controller.AllowRotateXY);
+            p1 = Vector2.Multiply(p1, Controller.AllowRotateXY);
             var newPos = Camera.CameraInternal.Position;
             var newLook = Camera.CameraInternal.LookDirection;
             var newUp = Vector3D.Normalize(Camera.CameraInternal.UpDirection);

--- a/Source/HelixToolkit.UWP/Controls/Viewport3DXProperties.cs
+++ b/Source/HelixToolkit.UWP/Controls/Viewport3DXProperties.cs
@@ -800,6 +800,52 @@ namespace HelixToolkit.UWP
             }
         }
 
+
+        // Using a DependencyProperty as the backing store for AllowUpDownRotation.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty AllowUpDownRotationProperty =
+            DependencyProperty.Register("AllowUpDownRotation", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) =>
+            {
+                var viewport = d as Viewport3DX;
+                float allowX = viewport.cameraController.AllowRotateXY.X;
+                float allowY = (bool)e.NewValue ? 1 : 0;
+                viewport.CameraController.AllowRotateXY = new global::SharpDX.Vector2(allowX, allowY);
+            }));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether globally [allow up down rotation].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [allow up down rotation]; otherwise, <c>false</c>.
+        /// </value>
+        public bool AllowUpDownRotation
+        {
+            get { return (bool)GetValue(AllowUpDownRotationProperty); }
+            set { SetValue(AllowUpDownRotationProperty, value); }
+        }
+
+
+        // Using a DependencyProperty as the backing store for AllowLeftRightRotation.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty AllowLeftRightRotationProperty =
+            DependencyProperty.Register("AllowLeftRightRotation", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) =>
+            {
+                var viewport = d as Viewport3DX;
+                float allowX = (bool)e.NewValue ? 1 : 0;
+                float allowY = viewport.cameraController.AllowRotateXY.Y;
+                viewport.CameraController.AllowRotateXY = new global::SharpDX.Vector2(allowX, allowY);
+            }));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether globally [allow left right rotation].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [allow left right rotation]; otherwise, <c>false</c>.
+        /// </value>
+        public bool AllowLeftRightRotation
+        {
+            get { return (bool)GetValue(AllowLeftRightRotationProperty); }
+            set { SetValue(AllowLeftRightRotationProperty, value); }
+        }
+
         /// <summary>
         /// The zoom sensitivity property
         /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
@@ -548,6 +548,20 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             set; get;
         } = new Vector3();
+
+        /// <summary>
+        /// Gets or sets to allow rotate x direction and y direction globally. X, Y is screen space.
+        /// <para>X = 1: Allow left/right rotation. Y = 1: Allow up/down rotation</para>
+        /// <para>Default is (1, 1)</para>
+        /// </summary>
+        /// <value>
+        /// The allow rotate xy.
+        /// </value>
+        public Vector2 AllowRotateXY
+        {
+            set; get;
+        } = Vector2.One;
+
 #region TouchGesture
         public bool EnableTouchRotate { set; get; } = true;
         public bool EnablePinchZoom { set; get; } = true;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/RotateHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/RotateHandler.cs
@@ -156,6 +156,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 Controller.StopZooming();
                 Controller.StopPanning();
             }
+            p0 = Vector2.Multiply(p0, Controller.AllowRotateXY);
+            p1 = Vector2.Multiply(p1, Controller.AllowRotateXY);
             Vector3 newPos = Camera.CameraInternal.Position;
             Vector3 newLook = Camera.CameraInternal.LookDirection;
             Vector3 newUp = Vector3.Normalize(Camera.CameraInternal.UpDirection);

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
@@ -719,6 +719,27 @@ namespace HelixToolkit.Wpf.SharpDX
                     viewport.CameraController.UpDownRotationSensitivity = (double)e.NewValue;
                 }));
 
+        // Using a DependencyProperty as the backing store for AllowUpDownRotation.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty AllowUpDownRotationProperty =
+            DependencyProperty.Register("AllowUpDownRotation", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) =>
+            {
+                var viewport = d as Viewport3DX;
+                float allowX = viewport.cameraController.AllowRotateXY.X;
+                float allowY = (bool)e.NewValue ? 1 : 0;
+                viewport.CameraController.AllowRotateXY = new global::SharpDX.Vector2(allowX, allowY);
+            }));
+
+        // Using a DependencyProperty as the backing store for AllowLeftRightRotation.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty AllowLeftRightRotationProperty =
+            DependencyProperty.Register("AllowLeftRightRotation", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) =>
+            {
+                var viewport = d as Viewport3DX;
+                float allowX = (bool)e.NewValue ? 1 : 0;
+                float allowY = viewport.cameraController.AllowRotateXY.Y;
+                viewport.CameraController.AllowRotateXY = new global::SharpDX.Vector2(allowX, allowY);
+            }));
+
+
         /// <summary>
         /// The use default gestures property
         /// </summary>
@@ -3031,6 +3052,30 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             get { return (int)GetValue(MinimumUpdateCountProperty); }
             set { SetValue(MinimumUpdateCountProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether globally [allow up down rotation].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [allow up down rotation]; otherwise, <c>false</c>.
+        /// </value>
+        public bool AllowUpDownRotation
+        {
+            get { return (bool)GetValue(AllowUpDownRotationProperty); }
+            set { SetValue(AllowUpDownRotationProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether globally [allow left right rotation].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [allow left right rotation]; otherwise, <c>false</c>.
+        /// </value>
+        public bool AllowLeftRightRotation
+        {
+            get { return (bool)GetValue(AllowLeftRightRotationProperty); }
+            set { SetValue(AllowLeftRightRotationProperty, value); }
         }
     }
 }


### PR DESCRIPTION
Added `AllowRotateLeftRight` and `AllowRotateUpDown` in Viewport3DX.