### PR TITLE
Fix billboardText not being call to initialize

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IModels.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IModels.cs
@@ -64,6 +64,14 @@ namespace HelixToolkit.UWP
         /// The height.
         /// </value>
         float Height { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this billboard internal is initialized.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is initialized; otherwise, <c>false</c>.
+        /// </value>
+        bool IsInitialized { get; }
     }
 
     /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BillboardNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BillboardNode.cs
@@ -71,6 +71,10 @@ namespace HelixToolkit.UWP
                 {
                     return true;
                 }
+                if (Geometry is IBillboardText billboard && !billboard.IsInitialized)
+                {
+                    return true;
+                }
                 return BoundingFrustumExtensions.Intersects(ref viewFrustum, ref BoundManager.BoundsSphereWithTransform);// viewFrustum.Intersects(ref sphere);
             }
 


### PR DESCRIPTION
Fix billboardText not being call to initialize during first pass of rendering. Ref #1349.