### PR TITLE
HitTestThickness is not taken in account into the bounds computation …

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/LineNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/LineNode.cs
@@ -126,6 +126,12 @@ namespace HelixToolkit.UWP
             {
                 return (Geometry as LineGeometry3D).HitTest(context, totalModelMatrix, ref ray, ref hits, this.WrapperSource, (float)HitTestThickness);
             }
+
+            protected override bool PreHitTestOnBounds(ref Ray ray)
+            {
+                // HitTestThickness is not taken in account into the bounds computation so we can not use it for hit test.
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
In the FindHits process, there is a step where the ray is tested against the bounds (`PreHitTestOnBounds()`). In the case of a vertical or an horizontal line, the bounds can be very thin (in fact the minimum size is fixed to 0.2) and the HitTestThickness is not taken in account when the bounds are computed so the test fails before the actual Ray/Line distance is computed.

I think we should skip the `PreHitTestOnBounds()` in the case of a line (by make it returns true) because the HitTestThickness is not taken in account .