### PR TITLE
Implement Bone Skinning mesh hit test. Mesh Hit test bug fix.

### DIFF
--- a/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
@@ -108,6 +108,8 @@ namespace BoneSkinDemo
 
         public Media3D.Transform3D ModelTransform { private set; get; }
 
+        public LineGeometry3D HitLineGeometry { get; } = new LineGeometry3D() { IsDynamic = true };
+
         public string[] Animations { set; get; }
 
         public GridPattern[] GridTypes { get; } = new GridPattern[] { GridPattern.Tile, GridPattern.Grid };
@@ -140,8 +142,14 @@ namespace BoneSkinDemo
                 NearPlaneDistance = 1,
                 FarPlaneDistance = 2000
             };
+            HitLineGeometry.Positions = new Vector3Collection(2);
+            HitLineGeometry.Positions.Add(Vector3.Zero);
+            HitLineGeometry.Positions.Add(Vector3.Zero);
+            HitLineGeometry.Indices = new IntCollection(2);
+            HitLineGeometry.Indices.Add(0);
+            HitLineGeometry.Indices.Add(1);
             LoadFile();
-            compositeHelper.Rendering += CompositeHelper_Rendering;
+            compositeHelper.Rendering += CompositeHelper_Rendering;           
         }
 
         private void LoadFile()
@@ -162,6 +170,7 @@ namespace BoneSkinDemo
                         m.IsThrowingShadow = true;
                         m.WireframeColor = new SharpDX.Color4(0, 0, 1, 1);
                         boneSkinNodes.Add(m);
+                        m.MouseDown += M_MouseDown;
                     }
                     else
                     {
@@ -170,6 +179,14 @@ namespace BoneSkinDemo
                     }
                 }
             }
+        }
+
+        private void M_MouseDown(object sender, SceneNodeMouseDownArgs e)
+        {
+            var result = e.HitResult;
+            HitLineGeometry.Positions[0] = result.PointHit;
+            HitLineGeometry.Positions[1] = result.PointHit + result.NormalAtHit;
+            HitLineGeometry.UpdateVertices();
         }
 
         private void CompositeHelper_Rendering(object sender, System.Windows.Media.RenderingEventArgs e)

--- a/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
@@ -184,8 +184,8 @@ namespace BoneSkinDemo
         private void M_MouseDown(object sender, SceneNodeMouseDownArgs e)
         {
             var result = e.HitResult;
-            HitLineGeometry.Positions[0] = result.PointHit;
-            HitLineGeometry.Positions[1] = result.PointHit + result.NormalAtHit;
+            HitLineGeometry.Positions[0] = result.PointHit - result.NormalAtHit * 0.5f;
+            HitLineGeometry.Positions[1] = result.PointHit + result.NormalAtHit * 0.5f;
             HitLineGeometry.UpdateVertices();
         }
 

--- a/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainWindow.xaml
@@ -49,6 +49,7 @@
             <hx:AmbientLight3D Color="#828282" />
             <hx:DirectionalLight3D Direction="0, -1, -1" Color="White" />
             <hx:Element3DPresenter Content="{Binding ModelGroup}" />
+            <hx:LineGeometryModel3D Geometry="{Binding HitLineGeometry}" Color="Red" IsHitTestVisible="False"/>
             <hx:AxisPlaneGridModel3D
                 x:Name="plane"
                 AutoSpacing="False"

--- a/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainWindow.xaml
@@ -42,8 +42,8 @@
                 <KeyBinding Key="R" Command="hx:ViewportCommands.RightView" />
                 <KeyBinding Command="hx:ViewportCommands.ZoomExtents" Gesture="Control+E" />
                 <MouseBinding Command="hx:ViewportCommands.Rotate" Gesture="RightClick" />
-                <MouseBinding Command="hx:ViewportCommands.Zoom" Gesture="MiddleClick" />
-                <MouseBinding Command="hx:ViewportCommands.Pan" Gesture="LeftClick" />
+                <!--<MouseBinding Command="hx:ViewportCommands.Zoom" Gesture="MiddleClick" />-->
+                <MouseBinding Command="hx:ViewportCommands.Pan" Gesture="MiddleClick" />
             </hx:Viewport3DX.InputBindings>
             <hx:ShadowMap3D OrthoWidth="200" />
             <hx:AmbientLight3D Color="#828282" />

--- a/Source/HelixToolkit.SharpDX.Shared/Core/BoneSkinRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/BoneSkinRenderCore.cs
@@ -122,6 +122,11 @@ namespace HelixToolkit.UWP
                 internalBoneBuffer.Detach();
                 base.OnDetach();
             }
+
+            public int CopySkinnedToArray(DeviceContextProxy context, Vector3[] array)
+            {
+                return preComputeBoneBuffer.CopySkinnedToArray(context, array);
+            }
         }
     }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IGeometryBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IGeometryBufferModel.cs
@@ -138,5 +138,12 @@ namespace HelixToolkit.UWP
         /// </summary>
         /// <param name="context">The context.</param>
         void ResetSkinnedVertexBuffer(DeviceContextProxy context);
+        /// <summary>
+        /// Copies the skinned to array.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="array">The array.</param>
+        /// <returns></returns>
+        int CopySkinnedToArray(DeviceContextProxy context, global::SharpDX.Vector3[] array);
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -73,6 +73,13 @@ namespace HelixToolkit.UWP
         /// </value>
         Device Device { get; }
         /// <summary>
+        /// Gets the immediate device context.
+        /// </summary>
+        /// <value>
+        /// The immediate device context.
+        /// </value>
+        DeviceContextProxy ImmediateDeviceContext { get; }
+        /// <summary>
         /// Gets the device2d.
         /// </summary>
         /// <value>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BoneSkinnedMeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BoneSkinnedMeshGeometry3D.cs
@@ -176,6 +176,7 @@ namespace HelixToolkit.UWP
             var rayModel = new Ray(Vector3.TransformCoordinate(rayWS.Position, modelInvert), Vector3.Normalize(Vector3.TransformNormal(rayWS.Direction, modelInvert)));
 
             int index = 0;
+            float minDistance = float.MaxValue;
             foreach (var t in skinnedTriangles(skinnedVertices))
             {
                 var v0 = t.P0;
@@ -183,11 +184,11 @@ namespace HelixToolkit.UWP
                 var v2 = t.P2;
                 if (Collision.RayIntersectsTriangle(ref rayModel, ref v0, ref v1, ref v2, out float d))
                 {
-                    if (d > 0 && d < result.Distance) // If d is NaN, the condition is false.
+                    if (d >= 0 && d < minDistance) // If d is NaN, the condition is false.
                     {
+                        minDistance = d;
                         result.IsValid = true;
                         result.ModelHit = originalSource;
-                        // transform hit-info to world space now:
                         var pointWorld = Vector3.TransformCoordinate(rayModel.Position + (rayModel.Direction * d), modelMatrix);
                         result.PointHit = pointWorld;
                         result.Distance = (rayWS.Position - pointWorld).Length();

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BoneSkinnedMeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BoneSkinnedMeshGeometry3D.cs
@@ -145,5 +145,72 @@ namespace HelixToolkit.UWP
             mesh.Normals = mesh.CalculateNormals();
             return mesh;
         }
+
+        private IEnumerable<Triangle> skinnedTriangles(Vector3[] skinnedVertices)
+        {
+            for (int i = 0; i < Indices.Count; i += 3)
+            {
+                yield return new Triangle() { P0 = skinnedVertices[Indices[i]], P1 = skinnedVertices[Indices[i + 1]], P2 = skinnedVertices[Indices[i + 2]], };
+            }
+        }
+
+        public virtual bool HitTestWithSkinnedVertices(RenderContext context, Vector3[] skinnedVertices, Matrix modelMatrix,
+            ref Ray rayWS, ref List<HitTestResult> hits, object originalSource)
+        {
+            if (skinnedVertices == null || skinnedVertices.Length == 0
+                || Indices == null || Indices.Count == 0)
+            {
+                return false;
+            }
+            bool isHit = false;
+            var result = new HitTestResult
+            {
+                Distance = double.MaxValue
+            };
+            var modelInvert = modelMatrix.Inverted();
+            if (modelInvert == Matrix.Zero)//Check if model matrix can be inverted.
+            {
+                return false;
+            }
+            //transform ray into model coordinates
+            var rayModel = new Ray(Vector3.TransformCoordinate(rayWS.Position, modelInvert), Vector3.Normalize(Vector3.TransformNormal(rayWS.Direction, modelInvert)));
+
+            int index = 0;
+            foreach (var t in skinnedTriangles(skinnedVertices))
+            {
+                var v0 = t.P0;
+                var v1 = t.P1;
+                var v2 = t.P2;
+                if (Collision.RayIntersectsTriangle(ref rayModel, ref v0, ref v1, ref v2, out float d))
+                {
+                    if (d > 0 && d < result.Distance) // If d is NaN, the condition is false.
+                    {
+                        result.IsValid = true;
+                        result.ModelHit = originalSource;
+                        // transform hit-info to world space now:
+                        var pointWorld = Vector3.TransformCoordinate(rayModel.Position + (rayModel.Direction * d), modelMatrix);
+                        result.PointHit = pointWorld;
+                        result.Distance = (rayWS.Position - pointWorld).Length();
+                        var p0 = Vector3.TransformCoordinate(v0, modelMatrix);
+                        var p1 = Vector3.TransformCoordinate(v1, modelMatrix);
+                        var p2 = Vector3.TransformCoordinate(v2, modelMatrix);
+                        var n = Vector3.Cross(p1 - p0, p2 - p0);
+                        n.Normalize();
+                        // transform hit-info to world space now:
+                        result.NormalAtHit = n;// Vector3.TransformNormal(n, m).ToVector3D();
+                        result.TriangleIndices = new System.Tuple<int, int, int>(Indices[index], Indices[index + 1], Indices[index + 2]);
+                        result.Tag = index / 3;
+                        result.Geometry = this;
+                        isHit = true;
+                    }
+                }
+                index += 3;
+            }
+            if (isHit)
+            {
+                hits.Add(result);
+            }
+            return isHit;
+        }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
@@ -191,6 +191,7 @@ namespace HelixToolkit.UWP
                 if (rayModel.Intersects(ref b))
                 {
                     int index = 0;
+                    float minDistance = float.MaxValue;
                     foreach (var t in Triangles)
                     {
                         var v0 = t.P0;
@@ -198,8 +199,9 @@ namespace HelixToolkit.UWP
                         var v2 = t.P2;
                         if (Collision.RayIntersectsTriangle(ref rayModel, ref v0, ref v1, ref v2, out float d))
                         {
-                            if (d > 0 && d < result.Distance) // If d is NaN, the condition is false.
+                            if (d >= 0 && d < minDistance) // If d is NaN, the condition is false.
                             {
+                                minDistance = d;
                                 result.IsValid = true;
                                 result.ModelHit = originalSource;
                                 // transform hit-info to world space now:

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
@@ -87,12 +87,12 @@ namespace HelixToolkit.UWP
             /// <returns></returns>
             public override bool TestViewFrustum(ref BoundingFrustum viewFrustum)
             {
-                return true;
+                return BoneMatrices == null ? base.TestViewFrustum(ref viewFrustum) : true;
             }
 
             protected override bool PreHitTestOnBounds(ref Ray ray)
             {
-                return true;
+                return BoneMatrices == null ? base.PreHitTestOnBounds(ref ray) : true;
             }
             /// <summary>
             /// Creates the skeleton node.

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BoneSkinMeshNode.cs
@@ -87,12 +87,12 @@ namespace HelixToolkit.UWP
             /// <returns></returns>
             public override bool TestViewFrustum(ref BoundingFrustum viewFrustum)
             {
-                return BoneMatrices == null ? base.TestViewFrustum(ref viewFrustum) : true;
+                return BoneMatrices.Length == 0 ? base.TestViewFrustum(ref viewFrustum) : true;
             }
 
             protected override bool PreHitTestOnBounds(ref Ray ray)
             {
-                return BoneMatrices == null ? base.PreHitTestOnBounds(ref ray) : true;
+                return BoneMatrices.Length == 0 ? base.PreHitTestOnBounds(ref ray) : true;
             }
             /// <summary>
             /// Creates the skeleton node.
@@ -185,7 +185,7 @@ namespace HelixToolkit.UWP
 
             protected override bool OnHitTest(RenderContext context, Matrix totalModelMatrix, ref Ray rayWS, ref List<HitTestResult> hits)
             {
-                if(Geometry is BoneSkinnedMeshGeometry3D skGeometry)
+                if(BoneMatrices.Length > 0 && Geometry is BoneSkinnedMeshGeometry3D skGeometry)
                 {
                     if(RenderCore is BoneSkinRenderCore skCore)
                     {

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ElementsBufferProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ElementsBufferProxy.cs
@@ -73,6 +73,8 @@ namespace HelixToolkit.UWP
             /// </summary>
             public ResourceOptionFlags OptionFlags { private set; get; }
             public ResourceUsage Usage { private set; get; } = ResourceUsage.Immutable;
+
+            public CpuAccessFlags CpuAccess { private set; get; } = CpuAccessFlags.None;
             /// <summary>
             ///
             /// </summary>
@@ -85,6 +87,25 @@ namespace HelixToolkit.UWP
             {
                 OptionFlags = optionFlags;
                 Usage = usage;
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ImmutableBufferProxy"/> class.
+            /// </summary>
+            /// <param name="structureSize">Size of the structure.</param>
+            /// <param name="bindFlags">The bind flags.</param>
+            /// <param name="cpuAccess">The cpu access.</param>
+            /// <param name="optionFlags">The option flags.</param>
+            /// <param name="usage">The usage.</param>
+            public ImmutableBufferProxy(int structureSize, BindFlags bindFlags, 
+                CpuAccessFlags cpuAccess,
+                ResourceOptionFlags optionFlags = ResourceOptionFlags.None, 
+                ResourceUsage usage = ResourceUsage.Immutable)
+                : base(structureSize, bindFlags)
+            {
+                OptionFlags = optionFlags;
+                Usage = usage;
+                CpuAccess = cpuAccess;
             }
 
             /// <summary>
@@ -119,7 +140,7 @@ namespace HelixToolkit.UWP
                 var buffdesc = new BufferDescription()
                 {
                     BindFlags = this.BindFlags,
-                    CpuAccessFlags = CpuAccessFlags.None,
+                    CpuAccessFlags = CpuAccess,
                     OptionFlags = this.OptionFlags,
                     SizeInBytes = StructureSize * count,
                     StructureByteStride = StructureSize,
@@ -147,7 +168,7 @@ namespace HelixToolkit.UWP
                 var buffdesc = new BufferDescription()
                 {
                     BindFlags = this.BindFlags,
-                    CpuAccessFlags = CpuAccessFlags.None,
+                    CpuAccessFlags = CpuAccess,
                     OptionFlags = this.OptionFlags,
                     SizeInBytes = countByBytes,
                     StructureByteStride = StructureSize,
@@ -182,6 +203,8 @@ namespace HelixToolkit.UWP
             /// The capacity used.
             /// </value>
             public int CapacityUsed { private set; get; }
+
+            public CpuAccessFlags CpuAccess { private set; get; } = CpuAccessFlags.Write;
             /// <summary>
             ///
             /// </summary>
@@ -213,6 +236,25 @@ namespace HelixToolkit.UWP
                 CanOverwrite = canOverWrite;
                 this.OptionFlags = optionFlags;
                 LazyResize = lazyResize;
+            }
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DynamicBufferProxy"/> class.
+            /// </summary>
+            /// <param name="structureSize">Size of the structure.</param>
+            /// <param name="bindFlags">The bind flags.</param>
+            /// <param name="canOverWrite">if set to <c>true</c> [can over write].</param>
+            /// <param name="cpuAccess">The cpu access.</param>
+            /// <param name="optionFlags">The option flags.</param>
+            /// <param name="lazyResize">if set to <c>true</c> [lazy resize].</param>
+            public DynamicBufferProxy(int structureSize, BindFlags bindFlags, bool canOverWrite,
+                CpuAccessFlags cpuAccess,
+                ResourceOptionFlags optionFlags = ResourceOptionFlags.None, bool lazyResize = true)
+                : base(structureSize, bindFlags)
+            {
+                CanOverwrite = canOverWrite;
+                this.OptionFlags = optionFlags;
+                LazyResize = lazyResize;
+                CpuAccess = cpuAccess;
             }
             /// <summary>
             /// <see cref="IElementsBufferProxy.UploadDataToBuffer{T}(DeviceContextProxy, IList{T}, int)"/>
@@ -353,7 +395,7 @@ namespace HelixToolkit.UWP
                 var buffdesc = new BufferDescription()
                 {
                     BindFlags = this.BindFlags,
-                    CpuAccessFlags = CpuAccessFlags.Write,
+                    CpuAccessFlags = CpuAccess,
                     OptionFlags = this.OptionFlags,
                     SizeInBytes = StructureSize * System.Math.Max(count, minBufferCount),
                     StructureByteStride = StructureSize,

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
@@ -140,6 +140,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        public DeviceContextProxy ImmediateDeviceContext { get => currentRenderHost?.ImmediateDeviceContext; }
+
         public new float ActualWidth { get => 0; }
         public new float ActualHeight { get => 0; }
 


### PR DESCRIPTION
1. Implement Bone Skinning mesh hit test. (Skinned vertices will be copied from GPU to CPU during hit test. This hit test does not check bounding box of the object. Will be triggered each time during hit test.)
2. Fix mesh hit test using wrong distance comparison.
