### PR TITLE
Orthographic camera : small error in the calculation of the animation

### DIFF
--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/OrthographicCamera.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/OrthographicCamera.cs
@@ -105,7 +105,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             else
             {
-                Width = oldWidth + (newWidth - oldWidth) / (accumTime / aniTime);
+                Width = oldWidth + (newWidth - oldWidth) * (accumTime / aniTime);
                 return true;
             }
         }


### PR DESCRIPTION
accumTime / aniTime  is a ratio equal to or less than 1 so we need to multiply with the delta and not divide to move gradually from the current value to the new value.