### PR TITLE
Docking behaviours support

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFCanvas.cs
@@ -164,7 +164,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 parentWindow.Closed -= ParentWindow_Closed;
             }
-            if (DataContext == null && RenderHost.EffectsManager == null)
+            if (DataContext == null && RenderHost.EffectsManager == null && belongsToParentWindow)
             {
                 EndD3D();
             }

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFCanvas.cs
@@ -77,6 +77,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </value>
         public IRenderHost RenderHost { private set; get; }
         private Window parentWindow;
+        private readonly bool belongsToParentWindow;
 
         /// <summary>
         /// Fired whenever an exception occurred on this object.
@@ -87,7 +88,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// 
         /// </summary>
-        public DPFCanvas(bool deferredRendering = false)
+        public DPFCanvas(bool deferredRendering = false, bool attachedToWindow = true)
         {
             if (deferredRendering)
             {
@@ -103,6 +104,7 @@ namespace HelixToolkit.Wpf.SharpDX
             RenderHost.StopRenderLoop += RenderHost_StopRenderLoop;
             RenderHost.ExceptionOccurred += (s, e) => { HandleExceptionOccured(e.Exception); };
             (RenderHost as DX11ImageSourceRenderHost).OnImageSourceChanged += DPFCanvas_OnImageSourceChanged;
+            belongsToParentWindow = attachedToWindow;
         }
 
         private void DPFCanvas_OnImageSourceChanged(object sender, DX11ImageSourceArgs e)
@@ -119,12 +121,16 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             try
             {
-                parentWindow = FindVisualAncestor<Window>(this);
-                if (parentWindow != null)
+                if (belongsToParentWindow)
                 {
-                    parentWindow.Closed -= ParentWindow_Closed;
-                    parentWindow.Closed += ParentWindow_Closed;
+                    parentWindow = FindVisualAncestor<Window>(this);
+                    if (parentWindow != null)
+                    {
+                        parentWindow.Closed -= ParentWindow_Closed;
+                        parentWindow.Closed += ParentWindow_Closed;
+                    }
                 }
+
                 StartD3D();
             }
             catch (Exception ex)
@@ -154,7 +160,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="e"></param>
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
-            if(parentWindow != null)
+            if(belongsToParentWindow && parentWindow != null)
             {
                 parentWindow.Closed -= ParentWindow_Closed;
             }
@@ -312,6 +318,9 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 if (disposing)
                 {
+                    if (!belongsToParentWindow)
+                        EndD3D();
+
                     compositionTarget.Dispose();
                     this.Source = null;
                     // TODO: dispose managed state (managed objects).

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFSurfaceSwapChain.cs
@@ -143,7 +143,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 parentWindow.Closed -= ParentWindow_Closed;
             }
-            if (DataContext == null && RenderHost.EffectsManager == null)
+            if (DataContext == null && RenderHost.EffectsManager == null && belongsToParentWindow)
             {
                 EndD3D();
             }

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFSurfaceSwapChain.cs
@@ -37,7 +37,7 @@ namespace HelixToolkit.Wpf.SharpDX
     /// 
     /// </summary>
     /// <seealso cref="System.Windows.Controls.Image" />
-    public class DPFSurfaceSwapChain : WinformHostExtend, IRenderCanvas
+    public class DPFSurfaceSwapChain : WinformHostExtend, IRenderCanvas, IDisposable
     {
         private readonly IRenderHost renderHost;
         /// <summary>
@@ -49,6 +49,8 @@ namespace HelixToolkit.Wpf.SharpDX
         public IRenderHost RenderHost { get { return renderHost; } }
         private RenderControl surfaceD3D;
         private Window parentWindow;
+        private readonly bool belongsToParentWindow;
+
         /// <summary>
         /// Fired whenever an exception occurred on this object.
         /// </summary>
@@ -59,7 +61,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// 
         /// </summary>
-        public DPFSurfaceSwapChain(bool deferredRendering = false)
+        public DPFSurfaceSwapChain(bool deferredRendering = false, bool attachedToWindow = true)
         {
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
@@ -77,9 +79,11 @@ namespace HelixToolkit.Wpf.SharpDX
             RenderHost.StartRenderLoop += RenderHost_StartRenderLoop;
             RenderHost.StopRenderLoop += RenderHost_StopRenderLoop;
             RenderHost.ExceptionOccurred += (s, e) => { HandleExceptionOccured(e.Exception); };
+
+            belongsToParentWindow = attachedToWindow;
         }
 
-        public DPFSurfaceSwapChain(Func<IntPtr, IRenderHost> createRenderHost)
+        public DPFSurfaceSwapChain(Func<IntPtr, IRenderHost> createRenderHost, bool attachedToWindow = true)
         {
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
@@ -89,6 +93,8 @@ namespace HelixToolkit.Wpf.SharpDX
             RenderHost.StartRenderLoop += RenderHost_StartRenderLoop;
             RenderHost.StopRenderLoop += RenderHost_StopRenderLoop;
             RenderHost.ExceptionOccurred += (s, e) => { HandleExceptionOccured(e.Exception); };
+
+            belongsToParentWindow = attachedToWindow;
         }
 
         /// <summary>
@@ -100,12 +106,16 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             try
             {
-                parentWindow = FindVisualAncestor<Window>(this);
-                if (parentWindow != null)
+                if (belongsToParentWindow)
                 {
-                    parentWindow.Closed -= ParentWindow_Closed;
-                    parentWindow.Closed += ParentWindow_Closed;
+                    parentWindow = FindVisualAncestor<Window>(this);
+                    if (parentWindow != null)
+                    {
+                        parentWindow.Closed -= ParentWindow_Closed;
+                        parentWindow.Closed += ParentWindow_Closed;
+                    }
                 }
+
                 StartD3D();
             }
             catch (Exception ex)
@@ -129,7 +139,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="e"></param>
         private void OnUnloaded(object sender, RoutedEventArgs e)
         {
-            if (parentWindow != null)
+            if (belongsToParentWindow && parentWindow != null)
             {
                 parentWindow.Closed -= ParentWindow_Closed;
             }
@@ -255,5 +265,44 @@ namespace HelixToolkit.Wpf.SharpDX
 
             return null;
         }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    if (!belongsToParentWindow)
+                        EndD3D();
+
+                    compositionTarget.Dispose();
+                    // TODO: dispose managed state (managed objects).
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~DPFCanvas() {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+        #endregion
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
@@ -1213,6 +1213,12 @@ namespace HelixToolkit.Wpf.SharpDX
             }));
 
         /// <summary>
+        /// The belongs to parent window property
+        /// </summary>
+        public static readonly DependencyProperty BelongsToParentWindowProperty =
+            DependencyProperty.Register("BelongsToParentWindow", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true));
+
+        /// <summary>
         /// Background Color
         /// </summary>
         public Color BackgroundColor
@@ -3076,6 +3082,19 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             get { return (bool)GetValue(AllowLeftRightRotationProperty); }
             set { SetValue(AllowLeftRightRotationProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating if the life cycle of the viewport
+        /// depends on the first parent window found in the actual visual tree.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the viewport belongs to the first parent window; otherwise, <c>false</c>
+        /// </value>
+        public bool BelongsToParentWindow
+        {
+            get { return (bool)GetValue(BelongsToParentWindowProperty); }
+            set { SetValue(BelongsToParentWindowProperty, value); }
         }
     }
 }


### PR DESCRIPTION
A dependency property has been added to Viewport3DX named _**BelongsToParentWindow**_, by default set to true (legacy behavior). If BelongsToParentWindow is toggled off, the Viewport won't try to find the first window available in the control's visual tree to shutdown the renderer when it's closing. In this case, the viewport is shutdown when the viewport's Dispose method is called. This behaviour allows to survive on dock or undocking situations.

The patch is working with the docking framework I used. Please feel free to suggest improvements.

Closes: #1120