### PR TITLE
Take cross section from planes into account when hit testing

### DIFF
--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainViewModel.cs
@@ -25,7 +25,7 @@
         public string Name { get; set; }
         public MainViewModel ViewModel { get { return this; } }
         public MeshGeometry3D Model { get; private set; }
-
+        public MeshGeometry3D BoxModel { get; private set; }
         public MeshGeometry3D FloorModel { private set; get; }
         public PhongMaterial FloorMaterial { private set; get; }
         public Transform3D ModelTransform { get; private set; }
@@ -121,6 +121,10 @@
 
             Plane1Transform = new TranslateTransform3D(new Vector3D(0, 15, 0));
             Plane2Transform = new TranslateTransform3D(new Vector3D(15, 0, 0));
+
+            var meshBuilder = new MeshBuilder();
+            meshBuilder.AddBox(new Vector3(5f), 40, 1, 2);
+            BoxModel = meshBuilder.ToMeshGeometry3D();
         }
 
         public List<Object3D> Load3ds(string path)

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml
@@ -56,11 +56,27 @@
                 EnablePlane2="{Binding EnablePlane2}"
                 FillMode="Solid"
                 Geometry="{Binding Model}"
-                IsHitTestVisible="False"
+                IsHitTestVisible="True"
                 Material="{Binding ModelMaterial}"
                 Plane1="{Binding Plane1}"
                 Plane2="{Binding Plane2}"
-                Transform="{Binding ModelTransform}" />
+                Transform="{Binding ModelTransform}" 
+                Mouse3DDown="geometry_Mouse3DDown" 
+                />
+            <hx:CrossSectionMeshGeometryModel3D
+                x:Name="crossModel2"
+                CrossSectionColor="GreenYellow"
+                CullMode="Back"
+                CuttingOperation="{Binding CuttingOperation}"
+                EnablePlane1="{Binding EnablePlane1}"
+                EnablePlane2="{Binding EnablePlane2}"
+                FillMode="Solid"
+                Geometry="{Binding BoxModel}"
+                IsHitTestVisible="True"
+                Material="{Binding ModelMaterial}"
+                Plane1="{Binding Plane1}"
+                Plane2="{Binding Plane2}"
+                Mouse3DDown="geometry_Mouse3DDown" />
             <local:CrossSectionPlaneManipulator3D
                 CornerScale="4"
                 CutPlane="{Binding Plane1, Mode=TwoWay}"
@@ -74,20 +90,7 @@
                 IsRendering="{Binding EnablePlane2}"
                 SizeScale="10" />
             <hx:AxisPlaneGridModel3D />
-            <!--<hx:MeshGeometryModel3D
-                CullMode="Back"
-                Geometry="{Binding Plane1Model}"
-                IsRendering="{Binding EnablePlane1}"
-                IsTransparent="True"
-                Material="{Binding PlaneMaterial}"
-                Transform="{Binding Plane1Transform}" />
-            <hx:MeshGeometryModel3D
-                CullMode="Back"
-                Geometry="{Binding Plane2Model}"
-                IsRendering="{Binding EnablePlane2}"
-                IsTransparent="True"
-                Material="{Binding PlaneMaterial}"
-                Transform="{Binding Plane2Transform}" />-->
+           
         </hx:Viewport3DX>
         <StackPanel
             Grid.Column="1"

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml.cs
@@ -31,5 +31,10 @@ namespace CrossSectionDemo
                 }
             };
         }
+
+        private void geometry_Mouse3DDown(object sender, HelixToolkit.Wpf.SharpDX.MouseDown3DEventArgs e)
+        {
+
+        }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Core.Tests/CrossSectionMeshNodeTests.cs
+++ b/Source/HelixToolkit.SharpDX.Core.Tests/CrossSectionMeshNodeTests.cs
@@ -1,0 +1,88 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CrossSectionMeshNodeTests.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using HelixToolkit.SharpDX.Core.Controls;
+using HelixToolkit.SharpDX.Core.Model.Scene;
+using NUnit.Framework;
+using SharpDX;
+
+namespace HelixToolkit.SharpDX.Core.Tests
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    class CrossSectionMeshNodeTests
+    {
+        private readonly ViewportCore viewport = new ViewportCore(IntPtr.Zero);
+        private CrossSectionMeshNode GetSceneNode()
+        {
+            var meshBuilder = new MeshBuilder();
+            meshBuilder.AddBox(new Vector3(0f), 1, 1, 1);
+            var geometryModel3D = new CrossSectionMeshNode()
+            {
+                Geometry = meshBuilder.ToMesh(),
+            };
+            return geometryModel3D;
+        }
+        [Test]
+        public void HitTestShouldReturnOnePointOnFrontOfCubeWithNoCuttingPlanes()
+        {
+            var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
+            var hits = new List<HitTestResult>();
+            var geometryModel3D = GetSceneNode();
+            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            Assert.AreEqual(1, hits.Count);
+            Assert.AreEqual(new Vector3(0.5f, 0, 0), hits[0].PointHit);
+        }
+
+        [TestCaseSource(nameof(GetPlanes))]
+        public void HitTestShouldReturnOnePointOnBackOfCubeWithCuttingPlaneInXZero(Action<CrossSectionMeshNode, Plane> setupPlane)
+        {
+            var plane = new Plane(new Vector3(0f), new Vector3(-1, 0, 0));
+            var geometryModel3D = GetSceneNode();
+            setupPlane(geometryModel3D, plane);
+            var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
+            var hits = new List<HitTestResult>();
+            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            Assert.AreEqual(1, hits.Count);
+            Assert.AreEqual(new Vector3(-0.5f, 0, 0), hits[0].PointHit);
+        }
+
+        /// <summary>
+        /// Get all planes in the CrossSectionMeshNode with reflection so that if more planes are added tests will fail
+        /// </summary>
+        public static IEnumerable<object[]> GetPlanes()
+        {
+            var properties = typeof(CrossSectionMeshNode)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public);
+
+            var enables = properties
+                .Where(p => p.Name.StartsWith("EnablePlane", StringComparison.InvariantCulture))
+                .ToArray();
+            var planes = properties
+                .Where(p => p.Name.StartsWith("Plane", StringComparison.InvariantCulture))
+                .ToArray();
+            for (int i = 0; i < enables.Length; i++)
+            {
+                var planeProperty = planes[i];
+                var enableProperty = enables[i];
+
+                void Action(CrossSectionMeshNode model, Plane plane)
+                {
+                    planeProperty.SetValue(model, plane);
+                    enableProperty.SetValue(model, true);
+                }
+
+                yield return new object[] { (Action<CrossSectionMeshNode, Plane>)Action };
+            }
+
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Core.Tests/CrossSectionMeshNodeTests.cs
+++ b/Source/HelixToolkit.SharpDX.Core.Tests/CrossSectionMeshNodeTests.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CrossSectionMeshNodeTests.cs" company="Helix Toolkit">
-//   Copyright (c) 2014 Helix Toolkit contributors
+//   Copyright (c) 2020 Helix Toolkit contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -21,23 +21,22 @@ namespace HelixToolkit.SharpDX.Core.Tests
     class CrossSectionMeshNodeTests
     {
         private readonly ViewportCore viewport = new ViewportCore(IntPtr.Zero);
-        private CrossSectionMeshNode GetSceneNode()
+        private CrossSectionMeshNode GetNode()
         {
             var meshBuilder = new MeshBuilder();
             meshBuilder.AddBox(new Vector3(0f), 1, 1, 1);
-            var geometryModel3D = new CrossSectionMeshNode()
+            return new CrossSectionMeshNode()
             {
                 Geometry = meshBuilder.ToMesh(),
             };
-            return geometryModel3D;
         }
         [Test]
         public void HitTestShouldReturnOnePointOnFrontOfCubeWithNoCuttingPlanes()
         {
             var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
             var hits = new List<HitTestResult>();
-            var geometryModel3D = GetSceneNode();
-            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            var node = GetNode();
+            node.HitTest(viewport.RenderContext, ray, ref hits);
             Assert.AreEqual(1, hits.Count);
             Assert.AreEqual(new Vector3(0.5f, 0, 0), hits[0].PointHit);
         }
@@ -46,11 +45,11 @@ namespace HelixToolkit.SharpDX.Core.Tests
         public void HitTestShouldReturnOnePointOnBackOfCubeWithCuttingPlaneInXZero(Action<CrossSectionMeshNode, Plane> setupPlane)
         {
             var plane = new Plane(new Vector3(0f), new Vector3(-1, 0, 0));
-            var geometryModel3D = GetSceneNode();
-            setupPlane(geometryModel3D, plane);
+            var node = GetNode();
+            setupPlane(node, plane);
             var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
             var hits = new List<HitTestResult>();
-            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            node.HitTest(viewport.RenderContext, ray, ref hits);
             Assert.AreEqual(1, hits.Count);
             Assert.AreEqual(new Vector3(-0.5f, 0, 0), hits[0].PointHit);
         }

--- a/Source/HelixToolkit.SharpDX.Core.Tests/EffectsManagerTests.cs
+++ b/Source/HelixToolkit.SharpDX.Core.Tests/EffectsManagerTests.cs
@@ -1,13 +1,17 @@
-﻿using HelixToolkit.SharpDX.Core;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EffectsManagerTests.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using NUnit.Framework;
 
 namespace HelixToolkit.SharpDX.Core.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class EffectsManagerTests
     {
-        [TestMethod]
+        [Test]
         public void InitializationTest()
         {
             var effectsManager = new DefaultEffectsManager();

--- a/Source/HelixToolkit.SharpDX.Core.Tests/HelixToolkit.SharpDX.Core.Tests.csproj
+++ b/Source/HelixToolkit.SharpDX.Core.Tests/HelixToolkit.SharpDX.Core.Tests.csproj
@@ -7,9 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-        <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+        <PackageReference Include="NUnit" Version="3.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/HelixToolkit.SharpDX.Core.Tests/SceneNodeTests.cs
+++ b/Source/HelixToolkit.SharpDX.Core.Tests/SceneNodeTests.cs
@@ -1,0 +1,45 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SceneNodeTests.cs" company="Helix Toolkit">
+//   Copyright (c) 2014 Helix Toolkit contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using HelixToolkit.SharpDX.Core.Controls;
+using HelixToolkit.SharpDX.Core.Model.Scene;
+using NUnit.Framework;
+using SharpDX;
+
+namespace HelixToolkit.SharpDX.Core.Tests
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    class SceneNodeTests
+    {
+
+        private SceneNode GetSceneNode()
+        {
+            var meshBuilder = new MeshBuilder();
+            meshBuilder.AddBox(new Vector3(0f), 1, 1, 1);
+            var geometryModel3D = new MeshNode()
+            {
+                Geometry = meshBuilder.ToMesh(),
+            };
+            return geometryModel3D;
+        }
+
+        [Test]
+        public void HitTestShouldReturnOnePointOnFrontOfCubeWithNoCuttingPlanes()
+        {
+            var viewport = new ViewportCore(IntPtr.Zero);
+            var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
+            var hits = new List<HitTestResult>();
+            var geometryModel3D = GetSceneNode();
+            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            Assert.AreEqual(1, hits.Count);
+            Assert.AreEqual(new Vector3(0.5f, 0, 0), hits[0].PointHit);
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Core.Tests/SceneNodeTests.cs
+++ b/Source/HelixToolkit.SharpDX.Core.Tests/SceneNodeTests.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SceneNodeTests.cs" company="Helix Toolkit">
-//   Copyright (c) 2014 Helix Toolkit contributors
+//   Copyright (c) 2020 Helix Toolkit contributors
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -19,15 +19,14 @@ namespace HelixToolkit.SharpDX.Core.Tests
     class SceneNodeTests
     {
 
-        private SceneNode GetSceneNode()
+        private SceneNode GetNode()
         {
             var meshBuilder = new MeshBuilder();
             meshBuilder.AddBox(new Vector3(0f), 1, 1, 1);
-            var geometryModel3D = new MeshNode()
+            return new MeshNode()
             {
                 Geometry = meshBuilder.ToMesh(),
             };
-            return geometryModel3D;
         }
 
         [Test]
@@ -36,8 +35,8 @@ namespace HelixToolkit.SharpDX.Core.Tests
             var viewport = new ViewportCore(IntPtr.Zero);
             var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
             var hits = new List<HitTestResult>();
-            var geometryModel3D = GetSceneNode();
-            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            var sceneNode = GetNode();
+            sceneNode.HitTest(viewport.RenderContext, ray, ref hits);
             Assert.AreEqual(1, hits.Count);
             Assert.AreEqual(new Vector3(0.5f, 0, 0), hits[0].PointHit);
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
@@ -160,6 +160,12 @@ namespace HelixToolkit.UWP
             }
         }
 
+        /// <summary>
+        /// Callers should set this property to true before calling HitTest if the callers need multiple hits throughout the geometry.
+        /// This is useful when the geometry is cut by a plane.
+        /// </summary>
+        public bool ReturnMultipleHitsOnHitTest { get; set; }
+
         public virtual bool HitTest(RenderContext context, Matrix modelMatrix, ref Ray rayWS, ref List<HitTestResult> hits, object originalSource)
         {
             if(Positions == null || Positions.Count == 0
@@ -192,11 +198,7 @@ namespace HelixToolkit.UWP
                 {
                     int index = 0;
                     float minDistance = float.MaxValue;
-#if !NETFX_CORE
-                    bool isCrossSectionMeshGeometryModel3D = originalSource is CrossSectionMeshGeometryModel3D;
-#else
-                    bool isCrossSectionMeshGeometryModel3D = false;
-#endif
+
                     foreach (var t in Triangles)
                     {
                         var v0 = t.P0;
@@ -206,7 +208,7 @@ namespace HelixToolkit.UWP
                         {
                             // For CrossSectionMeshGeometryModel3D another hit than the closest may be the valid one, since the closest one might be removed by a crossing plane
                             if (isHit && result.IsValid &&
-                                isCrossSectionMeshGeometryModel3D)
+                                ReturnMultipleHitsOnHitTest)
                             {
                                 hits.Add(result);
                                 result = new HitTestResult
@@ -215,7 +217,7 @@ namespace HelixToolkit.UWP
                                 };
                             }
 
-                            if (d >= 0 && (d < minDistance || isCrossSectionMeshGeometryModel3D)) // If d is NaN, the condition is false.
+                            if (d >= 0 && (d < minDistance || ReturnMultipleHitsOnHitTest)) // If d is NaN, the condition is false.
                             {
                                 minDistance = d;
                                 result.IsValid = true;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/MaterialGeometryNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/MaterialGeometryNode.cs
@@ -1,6 +1,6 @@
 ﻿/*
 The MIT License(MIT)
-Copyright(c) 2018 Helix Toolkit contributors
+Copyright(c) 2020 Helix Toolkit contributors
 */
 #if !NETFX_CORE
 namespace HelixToolkit.Wpf.SharpDX

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
@@ -18,6 +18,8 @@ namespace HelixToolkit.UWP
     namespace Model.Scene
     {
         using Core;
+        using System.Collections.Generic;
+
         /// <summary>
         /// 
         /// </summary>
@@ -237,6 +239,82 @@ namespace HelixToolkit.UWP
             protected override RenderCore OnCreateRenderCore()
             {
                 return new CrossSectionMeshRenderCore();
+            }
+
+            protected override bool OnHitTest(RenderContext context, Matrix totalModelMatrix, ref Ray rayWS, ref List<HitTestResult> hits)
+            {
+                int hitsBeforeCheck = hits?.Count ?? 0;
+                bool result = base.OnHitTest(context, totalModelMatrix, ref rayWS, ref hits);
+                if (result)
+                {
+                    if (EnablePlane1)
+                        result = CheckWithCrossingPlane(Plane1, hits, hitsBeforeCheck);
+                    if (result && EnablePlane2)
+                        result = CheckWithCrossingPlane(Plane2, hits, hitsBeforeCheck);
+                    if (result && EnablePlane3)
+                        result = CheckWithCrossingPlane(Plane3, hits, hitsBeforeCheck);
+                    if (result && EnablePlane4)
+                        result = CheckWithCrossingPlane(Plane4, hits, hitsBeforeCheck);
+                    if (result)
+                        RemoveAllButClosest(hits, hitsBeforeCheck);
+                }
+                return result;
+            }
+
+            private static bool CheckWithCrossingPlane(Plane plane, List<HitTestResult> hits, int hitsBeforeCheck)
+            {
+                // Loop backwards to remove at end of list when possible
+                for (int i = hits.Count-1; i >= hitsBeforeCheck; i--)
+                {
+                    var pointTimesNormal = (hits[i].PointHit * plane.Normal);
+                    float distanceToPlane = pointTimesNormal.X + pointTimesNormal.Y + pointTimesNormal.Z - plane.D;
+                    if (distanceToPlane < 0)
+                    {
+                        hits.RemoveAt(i);
+                    }
+                }
+                if (hits.Count == hitsBeforeCheck)
+                    return false;
+                return true;
+            }
+
+            /// <summary>
+            /// Removes all but the closes hit point, this is done here despite similar checks being done further up the call stack. 
+            /// This minimizes the risk of breaking callers assumptions of one hit per object
+            /// </summary>
+            /// <param name="hits">All hits so far</param>
+            /// <param name="hitsBeforeCheck">The number of hits before this object was processed</param>
+            private static void RemoveAllButClosest(List<HitTestResult> hits, int hitsBeforeCheck)
+            {
+                if(hits.Count - hitsBeforeCheck == 0)
+                {
+                    return;
+                }
+                double minDistance = double.MaxValue;
+                for (int i = hits.Count - 1; i >= hitsBeforeCheck; i--)
+                {
+                    var hit = hits[i];
+                    if(minDistance > hit.Distance)
+                    {
+                        minDistance = hit.Distance;
+                    }
+                }
+                if(minDistance<double.MaxValue)
+                {
+                    bool foundMinDistance = false;
+                    // Loop backwards to remove at end of list when possible
+                    for (int i = hits.Count - 1; i >= hitsBeforeCheck; i--)
+                    {
+                        if(hits[i].Distance > minDistance || (foundMinDistance && hits[i].Distance == minDistance))
+                        {
+                            hits.RemoveAt(i);
+                        }
+                        else
+                        {
+                            foundMinDistance = true;
+                        }
+                    }
+                }
             }
         }
     }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
@@ -244,7 +244,11 @@ namespace HelixToolkit.UWP
             protected override bool OnHitTest(RenderContext context, Matrix totalModelMatrix, ref Ray rayWS, ref List<HitTestResult> hits)
             {
                 int hitsBeforeCheck = hits?.Count ?? 0;
-                bool result = base.OnHitTest(context, totalModelMatrix, ref rayWS, ref hits);
+                var meshGeometry3d = Geometry as MeshGeometry3D;
+                if (meshGeometry3d == null)
+                    return false;
+                meshGeometry3d.ReturnMultipleHitsOnHitTest = true;
+                bool result = meshGeometry3d.HitTest(context, totalModelMatrix, ref rayWS, ref hits, this.WrapperSource);
                 if (result)
                 {
                     if (EnablePlane1)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
@@ -3,6 +3,7 @@ The MIT License(MIT)
 Copyright(c) 2020 Helix Toolkit contributors
 */
 
+using System;
 using SharpDX;
 
 #if !NETFX_CORE
@@ -247,8 +248,11 @@ namespace HelixToolkit.UWP
                 var meshGeometry3d = Geometry as MeshGeometry3D;
                 if (meshGeometry3d == null)
                     return false;
+                if(meshGeometry3d.ReturnMultipleHitsOnHitTest)
+                    throw new InvalidOperationException($"All hit tests should be called on the same thread, {nameof(Geometry)}.{nameof(meshGeometry3d.ReturnMultipleHitsOnHitTest)} would not be true if that was the case");
                 meshGeometry3d.ReturnMultipleHitsOnHitTest = true;
                 bool result = meshGeometry3d.HitTest(context, totalModelMatrix, ref rayWS, ref hits, this.WrapperSource);
+                meshGeometry3d.ReturnMultipleHitsOnHitTest = false;
                 if (result)
                 {
                     if (EnablePlane1)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
@@ -1,6 +1,6 @@
 ﻿/*
 The MIT License(MIT)
-Copyright(c) 2018 Helix Toolkit contributors
+Copyright(c) 2020 Helix Toolkit contributors
 */
 
 using SharpDX;

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/HitTestResult.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/HitTestResult.cs
@@ -75,6 +75,14 @@ namespace HelixToolkit.UWP
                 return this.Distance.CompareTo(other.Distance);
             }
         }
+
+        /// <summary>
+        /// Get a descirption of the HitTestResult
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{nameof(HitTestResult)} {nameof(ModelHit)}: {ModelHit}, {nameof(Distance)}: {Distance}, {nameof(IsValid)}: {IsValid}, {nameof(PointHit)}: {PointHit}, {nameof(NormalAtHit)}: {NormalAtHit}";
+        }
     }
 
     /// <summary>

--- a/Source/HelixToolkit.Tests/HelixToolkit.Tests.csproj
+++ b/Source/HelixToolkit.Tests/HelixToolkit.Tests.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit">
-      <Version>3.10.1</Version>
+      <Version>3.12.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/CrossSectionMeshGeometryModel3DTests.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/CrossSectionMeshGeometryModel3DTests.cs
@@ -24,11 +24,10 @@ namespace HelixToolkit.Wpf.SharpDX.Tests.Elements3D
         {
             var meshBuilder = new MeshBuilder();
             meshBuilder.AddBox(new Vector3(0f), 1, 1, 1);
-            var geometryModel3D = new CrossSectionMeshGeometryModel3D()
+            return new CrossSectionMeshGeometryModel3D()
             {
                 Geometry = meshBuilder.ToMesh(),
             };
-            return geometryModel3D;
         }
 
         [Test]

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/CrossSectionMeshGeometryModel3DTests.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/CrossSectionMeshGeometryModel3DTests.cs
@@ -1,0 +1,88 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MeshGeometryModel3DTests.cs" company="Helix Toolkit">
+//   Copyright (c) 2020 Helix Toolkit contributors
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using NUnit.Framework;
+using SharpDX;
+
+namespace HelixToolkit.Wpf.SharpDX.Tests.Elements3D
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    class CrossSectionMeshGeometryModel3DTests
+    {
+        private readonly Viewport3DX viewport = new Viewport3DX();
+
+        private CrossSectionMeshGeometryModel3D GetGeometryModel3D()
+        {
+            var meshBuilder = new MeshBuilder();
+            meshBuilder.AddBox(new Vector3(0f), 1, 1, 1);
+            var geometryModel3D = new CrossSectionMeshGeometryModel3D()
+            {
+                Geometry = meshBuilder.ToMesh(),
+            };
+            return geometryModel3D;
+        }
+
+        [Test]
+        public void HitTestShouldReturnOnePointOnFrontOfCubeWithNoCuttingPlanes()
+        {
+            var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
+            var hits = new List<HitTestResult>();
+            var geometryModel3D = GetGeometryModel3D();
+            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            Assert.AreEqual(1,hits.Count);
+            Assert.AreEqual(new Vector3(0.5f,0,0), hits[0].PointHit);
+        }
+
+        [TestCaseSource(nameof(GetPlanes))]
+        public void HitTestShouldReturnOnePointOnBackOfCubeWithCuttingPlaneInXZero(Action<CrossSectionMeshGeometryModel3D, Plane> setupPlane)
+        {
+            var plane = new Plane(new Vector3(0f),new Vector3(-1,0,0));
+            var geometryModel3D = GetGeometryModel3D();
+            setupPlane(geometryModel3D, plane);
+            var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
+            var hits = new List<HitTestResult>();
+            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            Assert.AreEqual(1, hits.Count);
+            Assert.AreEqual(new Vector3(-0.5f, 0, 0), hits[0].PointHit);
+        }
+
+        /// <summary>
+        /// Get all planes in the CrossSectionMeshGeometryModel3D with reflection so that if more planes are added tests will fail
+        /// </summary>
+        public static IEnumerable<object[]> GetPlanes()
+        {
+            var properties = typeof(CrossSectionMeshGeometryModel3D)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public);
+
+            var enables = properties
+                .Where(p => p.Name.StartsWith("EnablePlane", StringComparison.InvariantCulture))
+                .ToArray();
+            var planes = properties
+                .Where(p => p.Name.StartsWith("Plane", StringComparison.InvariantCulture))
+                .ToArray();
+            for (int i = 0; i < enables.Length; i++)
+            {
+                var planeProperty = planes[i];
+                var enableProperty = enables[i];
+
+                void Action(CrossSectionMeshGeometryModel3D model, Plane plane)
+                {
+                    planeProperty.SetValue(model, plane);
+                    enableProperty.SetValue(model, true);
+                }
+
+                yield return new object[]{(Action<CrossSectionMeshGeometryModel3D, Plane>) Action};
+            }
+
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/MeshGeometryModel3DTests.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/MeshGeometryModel3DTests.cs
@@ -1,11 +1,7 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MeshGeometryModel3DTests.cs" company="Helix Toolkit">
-//   Copyright (c) 2014 Helix Toolkit contributors
+//   Copyright (c) 2020 Helix Toolkit contributors
 // </copyright>
-// <summary>
-//   Test for pull request #54.
-//   Fix IndexOutOfRange exception in CreateDefaultVertexArray.
-// </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
@@ -47,11 +43,10 @@ namespace HelixToolkit.Wpf.SharpDX.Tests.Elements3D
         {
             var meshBuilder = new MeshBuilder();
             meshBuilder.AddBox(new Vector3(0f), 1, 1, 1);
-            var geometryModel3D = new MeshGeometryModel3D()
+            return new MeshGeometryModel3D()
             {
                 Geometry = meshBuilder.ToMesh(),
             };
-            return geometryModel3D;
         }
 
         [Test]

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/MeshGeometryModel3DTests.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/MeshGeometryModel3DTests.cs
@@ -9,20 +9,24 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using HelixToolkit.Wpf.SharpDX.Tests.Controls;
 using NUnit.Framework;
 using System.IO;
+using System.Threading;
+using SharpDX;
 
 namespace HelixToolkit.Wpf.SharpDX.Tests.Elements3D
 {
     [TestFixture]
+    [Apartment(ApartmentState.STA)]
     class MeshGeometryModel3DTests
     {
         /// <summary>
         /// Test for pull request #54.
         /// Fix IndexOutOfRange exception in CreateDefaultVertexArray.
         /// </summary>
-        [Test, STAThread]
+        [Test]
         public void CreateDefaultVertexArrayForTriangle()
         {
             var reader = new ObjReader();
@@ -37,6 +41,29 @@ namespace HelixToolkit.Wpf.SharpDX.Tests.Elements3D
             model.SceneNode.Attach(canvas.RenderHost);
 
             Assert.AreEqual(true, model.IsAttached);
+        }
+
+        private MeshGeometryModel3D GetGeometryModel3D()
+        {
+            var meshBuilder = new MeshBuilder();
+            meshBuilder.AddBox(new Vector3(0f), 1, 1, 1);
+            var geometryModel3D = new MeshGeometryModel3D()
+            {
+                Geometry = meshBuilder.ToMesh(),
+            };
+            return geometryModel3D;
+        }
+
+        [Test]
+        public void HitTestShouldReturnOnePointOnFrontOfCubeWithNoCuttingPlanes()
+        {
+            var viewport = new Viewport3DX();
+            var ray = new Ray(new Vector3(2f, 0f, 0f), new Vector3(-1, 0, 0));
+            var hits = new List<HitTestResult>();
+            var geometryModel3D = GetGeometryModel3D();
+            geometryModel3D.HitTest(viewport.RenderContext, ray, ref hits);
+            Assert.AreEqual(1, hits.Count);
+            Assert.AreEqual(new Vector3(0.5f, 0, 0), hits[0].PointHit);
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/HelixToolkit.Wpf.SharpDX.Tests.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/HelixToolkit.Wpf.SharpDX.Tests.csproj
@@ -89,6 +89,7 @@
     </Compile>
     <Compile Include="Controls\CanvasMock.cs" />
     <Compile Include="Controls\EffectsManagerTests.cs" />
+    <Compile Include="Elements3D\CrossSectionMeshGeometryModel3DTests.cs" />
     <Compile Include="Geometry\Polygon3DTests.cs" />
     <Compile Include="Elements3D\MeshGeometryModel3DTests.cs" />
     <Compile Include="Importers\ObjReaderTests.cs" />

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/HelixToolkit.Wpf.SharpDX.Tests.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/HelixToolkit.Wpf.SharpDX.Tests.csproj
@@ -181,7 +181,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit">
-      <Version>3.10.1</Version>
+      <Version>3.12.0</Version>
     </PackageReference>
     <PackageReference Include="SharpDX.D3DCompiler">
       <Version>4.2.0</Version>

--- a/Source/HelixToolkit.Wpf.Tests/HelixToolkit.Wpf.Tests.csproj
+++ b/Source/HelixToolkit.Wpf.Tests/HelixToolkit.Wpf.Tests.csproj
@@ -283,7 +283,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit">
-      <Version>3.10.1</Version>
+      <Version>3.12.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
First of all, thanks for a great project!

**Some background on this pull request:**
We are showing 3D drawings with HelixToolkit and to see the "inside" of objects we use the `CrossSectionMeshGeometryModel3D` to cut at arbitrary locations along the X, Y and Z axes. We noticed that if a cutting plane is active the hit testing doesn't take that into account. This obviously makes it hard for the user to select objects behind other objects.

This pull request takes the cutting planes into account for hit testing for `CrossSectionMeshGeometryModel3D`. There are still **some open questions** from my side:

- [x] `CrossSectionMeshGeometryModel3D` doesn't exist in HelixToolkit.SharpDX.Core but rather in HelixToolkit.SharpDX.Core.Wpf. This means that the current solution doesn't work in .NET Core (see changes in `MeshGeometry3D`). Do you know how this could be resolved in a good way? I'm not sure if I understand the reasoning between the differences between the .NET Framework and .NET Core nuget package/project structure, but I guess it is related to the continuous changes from MS in what's available in .NET Core/Standard.
- [ ] I modified an existing example to test this, should I create a new one instead?
- [ ] What's the performance requirements, do I risk making the hit testing slower?
- [ ] Is there a use case for not taking the cutting planes into account? Will this break code for someone? Should it be optional?
- [ ] Tests for when OctTree is used?
- [ ] Test for WPF (without SharpDX)? Is there a way to use the cutting planes in WPF without SharpDX? I couldn't find it.

