### PR TITLE
Support High DPI rendering under DPI Scaling. Fix UWP runtime error.

### DIFF
--- a/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
@@ -13,10 +13,47 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace CoreTest
 {
+    public static class DpiHelper
+    {
+        [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
+        public static extern int GetDeviceCaps(IntPtr hDC, int nIndex);
+
+        public enum DeviceCap
+        {
+            VERTRES = 10,
+            DESKTOPVERTRES = 117
+        }
+
+        public static double GetWindowsScreenScalingFactor(bool percentage = true)
+        {
+            //Create Graphics object from the current windows handle
+            var GraphicsObject = System.Drawing.Graphics.FromHwnd(IntPtr.Zero);
+            //Get Handle to the device context associated with this Graphics object
+            IntPtr DeviceContextHandle = GraphicsObject.GetHdc();
+            //Call GetDeviceCaps with the Handle to retrieve the Screen Height
+            int LogicalScreenHeight = GetDeviceCaps(DeviceContextHandle, (int)DeviceCap.VERTRES);
+            int PhysicalScreenHeight = GetDeviceCaps(DeviceContextHandle, (int)DeviceCap.DESKTOPVERTRES);
+            //Divide the Screen Heights to get the scaling factor and round it to two decimals
+            double ScreenScalingFactor = Math.Round((double)PhysicalScreenHeight / (double)LogicalScreenHeight, 2);
+            //If requested as percentage - convert it
+            if (percentage)
+            {
+                ScreenScalingFactor *= 100.0;
+            }
+            //Release the Handle and Dispose of the GraphicsObject object
+            GraphicsObject.ReleaseHdc(DeviceContextHandle);
+            GraphicsObject.Dispose();
+            //Return the Scaling Factor
+            return ScreenScalingFactor;
+        }
+    }
+
+
     public class CoreTestApp
     {
         public ViewportCore Viewport { get => viewport; }
@@ -55,7 +92,10 @@ namespace CoreTest
 
         public CoreTestApp(Form window)
         {
+            var dpiScale = DpiHelper.GetWindowsScreenScalingFactor(false);
+
             viewport = new ViewportCore(window.Handle);
+            viewport.DpiScale = dpiScale;
             cameraController = new CameraController(viewport);
             cameraController.CameraMode = CameraMode.Inspect;
             cameraController.CameraRotationMode = CameraRotationMode.Trackball;

--- a/Source/Examples/SharpDX.Core/CoreTest/ImGuiNode.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/ImGuiNode.cs
@@ -89,7 +89,7 @@ namespace HelixToolkit.SharpDX.Core.Model
                 ImGui.Render();
             }
             var io = ImGui.GetIO();      
-            io.DisplaySize = new System.Numerics.Vector2((int)context.ActualWidth, (int)context.ActualHeight);
+            io.DisplaySize = new System.Numerics.Vector2((int)(context.ActualWidth * context.DpiScale), (int)(context.ActualHeight * context.DpiScale));
             if(previousTime == TimeSpan.Zero)
             {
                 previousTime = context.TimeStamp;
@@ -177,8 +177,8 @@ namespace HelixToolkit.SharpDX.Core.Model
           
             ProjectionMatrix = Matrix.OrthoOffCenterRH(
                 0f,
-                io.DisplaySize.X,
-                io.DisplaySize.Y,
+                io.DisplaySize.X / context.DpiScale,
+                io.DisplaySize.Y / context.DpiScale,
                 0.0f,
                 -1.0f,
                 1.0f);
@@ -200,6 +200,7 @@ namespace HelixToolkit.SharpDX.Core.Model
             unsafe
             {
                 var draw_data = ImGui.GetDrawData();
+                draw_data.ScaleClipRects(new System.Numerics.Vector2(context.DpiScale, context.DpiScale));
                 int idx_offset = 0;
                 int vtx_offset = 0;
                 for (int n = 0; n < draw_data.CmdListsCount; n++)

--- a/Source/Examples/UWP/SimpleDemo/MainPage.xaml
+++ b/Source/Examples/UWP/SimpleDemo/MainPage.xaml
@@ -54,7 +54,7 @@
             </Button>
         </StackPanel>
         <hx:ModelContainer3DX x:Name="sharedModel" EffectsManager="{Binding EffectsManager}">
-            <hx:ItemsModel3D ItemsSource="{Binding OITVM.ModelGeometry}" Transform3D="{Binding OITVM.Transform}">
+            <hx:ItemsModel3D ItemsSource="{Binding OITVM.ModelGeometry}" HxTransform3D="{Binding OITVM.Transform}">
                 <hx:ItemsModel3D.ItemTemplate>
                     <DataTemplate>
                         <hx:MeshGeometryModel3D
@@ -88,11 +88,11 @@
             ShowCoordinateSystem="true"
             ShowFrameDetails="True"
             ShowFrameRate="True">
-            <hx:Viewport3DX.InputBindings>
+            <hx:Viewport3DX.ManipulationBindings>
                 <hx:ManipulationBinding Command="Rotate" Gesture="Pan" />
                 <hx:ManipulationBinding Command="Pan" Gesture="TwoFingerPan" />
                 <hx:ManipulationBinding Command="Zoom" Gesture="Pinch" />
-            </hx:Viewport3DX.InputBindings>
+            </hx:Viewport3DX.ManipulationBindings>
             <hx:ShadowMap3D />
             <hx:DirectionalLight3D Direction="{Binding DirectionalLightDirection}" Color="White" />
             <hx:EnvironmentMap3D Texture="{Binding EnvironmentMap}" />
@@ -110,7 +110,7 @@
                     Color="White" />
                 <hx:BillboardTextModel3D Geometry="{Binding AxisLabelGeometry}" IsTransparent="True" />
             </hx:GroupModel3D>
-            <hx:GroupModel3D Transform3D="{Binding Transform}">
+            <hx:GroupModel3D HxTransform3D="{Binding Transform}">
                 <hx:GroupModel3D.OctreeManager>
                     <hx:GeometryModel3DOctreeManager />
                 </hx:GroupModel3D.OctreeManager>
@@ -119,21 +119,21 @@
                     Geometry="{Binding Geometry}"
                     IsThrowingShadow="True"
                     Material="{Binding Material}"
-                    Transform3D="{Binding Transform1}" />
+                    HxTransform3D="{Binding Transform1}" />
                 <hx:MeshGeometryModel3D
                     CullMode="Back"
                     Geometry="{Binding Geometry}"
                     IsThrowingShadow="True"
                     Material="{Binding Material}"
-                    Transform3D="{Binding Transform2}" />
+                    HxTransform3D="{Binding Transform2}" />
                 <hx:MeshGeometryModel3D
                     CullMode="Back"
                     Geometry="{Binding Geometry}"
                     IsThrowingShadow="True"
                     Material="{Binding Material}"
-                    Transform3D="{Binding Transform3}" />
+                    HxTransform3D="{Binding Transform3}" />
             </hx:GroupModel3D>
-            <hx:GroupModel3D Transform3D="{Binding Transform4}">
+            <hx:GroupModel3D HxTransform3D="{Binding Transform4}">
                 <hx:PointGeometryModel3D
                     Geometry="{Binding PointGeometry}"
                     IsThrowingShadow="True"
@@ -172,7 +172,7 @@
                 Geometry="{Binding OITVM.GridModel}"
                 IsHitTestVisible="False"
                 Thickness="0.5"
-                Transform3D="{Binding OITVM.GridTransform}"
+                HxTransform3D="{Binding OITVM.GridTransform}"
                 Color="#4F4E4E" />
             <hx:PostEffectMeshBorderHighlight EffectName="border" NumberOfBlurPass="2" />
         </hx:Viewport3DX>
@@ -195,11 +195,11 @@
             OnMouse3DDown="Viewport3DX_OnMouse3DDown"
             SharedModelContainer="{Binding ElementName=sharedModel}"
             ShowCoordinateSystem="true">
-            <hx:Viewport3DX.InputBindings>
+            <hx:Viewport3DX.ManipulationBindings>
                 <hx:ManipulationBinding Command="Rotate" Gesture="Pan" />
                 <hx:ManipulationBinding Command="Pan" Gesture="TwoFingerPan" />
                 <hx:ManipulationBinding Command="Zoom" Gesture="Pinch" />
-            </hx:Viewport3DX.InputBindings>
+            </hx:Viewport3DX.ManipulationBindings>
             <hx:DirectionalLight3D Direction="{Binding ElementName=viewport1, Path=Camera.LookDirection}" Color="White" />
             <!--<hx:AxisPlaneGridModel3D Offset="-20" AutoSpacing="False" PlaneColor="#003E3E3E" GridThickness="0.02"/>-->
             <hx:AxisPlaneGridModel3D

--- a/Source/Examples/WPF.SharpDX/D2DScreenMenuExample/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/D2DScreenMenuExample/MainWindow.xaml
@@ -13,7 +13,7 @@
     Background="Black"
     mc:Ignorable="d">
     <Grid>
-        <hx:Viewport3DX
+        <hx:Viewport3DX Name="view1"
             Camera="{Binding Camera}"
             EffectsManager="{Binding EffectsManager}"
             EnableSwapChainRendering="False">
@@ -84,5 +84,6 @@
                 </hx2D:Panel2D>
             </hx:Viewport3DX.Content2D>
         </hx:Viewport3DX>
+        <CheckBox IsChecked="{Binding ElementName=view1, Path=EnableHighDpiRendering}" HorizontalAlignment="Left" VerticalAlignment="Top">High Dpi</CheckBox>
     </Grid>
 </Window>

--- a/Source/Examples/WPF.SharpDX/SimpleDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/SimpleDemo/MainWindow.xaml
@@ -46,7 +46,7 @@
             CoordinateSystemLabelForeground="#434343"
             EffectsManager="{Binding EffectsManager}"
             EnableDesignModeRendering="True"
-            FXAALevel="Low"
+            FXAALevel="Low" EnableSwapChainRendering="False"
             ModelUpDirection="{Binding UpDirection}"
             ShowCoordinateSystem="True"
             SubTitle="{Binding SubTitle}"
@@ -136,6 +136,9 @@
             <Separator />
             <StatusBarItem>
                 <TextBlock Text="{Binding Items.Count, ElementName=view1, StringFormat=Children: \{0\}}" />
+            </StatusBarItem>
+            <StatusBarItem>
+                <CheckBox IsChecked="{Binding ElementName=view1, Path=EnableHighDpiRendering}">High DPI</CheckBox>
             </StatusBarItem>
         </StatusBar>
 

--- a/Source/HelixToolkit.Native.ShaderBuilder/Common/CommonBuffers.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/Common/CommonBuffers.hlsl
@@ -29,7 +29,7 @@ cbuffer cbTransforms : register(b0)
     float OITPower;
     float OITSlope;
     int OITWeightMode;
-    int OITReserved;
+    float DpiScale;
 };
 
 #if defined(MESHSIMPLE)

--- a/Source/HelixToolkit.Native.ShaderBuilder/GS/gsBillboard.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/GS/gsBillboard.hlsl
@@ -36,10 +36,10 @@ void main(point GSInputBT input[1], inout TriangleStream<PSInputBT> SpriteStream
     if (fixedSize)// if fixed sized billboard
     {
 		// Translate offset into normalized device coordinates.
-        ndcTranslated0.xy += windowToNdc(input[0].offTR);
-        ndcTranslated1.xy += windowToNdc(input[0].offBR);
-        ndcTranslated2.xy += windowToNdc(input[0].offTL);
-        ndcTranslated3.xy += windowToNdc(input[0].offBL);
+        ndcTranslated0.xy += windowToNdc(input[0].offTR * DpiScale);
+        ndcTranslated1.xy += windowToNdc(input[0].offBR * DpiScale);
+        ndcTranslated2.xy += windowToNdc(input[0].offTL * DpiScale);
+        ndcTranslated3.xy += windowToNdc(input[0].offBL * DpiScale);
     }
 
     float3 vEye = vEyePos - input[0].p.xyz;

--- a/Source/HelixToolkit.Native.ShaderBuilder/GS/gsLine.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/GS/gsLine.hlsl
@@ -15,7 +15,7 @@ void makeLine(out float4 points[4], in float4 posA, in float4 posB, in float wid
     // Compute tangent and binormal of line AB in window space
     // Binormal is scaled by line width 
     float2 tangent = normalize(Bw.xy - Aw.xy);
-    float2 binormal = width * float2(tangent.y, -tangent.x);
+    float2 binormal = width * DpiScale * float2(tangent.y, -tangent.x);
     
     // Compute the corners of the ribbon in window space
     float2 A1w = Aw - binormal;

--- a/Source/HelixToolkit.Native.ShaderBuilder/GS/gsPoint.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/GS/gsPoint.hlsl
@@ -8,8 +8,8 @@ void makeQuad(out float4 points[4], in float4 posA, in float w, in float h)
 {
     // Bring A and B in window space
     float2 Aw = projToWindow(posA);
-    float w2 = w * 0.5;
-    float h2 = h * 0.5;
+    float w2 = w * 0.5 * DpiScale;
+    float h2 = h * 0.5 * DpiScale;
 
     // Compute the corners of the ribbon in window space
     float2 A1w = float2(Aw.x + w2, Aw.y + h2);

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
@@ -36,6 +36,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
                     Viewport = this,
                 };
             }
+            RenderHost.DpiScale = (float)DpiScale;
             BackgroundColor = Color.Black;
             RenderHost.StartRenderLoop += RenderHost_StartRenderLoop;
             RenderHost.StopRenderLoop += RenderHost_StopRenderLoop;

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCoreProperties.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCoreProperties.cs
@@ -197,7 +197,7 @@ namespace HelixToolkit.SharpDX.Core.Controls
         /// <value>
         /// The viewport rectangle.
         /// </value>
-        public Rectangle ViewportRectangle { get { return new Rectangle(0, 0, (int)RenderHost.ActualWidth, (int)RenderHost.ActualHeight); } }
+        public Rectangle ViewportRectangle { get { return new Rectangle(0, 0, (int)(RenderHost.ActualWidth / DpiScale), (int)(RenderHost.ActualHeight / DpiScale)); } }
         /// <summary>
         /// Gets the render context.
         /// </summary>
@@ -261,6 +261,23 @@ namespace HelixToolkit.SharpDX.Core.Controls
         /// The actual height.
         /// </value>
         public double ActualHeight { private set; get; }
+
+        private double dpiScale = 1;
+        public double DpiScale
+        {
+            set
+            {
+                dpiScale = value;
+                if (RenderHost != null)
+                {
+                    RenderHost.DpiScale = (float)value;
+                }
+            }
+            get
+            {
+                return dpiScale;
+            }
+        } 
 
         private Vector3 modelUpDirection = Vector3.UnitY;
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
@@ -257,12 +257,12 @@ namespace HelixToolkit.UWP
             /// Called when [create projection matrix].
             /// </summary>
             /// <param name="scale">The scale.</param>
-            protected virtual void OnCreateProjectionMatrix(float scale)
+            protected virtual void OnCreateProjectionMatrix()
             {
-                projectionMatrix = CreateProjectionMatrix(IsPerspective, IsRightHand, scale, Fov, 0.001f, 100f, CameraDistance, CameraDistance);
+                projectionMatrix = CreateProjectionMatrix(IsPerspective, IsRightHand, Fov, 0.001f, 100f, CameraDistance, CameraDistance);
             }
 
-            private static Matrix CreateProjectionMatrix(bool isPerspective, bool isRightHand, float scale, float fov, float near, float far, float w, float h)
+            private static Matrix CreateProjectionMatrix(bool isPerspective, bool isRightHand, float fov, float near, float far, float w, float h)
             {
                 if (isPerspective)
                 {
@@ -286,7 +286,7 @@ namespace HelixToolkit.UWP
                     ScreenRatio = ratio;
                     Width = width;
                     Height = height;
-                    OnCreateProjectionMatrix(SizeScale);
+                    OnCreateProjectionMatrix();
                 }
             }
 
@@ -334,7 +334,6 @@ namespace HelixToolkit.UWP
                     dsView.Dispose();
                 }
                 IsRightHand = !context.Camera.CreateLeftHandSystem;
-                float viewportSize = Size * SizeScale;
                 switch (mode)
                 {
                     case ScreenSpacedMode.RelativeScreenSpaced:
@@ -357,7 +356,7 @@ namespace HelixToolkit.UWP
             private void RenderRelativeScreenSpaced(RenderContext context, DeviceContextProxy deviceContext)
             {
                 IsRightHand = !context.Camera.CreateLeftHandSystem;
-                float viewportSize = Size * SizeScale;
+                float viewportSize = Size * SizeScale * context.DpiScale;
                 var globalTrans = context.GlobalTransform;
                 UpdateProjectionMatrix((float)context.ActualWidth, (float)context.ActualHeight);
                 globalTrans.View = CreateViewMatrix(context, out globalTrans.EyePos);
@@ -394,7 +393,7 @@ namespace HelixToolkit.UWP
                 // Create new projection matrix with proper near/far field.
                 float w = globalTrans.Viewport.X;
                 float h = globalTrans.Viewport.Y;
-                globalTrans.Projection = CreateProjectionMatrix(context.IsPerspective, IsRightHand, 1,
+                globalTrans.Projection = CreateProjectionMatrix(context.IsPerspective, IsRightHand, 
                     globalTrans.Frustum.X, 0.01f, 500 / SizeScale, w, h);
                 globalTrans.ViewProjection = globalTrans.View * globalTrans.Projection;
                 globalTrans.EyePos = newPos;

--- a/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/ScreenSpacedMeshRenderCore.cs
@@ -256,7 +256,6 @@ namespace HelixToolkit.UWP
             /// <summary>
             /// Called when [create projection matrix].
             /// </summary>
-            /// <param name="scale">The scale.</param>
             protected virtual void OnCreateProjectionMatrix()
             {
                 projectionMatrix = CreateProjectionMatrix(IsPerspective, IsRightHand, Fov, 0.001f, 100f, CameraDistance, CameraDistance);

--- a/Source/HelixToolkit.SharpDX.Shared/Core2D/Abstract/RenderCore2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core2D/Abstract/RenderCore2D.cs
@@ -48,6 +48,11 @@ namespace HelixToolkit.UWP
                 set; get;
             } = true;
 
+            public IRenderHost RenderHost
+            {
+                private set; get;
+            } = null;
+
             private RectangleF rect = new RectangleF();
             /// <summary>
             /// Absolute layout rectangle cooridnate for renderable
@@ -155,6 +160,11 @@ namespace HelixToolkit.UWP
             {
                 if (IsAttached)
                 { return; }
+                if (host == null)
+                {
+                    return;
+                }
+                RenderHost = host;
                 IsAttached = OnAttach(host);
             }
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core2D/BorderRenderCore2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core2D/BorderRenderCore2D.cs
@@ -182,12 +182,12 @@ namespace HelixToolkit.UWP
                 {
                     context.DeviceContext.FillRoundedRectangle(roundRect, Background);
                 }
-
-                if (!borderThickness.IsZero && StrokeBrush != null && StrokeStyle != null)
+                var thickness = BorderThickness * context.DpiScale;
+                if (!thickness.IsZero && StrokeBrush != null && StrokeStyle != null)
                 {
-                    if(borderThickness.X == borderThickness.Y && borderThickness.X == borderThickness.Z && borderThickness.X == borderThickness.W)
+                    if(thickness.X == thickness.Y && thickness.X == thickness.Z && thickness.X == thickness.W)
                     {
-                        context.DeviceContext.DrawRoundedRectangle(roundRect, StrokeBrush, borderThickness.X, StrokeStyle);
+                        context.DeviceContext.DrawRoundedRectangle(roundRect, StrokeBrush, thickness.X, StrokeStyle);
                     }
                     else
                     {
@@ -199,7 +199,7 @@ namespace HelixToolkit.UWP
                             var bottomRight = LayoutBound.BottomRight - new Vector2(0, CornerRadius);
                             var bottomLeft = LayoutBound.BottomLeft + new Vector2(CornerRadius, 0);
 
-                            if (borderThickness.X > 0)
+                            if (thickness.X > 0)
                             {
                                 var figures = new List<Figure>();     
                                 var figure = new Figure(topLeft, false, false);
@@ -211,13 +211,13 @@ namespace HelixToolkit.UWP
                                 figure.AddSegment(new LineSegment(topRight));
                                 figures.Add(figure);
                                 borderRenderCore[0].Figures = figures;
-                                borderRenderCore[0].StrokeWidth = borderThickness.X;
+                                borderRenderCore[0].StrokeWidth = thickness.X;
                             }
                             else
                             {
                                 borderRenderCore[0].Figures = null;
                             }
-                            if(borderThickness.Y > 0)
+                            if(thickness.Y > 0)
                             {
                                 var figures = new List<Figure>();
                                 var figure = new Figure(topRight, false, false);
@@ -229,13 +229,13 @@ namespace HelixToolkit.UWP
                                 figure.AddSegment(new LineSegment(bottomRight));
                                 figures.Add(figure);
                                 borderRenderCore[1].Figures = figures;
-                                borderRenderCore[1].StrokeWidth = borderThickness.Y;
+                                borderRenderCore[1].StrokeWidth = thickness.Y;
                             }
                             else
                             {
                                 borderRenderCore[1].Figures = null;
                             }
-                            if (borderThickness.Z > 0)
+                            if (thickness.Z > 0)
                             {
                                 var figures = new List<Figure>();
                                 var figure = new Figure(bottomRight, false, false);
@@ -247,13 +247,13 @@ namespace HelixToolkit.UWP
                                 figure.AddSegment(new LineSegment(bottomLeft));
                                 figures.Add(figure);
                                 borderRenderCore[2].Figures = figures;
-                                borderRenderCore[2].StrokeWidth = borderThickness.Z;
+                                borderRenderCore[2].StrokeWidth = thickness.Z;
                             }
                             else
                             {
                                 borderRenderCore[2].Figures = null;
                             }
-                            if (borderThickness.W > 0)
+                            if (thickness.W > 0)
                             {
                                 var figures = new List<Figure>();
                                 var figure = new Figure(bottomLeft, false, false);
@@ -265,7 +265,7 @@ namespace HelixToolkit.UWP
                                 figure.AddSegment(new LineSegment(topLeft));
                                 figures.Add(figure);
                                 borderRenderCore[3].Figures = figures;
-                                borderRenderCore[3].StrokeWidth = borderThickness.W;
+                                borderRenderCore[3].StrokeWidth = thickness.W;
                             }
                             else
                             {

--- a/Source/HelixToolkit.SharpDX.Shared/Core2D/FrameStatisticsRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core2D/FrameStatisticsRenderCore.cs
@@ -88,7 +88,7 @@ namespace HelixToolkit.UWP
             protected override bool OnAttach(IRenderHost target)
             {
                 factory = Collect(new Factory(FactoryType.Isolated));
-                format = Collect(new TextFormat(factory, "Arial", 12));
+                format = Collect(new TextFormat(factory, "Arial", 12 * target.DpiScale));
                 previousStr = "";
                 this.statistics = target.RenderStatistics;
                 return base.OnAttach(target);

--- a/Source/HelixToolkit.SharpDX.Shared/Core2D/TextRenderCore2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core2D/TextRenderCore2D.cs
@@ -206,7 +206,7 @@ namespace HelixToolkit.UWP
                 {
                     textLayoutDirty = true;
                     textFactory = Collect(new Factory(FactoryType.Isolated));
-                    textFormat = Collect(new TextFormat(textFactory, FontFamily, FontWeight, FontStyle, FontSize));
+                    textFormat = Collect(new TextFormat(textFactory, FontFamily, FontWeight, FontStyle, FontSize * host.DpiScale));
                     return true;
                 }
                 else
@@ -218,7 +218,7 @@ namespace HelixToolkit.UWP
             private void UpdateFontFormat()
             {
                 RemoveAndDispose(ref textFormat);
-                textFormat = Collect(new TextFormat(textFactory, FontFamily, FontWeight, FontStyle, FontSize));
+                textFormat = Collect(new TextFormat(textFactory, FontFamily, FontWeight, FontStyle, FontSize * RenderHost.DpiScale));
                 textLayoutDirty = true;
             }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/IViewportExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/IViewportExtensions.cs
@@ -110,7 +110,6 @@ namespace HelixToolkit.UWP
                 {
                     hits = new List<HitTestResult>();
                 }
-
                 foreach (var element in viewport.Renderables)
                 {
                     element.HitTest(viewport.RenderHost.RenderContext, ray, ref hits);
@@ -182,8 +181,8 @@ namespace HelixToolkit.UWP
                 var viewMatrix = camera.CreateViewMatrix();               
 
                 var matrix = MatrixExtensions.PsudoInvert(ref viewMatrix);
-                float w = viewport.RenderHost.ActualWidth;
-                float h = viewport.RenderHost.ActualHeight;
+                float w = viewport.RenderHost.ActualWidth / viewport.RenderHost.DpiScale;
+                float h = viewport.RenderHost.ActualHeight / viewport.RenderHost.DpiScale;
                 var aspectRatio = w / h;
 
                 var projMatrix = camera.CreateProjectionMatrix(aspectRatio);

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -168,6 +168,16 @@ namespace HelixToolkit.UWP
         /// The actual width.
         /// </value>
         float ActualWidth { get; }
+        /// <summary>
+        /// Gets or sets the dpi scale.
+        /// </summary>
+        /// <value>
+        /// The dpi scale.
+        /// </value>
+        float DpiScale
+        {
+            set; get;
+        }
 
         /// <summary>
         /// Indicates if DPFCanvas busy on rendering.

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Layouts.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Layouts.cs
@@ -276,7 +276,7 @@ namespace HelixToolkit.UWP
         public float OITWeightPower;
         public float OITWeightDepthSlope;
         public int OITWeightMode;
-        private int padding1;
+        public float DpiScale;
         public const int SizeInBytes = 4 * (4 * 4 * 3 + 4 * 5);
     }
     /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenSpacedNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenSpacedNode.cs
@@ -223,7 +223,7 @@ namespace HelixToolkit.UWP
             {
                 var p = Vector3.TransformCoordinate(ray.Position, context.ScreenViewProjectionMatrix);
                 var screenSpaceCore = RenderCore as ScreenSpacedMeshRenderCore;
-                float viewportSize = screenSpaceCore.Size * screenSpaceCore.SizeScale;
+                float viewportSize = screenSpaceCore.Size * screenSpaceCore.SizeScale * context.DpiScale;
 
                 float offx = (float)(context.ActualWidth / 2 * (1 + screenSpaceCore.RelativeScreenLocationX) - viewportSize / 2);
                 float offy = (float)(context.ActualHeight / 2 * (1 - screenSpaceCore.RelativeScreenLocationY) - viewportSize / 2);
@@ -262,7 +262,7 @@ namespace HelixToolkit.UWP
                 {
                     var p = Vector3.TransformCoordinate(ray.Position, context.ScreenViewProjectionMatrix);
                     var screenSpaceCore = RenderCore as ScreenSpacedMeshRenderCore;
-                    float viewportSize = screenSpaceCore.Size * screenSpaceCore.SizeScale;
+                    float viewportSize = screenSpaceCore.Size * screenSpaceCore.SizeScale * context.DpiScale;
 
                     var abs = Vector3.TransformCoordinate(AbsolutePosition3D, context.ScreenViewProjectionMatrix);
                     float offx = (float)(abs.X - viewportSize / 2);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/SceneNode2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/SceneNode2D.cs
@@ -285,6 +285,11 @@ namespace HelixToolkit.UWP
                 get { return RenderCore.IsMouseOver; }
             }
 
+            public float DpiScale
+            {
+                private set; get;
+            } = 1;
+
             /// <summary>
             /// Initializes a new instance of the <see cref="SceneNode2D"/> class.
             /// </summary>
@@ -312,6 +317,7 @@ namespace HelixToolkit.UWP
                     return;
                 }
                 RenderHost = host;
+                DpiScale = host.DpiScale;
                 IsAttached = OnAttach(host);
                 if (IsAttached)
                 {
@@ -531,6 +537,11 @@ namespace HelixToolkit.UWP
             /// <returns></returns>
             public bool HitTest(Vector2 mousePoint, out HitTest2DResult hitResult)
             {
+                if (Parent == null)
+                {
+                    mousePoint *= DpiScale;
+                }
+
                 if (CanHitTest())
                 {
                     return OnHitTest(ref mousePoint, out hitResult);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/SceneNode2DLayout.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/SceneNode2DLayout.cs
@@ -93,7 +93,7 @@ namespace HelixToolkit.UWP
                 }
                 get
                 {
-                    return width;
+                    return width * DpiScale;
                 }
             }
 
@@ -110,8 +110,21 @@ namespace HelixToolkit.UWP
                 }
                 get
                 {
-                    return height;
+                    return height * DpiScale;
                 }
+            }
+
+            private float dpiScale = 1;
+            public float DpiScale
+            {
+                set
+                {
+                    if (Set(ref dpiScale, value))
+                    {
+                        InvalidateAll();
+                    }
+                } 
+                get => dpiScale;
             }
 
             private float minimumWidth = 0;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/SceneNode2DLayout.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/SceneNode2DLayout.cs
@@ -93,7 +93,7 @@ namespace HelixToolkit.UWP
                 }
                 get
                 {
-                    return width * DpiScale;
+                    return width;
                 }
             }
 
@@ -110,21 +110,8 @@ namespace HelixToolkit.UWP
                 }
                 get
                 {
-                    return height * DpiScale;
+                    return height;
                 }
-            }
-
-            private float dpiScale = 1;
-            public float DpiScale
-            {
-                set
-                {
-                    if (Set(ref dpiScale, value))
-                    {
-                        InvalidateAll();
-                    }
-                } 
-                get => dpiScale;
             }
 
             private float minimumWidth = 0;
@@ -447,7 +434,7 @@ namespace HelixToolkit.UWP
                 }
                 previousMeasureSize = size;
                 var availableSize = size.ToVector2();
-                var availableSizeWithoutMargin = availableSize - MarginWidthHeight;
+                var availableSizeWithoutMargin = availableSize - MarginWidthHeight * DpiScale;
                 Vector2 maxSize = Vector2.Zero, minSize = Vector2.Zero;
                 CalculateMinMax(ref minSize, ref maxSize);
 
@@ -471,7 +458,7 @@ namespace HelixToolkit.UWP
                     clipped = true;
                 }
 
-                var clippedDesiredSize = desiredSize + MarginWidthHeight;
+                var clippedDesiredSize = desiredSize + MarginWidthHeight * DpiScale;
 
                 if (clippedDesiredSize.X > availableSize.X)
                 {
@@ -542,11 +529,11 @@ namespace HelixToolkit.UWP
                 {
                     if (UnclippedDesiredSize.X == -1 || UnclippedDesiredSize.Y == -1)
                     {
-                        desiredSize = arrangeSize - MarginWidthHeight;
+                        desiredSize = arrangeSize - MarginWidthHeight * DpiScale;
                     }
                     else
                     {
-                        desiredSize = UnclippedDesiredSize - MarginWidthHeight;
+                        desiredSize = UnclippedDesiredSize - MarginWidthHeight * DpiScale;
                     }
                 }
 
@@ -591,7 +578,7 @@ namespace HelixToolkit.UWP
                 }
 
                 var oldRenderSize = RenderSize;
-                var arrangeResultSize = ArrangeOverride(new RectangleF(Margin.Left, Margin.Top, arrangeSize.X - MarginWidthHeight.X, arrangeSize.Y - MarginWidthHeight.Y)).ToVector2();
+                var arrangeResultSize = ArrangeOverride(new RectangleF(Margin.Left * DpiScale, Margin.Top * DpiScale, arrangeSize.X - MarginWidthHeight.X * DpiScale, arrangeSize.Y - MarginWidthHeight.Y * DpiScale)).ToVector2();
 
                 bool arrangeSizeChanged = arrangeResultSize != oldRenderSize;
                 if (arrangeSizeChanged)
@@ -607,7 +594,7 @@ namespace HelixToolkit.UWP
                     ClipEnabled = clippedArrangeResultSize.X < arrangeResultSize.X || clippedArrangeResultSize.Y < arrangeResultSize.Y;
                 }
 
-                var clientSize = new Vector2(Math.Max(0, rectWidthHeight.X - MarginWidthHeight.X), Math.Max(0, rectWidthHeight.Y - MarginWidthHeight.Y));
+                var clientSize = new Vector2(Math.Max(0, rectWidthHeight.X - MarginWidthHeight.X * DpiScale), Math.Max(0, rectWidthHeight.Y - MarginWidthHeight.Y * DpiScale));
 
                 if (!ClipEnabled)
                 {
@@ -694,12 +681,14 @@ namespace HelixToolkit.UWP
                 width = (float.IsInfinity(dimensionLength) ? 0 : dimensionLength);
 
                 minSize.X = Math.Max(Math.Min(maxSize.X, width), minSize.X);
+                minSize *= DpiScale;
+                maxSize *= DpiScale;
             }
 
             private void UpdateLayoutInternal()
             {
-                LayoutBound = new RectangleF((float)Margin.Left, (float)Margin.Top, RenderSize.X, RenderSize.Y);
-                LayoutClipBound = new RectangleF(0, 0, RenderSize.X + MarginWidthHeight.X, RenderSize.Y + MarginWidthHeight.Y);
+                LayoutBound = new RectangleF((float)Margin.Left * DpiScale, (float)Margin.Top * DpiScale, RenderSize.X, RenderSize.Y);
+                LayoutClipBound = new RectangleF(0, 0, RenderSize.X + MarginWidthHeight.X * DpiScale, RenderSize.Y + MarginWidthHeight.Y * DpiScale);
                 LayoutTranslate = Matrix3x2.Translation((float)Math.Round(LayoutOffsets.X), (float)Math.Round(LayoutOffsets.Y));
             }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/ShapeNode2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/Abstract/ShapeNode2D.cs
@@ -145,11 +145,11 @@ namespace HelixToolkit.UWP
             {
                 set
                 {
-                    (RenderCore as ShapeRenderCore2DBase).StrokeWidth = value;
+                    (RenderCore as ShapeRenderCore2DBase).StrokeWidth = value * DpiScale;
                 }
                 get
                 {
-                    return (RenderCore as ShapeRenderCore2DBase).StrokeWidth;
+                    return (RenderCore as ShapeRenderCore2DBase).StrokeWidth / DpiScale;
                 }
             }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/BorderNode2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/BorderNode2D.cs
@@ -205,6 +205,8 @@ namespace HelixToolkit.UWP
                 {
                     var margin = new Size2F((BorderThickness.Left / 2 + Padding.Left + BorderThickness.Right / 2 + Padding.Right),
                         (BorderThickness.Top / 2 + Padding.Top + BorderThickness.Bottom / 2 + Padding.Bottom));
+                    margin.Width *= DpiScale;
+                    margin.Height *= DpiScale;
                     var childAvail = new Size2F(Math.Max(0, availableSize.Width - margin.Width), Math.Max(0, availableSize.Height - margin.Height));
 
                     var size = base.MeasureOverride(childAvail);
@@ -216,29 +218,32 @@ namespace HelixToolkit.UWP
                     {
                         if (Width != float.PositiveInfinity)
                         {
-                            size.Width = Width;
+                            size.Width = Width * DpiScale;
                         }
                         if (Height != float.PositiveInfinity)
                         {
-                            size.Height = Height;
+                            size.Height = Height * DpiScale;
                         }
                         return size;
                     }
                 }
                 else
                 {
-                    return new Size2F((float)(BorderThickness.Left / 2 + Padding.Left + BorderThickness.Right / 2 + Padding.Right + MarginWidthHeight.X + Width == float.PositiveInfinity ? 0 : Width),
-                        (float)(BorderThickness.Top / 2 + Padding.Top + BorderThickness.Bottom / 2 + Padding.Bottom + MarginWidthHeight.Y + Height == float.PositiveInfinity ? 0 : Height));
+                    var size = new Size2F((float)(BorderThickness.Left / 2 + Padding.Left + BorderThickness.Right / 2 + Padding.Right + MarginWidthHeight.X + Width == float.PositiveInfinity ? 0 : Width),
+                        (float)(BorderThickness.Top / 2 + Padding.Top + BorderThickness.Bottom / 2 + Padding.Bottom + MarginWidthHeight.Y) + Height == float.PositiveInfinity ? 0 : Height);
+                    size.Width *= DpiScale;
+                    size.Height *= DpiScale;
+                    return size;
                 }
             }
 
             protected override RectangleF ArrangeOverride(RectangleF finalSize)
             {
                 var contentRect = new RectangleF(finalSize.Left, finalSize.Top, finalSize.Width, finalSize.Height);
-                contentRect.Left += (float)(BorderThickness.Left / 2 + Padding.Left);
-                contentRect.Right -= (float)(BorderThickness.Right / 2 + Padding.Right);
-                contentRect.Top += (float)(BorderThickness.Top / 2 + Padding.Top);
-                contentRect.Bottom -= (float)(BorderThickness.Bottom / 2 + Padding.Bottom);
+                contentRect.Left += (float)(BorderThickness.Left / 2 + Padding.Left) * DpiScale;
+                contentRect.Right -= (float)(BorderThickness.Right / 2 + Padding.Right) * DpiScale;
+                contentRect.Top += (float)(BorderThickness.Top / 2 + Padding.Top) * DpiScale;
+                contentRect.Bottom -= (float)(BorderThickness.Bottom / 2 + Padding.Bottom) * DpiScale;
                 base.ArrangeOverride(contentRect);
                 return finalSize;
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/ImageNode2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene2D/ImageNode2D.cs
@@ -111,6 +111,8 @@ namespace HelixToolkit.UWP
                 if (ImageStream != null)
                 {
                     var imageSize = (RenderCore as ImageRenderCore2D).ImageSize;
+                    imageSize.Width *= DpiScale;
+                    imageSize.Height *= DpiScale;
                     if (Width == 0 && Height == 0)
                     {
                         return new Size2F(Math.Min(availableSize.Width, imageSize.Width), Math.Min(availableSize.Height, imageSize.Height));
@@ -124,17 +126,17 @@ namespace HelixToolkit.UWP
                         float aspectRatio = imageSize.Width / imageSize.Height;
                         if (Width == 0)
                         {
-                            var height = Math.Min(availableSize.Height, Height);
+                            var height = Math.Min(availableSize.Height, Height) * DpiScale;
                             return new Size2F(height / aspectRatio, height);
                         }
                         else
                         {
-                            var width = Math.Min(availableSize.Width, Width);
+                            var width = Math.Min(availableSize.Width, Width) * DpiScale;
                             return new Size2F(width, width * aspectRatio);
                         }
                     }
                 }
-                return new Size2F(Math.Max(0, Width), Math.Max(0, Height));
+                return new Size2F(Math.Max(0, Width * DpiScale), Math.Max(0, Height * DpiScale));
             }
 
             protected override bool OnHitTest(ref Vector2 mousePoint, out HitTest2DResult hitResult)

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
@@ -109,7 +109,16 @@ namespace HelixToolkit.UWP
         /// The actual height.
         /// </value>
         public float ActualHeight { get { return RenderHost.ActualHeight; } }
-
+        /// <summary>
+        /// Gets the dpi scale.
+        /// </summary>
+        /// <value>
+        /// The dpi scale.
+        /// </value>
+        public float DpiScale
+        {
+            get => RenderHost.DpiScale;
+        }
         /// <summary>
         /// Gets or sets the camera.
         /// </summary>
@@ -368,7 +377,7 @@ namespace HelixToolkit.UWP
         /// </summary>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Matrix GetScreenViewProjectionMatrix()
+        internal Matrix GetScreenViewProjectionMatrix()
         {
             return ScreenViewProjectionMatrix;
         }
@@ -394,7 +403,8 @@ namespace HelixToolkit.UWP
                 globalTransform.View = ViewMatrix;
                 globalTransform.Projection = ProjectionMatrix;
                 globalTransform.ViewProjection = ViewMatrix * ProjectionMatrix;
-                globalTransform.TimeStamp = (float)Stopwatch.GetTimestamp()/Stopwatch.Frequency;                
+                globalTransform.TimeStamp = (float)Stopwatch.GetTimestamp()/Stopwatch.Frequency;
+                globalTransform.DpiScale = DpiScale;
                 cbuffer.UploadDataToBuffer(deviceContext, ref globalTransform);
             }
             if (updateLights)

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext2D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext2D.cs
@@ -34,6 +34,13 @@ namespace HelixToolkit.UWP
         /// </value>
         public double ActualHeight { get { return renderHost.ActualHeight; } }
         /// <summary>
+        /// Gets the dpi scale.
+        /// </summary>
+        /// <value>
+        /// The dpi scale.
+        /// </value>
+        public float DpiScale => renderHost.DpiScale;
+        /// <summary>
         /// Gets or sets the device context.
         /// </summary>
         /// <value>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -314,6 +314,20 @@ namespace HelixToolkit.UWP
                 }
                 get { return width; }
             }
+
+            private float dpiScale = 1;
+            public float DpiScale
+            {
+                set
+                {
+                    float oldDpiScale = dpiScale;
+                    if (Set(ref dpiScale, value))
+                    {
+                        Resize((int)(ActualWidth / oldDpiScale), (int)(ActualHeight / oldDpiScale));
+                    }
+                }
+                get => dpiScale;
+            }
             /// <summary>
             /// Gets or sets a value indicating whether this instance is busy.
             /// </summary>
@@ -993,12 +1007,12 @@ namespace HelixToolkit.UWP
             /// <param name="height">The height.</param>
             public void Resize(int width, int height)
             {
-                if(MathUtil.NearEqual(ActualWidth, width) && MathUtil.NearEqual(ActualHeight, height))
+                if(MathUtil.NearEqual(ActualWidth, width * DpiScale) && MathUtil.NearEqual(ActualHeight, height * DpiScale))
                 {
                     return;
                 }
-                ActualWidth = width;
-                ActualHeight = height;
+                ActualWidth = width * DpiScale;
+                ActualHeight = height * DpiScale;
                 Log(LogLevel.Information, $"Width = {width}; Height = {height};");
                 if (IsInitialized)
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -802,7 +802,7 @@ namespace HelixToolkit.UWP
                 else
                 {
                     EndD3D();
-                    StartD3D((int)Math.Floor(ActualWidth), (int)Math.Floor(ActualHeight));
+                    StartD3D((int)Math.Floor(ActualWidth / DpiScale), (int)Math.Floor(ActualHeight / DpiScale));
                 }
             }
             /// <summary>
@@ -817,8 +817,8 @@ namespace HelixToolkit.UWP
                     StartRendering();
                     return;
                 }
-                ActualWidth = width;
-                ActualHeight = height;
+                ActualWidth = width * DpiScale;
+                ActualHeight = height * DpiScale;
                 isLoaded = true;
                 if (EffectsManager == null || EffectsManager.Device == null || EffectsManager.Device.IsDisposed)
                 {
@@ -871,7 +871,6 @@ namespace HelixToolkit.UWP
                 EndD3D();
                 EffectsManager?.DisposeAllResources();
                 EffectsManager?.Reinitialize();
-                //StartD3D(ActualWidth, ActualHeight);
             }
 
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -323,7 +323,7 @@ namespace HelixToolkit.UWP
                     float oldDpiScale = dpiScale;
                     if (Set(ref dpiScale, value))
                     {
-                        Resize((int)(ActualWidth / oldDpiScale), (int)(ActualHeight / oldDpiScale));
+                        Resize((int)(ActualWidth / oldDpiScale), (int)(ActualHeight / oldDpiScale), true);
                     }
                 }
                 get => dpiScale;
@@ -1007,7 +1007,12 @@ namespace HelixToolkit.UWP
             /// <param name="height">The height.</param>
             public void Resize(int width, int height)
             {
-                if(MathUtil.NearEqual(ActualWidth, width * DpiScale) && MathUtil.NearEqual(ActualHeight, height * DpiScale))
+                Resize(width, height, false);
+            }
+
+            private void Resize(int width, int height, bool dpiChanged)
+            {
+                if (MathUtil.NearEqual(ActualWidth, width * DpiScale) && MathUtil.NearEqual(ActualHeight, height * DpiScale))
                 {
                     return;
                 }
@@ -1024,12 +1029,18 @@ namespace HelixToolkit.UWP
                         var overlay = Viewport.D2DRenderables.FirstOrDefault();
                         if (overlay != null)
                         {
+                            if (dpiChanged)
+                            {
+                                overlay.Detach();
+                                overlay.Attach(this);
+                            }
                             overlay.InvalidateAll();
                         }
                     }
-                    syncContext.Post((o) => { StartRendering(); }, null);                
+                    syncContext.Post((o) => { StartRendering(); }, null);
                 }
             }
+
             /// <summary>
             /// Sets the default render targets.
             /// </summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
@@ -145,6 +145,11 @@ namespace HelixToolkit.Wpf.SharpDX
         public new float ActualWidth { get => 0; }
         public new float ActualHeight { get => 0; }
 
+        public float DpiScale
+        {
+            set; get;
+        } = 1;
+
         /// <summary>
         /// Gets the current frame renderables for rendering.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/Abstract/Element3DCore.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/Abstract/Element3DCore.cs
@@ -31,7 +31,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// External Wrapper core to be used for different platform
         /// </summary>
 #if NETFX_CORE
-        public abstract class Element3DCore : ItemsControl, IDisposable
+        public abstract class Element3DCore : Control, IDisposable
 #else
         public abstract class Element3DCore : FrameworkContentElement, IDisposable
 #endif

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/InstancingMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/InstancingMeshGeometryModel3D.cs
@@ -34,13 +34,10 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 var d = s as InstancingMeshGeometryModel3D;
 #if NETFX_CORE
-                if(e.OldValue != null)
+                d.AttachChild(null);
+                if(e.NewValue is Element3D elem)
                 {
-                    d.Items.Remove(e.OldValue);
-                }
-                if(e.NewValue != null)
-                {
-                    d.Items.Add(e.NewValue);
+                    d.AttachChild(elem);
                 }
 #else
                 if (e.OldValue != null)
@@ -110,9 +107,9 @@ namespace HelixToolkit.Wpf.SharpDX
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
-            if(OctreeManager != null && !Items.Contains(OctreeManager))
+            if(OctreeManager is Element3D elem)
             {
-                Items.Add(OctreeManager);
+                AttachChild(elem);
             }
         }
 #endif

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/TransformManipulator3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/TransformManipulator3D.cs
@@ -213,8 +213,8 @@ namespace HelixToolkit.Wpf.SharpDX
             translationY.Mouse3DUp += Manipulation_Mouse3DUp;
             translationZ.Mouse3DUp += Manipulation_Mouse3DUp;
 #else
-            translationY.Transform3D = rotationYMatrix;
-            translationZ.Transform3D = rotationZMatrix;
+            translationY.HxTransform3D = rotationYMatrix;
+            translationZ.HxTransform3D = rotationZMatrix;
             translationX.OnMouse3DDown += Translation_Mouse3DDown;
             translationY.OnMouse3DDown += Translation_Mouse3DDown;
             translationZ.OnMouse3DDown += Translation_Mouse3DDown;
@@ -249,8 +249,8 @@ namespace HelixToolkit.Wpf.SharpDX
             rotationY.Mouse3DUp += Manipulation_Mouse3DUp;
             rotationZ.Mouse3DUp += Manipulation_Mouse3DUp;
 #else
-            rotationY.Transform3D = rotationYMatrix;
-            rotationZ.Transform3D = rotationZMatrix;
+            rotationY.HxTransform3D = rotationYMatrix;
+            rotationZ.HxTransform3D = rotationZMatrix;
             rotationX.OnMouse3DDown += Rotation_Mouse3DDown;
             rotationY.OnMouse3DDown += Rotation_Mouse3DDown;
             rotationZ.OnMouse3DDown += Rotation_Mouse3DDown;
@@ -285,8 +285,8 @@ namespace HelixToolkit.Wpf.SharpDX
             scaleY.Mouse3DUp += Manipulation_Mouse3DUp;
             scaleZ.Mouse3DUp += Manipulation_Mouse3DUp;
 #else
-            scaleY.Transform3D = rotationYMatrix;
-            scaleZ.Transform3D = rotationZMatrix;
+            scaleY.HxTransform3D = rotationYMatrix;
+            scaleZ.HxTransform3D = rotationZMatrix;
             scaleX.OnMouse3DDown += Scaling_Mouse3DDown;
             scaleY.OnMouse3DDown += Scaling_Mouse3DDown;
             scaleZ.OnMouse3DDown += Scaling_Mouse3DDown;
@@ -648,7 +648,7 @@ namespace HelixToolkit.Wpf.SharpDX
 #if !NETFX_CORE
             target.Transform = new Media3D.MatrixTransform3D(targetMatrix.ToMatrix3D());
 #else
-            target.Transform3D = targetMatrix;
+            target.HxTransform3D = targetMatrix;
 #endif
         }
 
@@ -659,7 +659,7 @@ namespace HelixToolkit.Wpf.SharpDX
 #if !NETFX_CORE
             ctrlGroup.Transform = new Media3D.MatrixTransform3D(m.ToMatrix3D());
 #else
-            ctrlGroup.Transform3D = m;
+            ctrlGroup.HxTransform3D = m;
 #endif
         }
 

--- a/Source/HelixToolkit.UWP/CommonDX/SwapChainRenderHost.cs
+++ b/Source/HelixToolkit.UWP/CommonDX/SwapChainRenderHost.cs
@@ -35,6 +35,28 @@ namespace HelixToolkit.UWP
 
         private readonly CompositionTargetEx compositionTarget = new CompositionTargetEx();
 
+        private float dpiScale = 1;
+        public float DpiScale
+        {
+            set
+            {
+                dpiScale = value;
+                RenderHost.DpiScale = enableDpiScale ? value : 1;
+            }
+            get => dpiScale;
+        }
+
+        private bool enableDpiScale = true;
+        public bool EnableDpiScale
+        {
+            set
+            {
+                enableDpiScale = value;
+                RenderHost.DpiScale = value ? DpiScale : 1;
+            }
+            get => enableDpiScale;
+        }
+
         public SwapChainRenderHost(bool enableDeferredRendering)
         {   
             if (enableDeferredRendering)
@@ -75,8 +97,10 @@ namespace HelixToolkit.UWP
             // Obtain a reference to the native COM object of the SwapChainPanel.
             using (global::SharpDX.DXGI.ISwapChainPanelNative nativeObject = global::SharpDX.ComObject.As<global::SharpDX.DXGI.ISwapChainPanelNative>(this))
             {
+                var swapChain = (renderHost.RenderBuffer as DX11SwapChainCompositionRenderBufferProxy).SwapChain;
+                swapChain.MatrixTransform = new SharpDX.Mathematics.Interop.RawMatrix3x2(1 / DpiScale, 0, 0, 1 / DpiScale, 0, 0);
                 // Set its swap chain.
-                nativeObject.SwapChain = (renderHost.RenderBuffer as DX11SwapChainCompositionRenderBufferProxy).SwapChain;
+                nativeObject.SwapChain = swapChain;
             }
         }
 

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
@@ -1251,7 +1251,7 @@ namespace HelixToolkit.UWP
             this.rotateFingerCount = -1;
             this.allowCombinedManipulation = false;
 
-            foreach (var mb in this.Viewport.InputBindings.OfType<ManipulationBinding>())
+            foreach (var mb in this.Viewport.ManipulationBindings)
             {
                 this.allowCombinedManipulation = true;
                 if (mb.Command == ViewportCommands.Pan)

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/ManipulationBinding.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/ManipulationBinding.cs
@@ -11,12 +11,67 @@ namespace HelixToolkit.UWP
 {
     using System.Windows.Input;
     using Windows.Foundation.Metadata;
+    using Windows.UI.Xaml;
 
     /// <summary>
     /// Binds a <see cref="ManipulationGesture"/> to an <see cref="ICommand"/> implementation.
     /// </summary>
-    public class ManipulationBinding : InputBinding
+    public class ManipulationBinding : DependencyObject
     {
+        /// <summary>
+        /// Dependency Property for Command property
+        /// </summary>
+        public static readonly DependencyProperty CommandProperty =
+            DependencyProperty.Register("Command", typeof(ViewportCommand), typeof(ManipulationBinding), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Dependency Property for Command Parameter
+        /// </summary>
+        public static readonly DependencyProperty CommandParameterProperty =
+            DependencyProperty.Register("CommandParameter", typeof(object), typeof(ManipulationBinding), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Dependency property for command target
+        /// </summary>
+        public static readonly DependencyProperty CommandTargetProperty =
+            DependencyProperty.Register("CommandTarget", typeof(UIElement), typeof(ManipulationBinding), new PropertyMetadata(null));
+
+        public static readonly DependencyProperty GestureProperty =
+            DependencyProperty.Register("Gesture", typeof(ManipulationGesture), typeof(ManipulationBinding), new PropertyMetadata(null));
+
+
+        /// <summary>
+        /// Gets or sets the command.
+        /// </summary>
+        /// <remarks>
+        /// Makes it possible to assign a string to this property in XAML via <see cref="CreateFromStringAttribute"/>.
+        /// Another way would be the use of <see cref="ViewportCommandExtension"/>, but it 
+        /// requires Min Target Platform Version "Windows 10 Fall Creators Update (introduced v10.0.16299.0)".
+        /// </remarks>
+        public ViewportCommand Command
+        {
+            get => (ViewportCommand)this.GetValue(CommandProperty);
+            set => this.SetValue(CommandProperty, value);
+        }
+
+        /// <summary>
+        /// A parameter for the command.
+        /// </summary>
+        public object CommandParameter
+        {
+            get => this.GetValue(CommandParameterProperty);
+            set => this.SetValue(CommandParameterProperty, value);
+        }
+
+        /// <summary>
+        /// Where the command should be raised.
+        /// </summary>
+        public UIElement CommandTarget
+        {
+            get => (UIElement)this.GetValue(CommandTargetProperty);
+            set => this.SetValue(CommandTargetProperty, value);
+        }
+
         /// <summary>
         /// Gets the finger count.
         /// </summary>
@@ -28,24 +83,17 @@ namespace HelixToolkit.UWP
         /// <remarks>
         /// Makes it possible to assign a string to this property in XAML via <see cref="CreateFromStringAttribute"/>.
         /// </remarks>
-        public new ManipulationGesture Gesture
-        {
-            get => (ManipulationGesture)base.Gesture;
-            set => base.Gesture = value;
-        }
 
-        /// <summary>
-        /// Gets or sets the command.
-        /// </summary>
-        /// <remarks>
-        /// Makes it possible to assign a string to this property in XAML via <see cref="CreateFromStringAttribute"/>.
-        /// Another way would be the use of <see cref="ViewportCommandExtension"/>, but it 
-        /// requires Min Target Platform Version "Windows 10 Fall Creators Update (introduced v10.0.16299.0)".
-        /// </remarks>
-        public new ViewportCommand Command
+        public ManipulationGesture Gesture
         {
-            get => (ViewportCommand)base.Command;
-            set => base.Command = value;
+            get
+            {
+                return (ManipulationGesture)GetValue(GestureProperty);
+            }
+            set
+            {
+                SetValue(GestureProperty, value);
+            }
         }
     }
 }

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/ManipulationCollection.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/ManipulationCollection.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HelixToolkit.UWP
+{
+    using System.Collections.ObjectModel;
+    public sealed class ManipulationBindingCollection : ObservableCollection<ManipulationBinding>
+    {
+    }
+}

--- a/Source/HelixToolkit.UWP/Controls/Viewport3DXProperties.cs
+++ b/Source/HelixToolkit.UWP/Controls/Viewport3DXProperties.cs
@@ -2378,5 +2378,39 @@ namespace HelixToolkit.UWP
                     viewport.renderHostInternal.RenderConfiguration.MinimumUpdateCount = (uint)Math.Max(0, (int)e.NewValue);
                 }
             }));
+
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [enable high dpi rendering].
+        /// Enable this option if you want to render high definition image with using high definition monitor and using dpi scaling in windows.
+        /// This option may impact rendering performance due to higher resolution.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable high dpi rendering]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableHighDpiRendering
+        {
+            get
+            {
+                return (bool)GetValue(EnableHighDpiRenderingProperty);
+            }
+            set
+            {
+                SetValue(EnableHighDpiRenderingProperty, value);
+            }
+        }
+
+        // Using a DependencyProperty as the backing store for EnableHighDpiRendering.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty EnableHighDpiRenderingProperty =
+            DependencyProperty.Register("EnableHighDpiRendering", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e)=> 
+            {
+                var viewport = (d as Viewport3DX);
+                if (viewport.hostPresenter != null && viewport.hostPresenter.Content is SwapChainRenderHost host)
+                {
+                    host.EnableDpiScale = (bool)e.NewValue;
+                }
+            }));
+
+
     }
 }

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Controls\MouseHandlers\InputGesture.cs" />
     <Compile Include="Controls\MouseHandlers\ManipulationAction.cs" />
     <Compile Include="Controls\MouseHandlers\ManipulationBinding.cs" />
+    <Compile Include="Controls\MouseHandlers\ManipulationCollection.cs" />
     <Compile Include="Controls\MouseHandlers\ManipulationGesture.cs" />
     <Compile Include="Controls\MouseHandlers\MouseInputController.cs" />
     <Compile Include="Controls\MouseHandlers\ManipulationEventArgs.cs" />

--- a/Source/HelixToolkit.UWP/Model/Element3D/Abstract/Element3D.cs
+++ b/Source/HelixToolkit.UWP/Model/Element3D/Abstract/Element3D.cs
@@ -5,10 +5,13 @@ Copyright (c) 2018 Helix Toolkit contributors
 using HelixToolkit.UWP.Model;
 using SharpDX;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Markup;
 using Point = Windows.Foundation.Point;
 
 namespace HelixToolkit.UWP
@@ -17,7 +20,7 @@ namespace HelixToolkit.UWP
     /// 
     /// </summary>
     /// <seealso cref="Element3DCore" />
-    [TemplatePart(Name = "PART_ItemsContainer", Type = typeof(ItemsControl))]
+    [TemplatePart(Name = "PART_Container", Type = typeof(ContentPresenter))]
     public abstract class Element3D : Element3DCore
     {
         #region Dependency Properties
@@ -46,8 +49,8 @@ namespace HelixToolkit.UWP
         /// <summary>
         /// 
         /// </summary>
-        public new static readonly DependencyProperty Transform3DProperty =
-            DependencyProperty.Register("Transform3D", typeof(Matrix), typeof(Element3D), new PropertyMetadata(Matrix.Identity,
+        public static readonly DependencyProperty HxTransform3DProperty =
+            DependencyProperty.Register("HxTransform3D", typeof(Matrix), typeof(Element3D), new PropertyMetadata(Matrix.Identity,
                 (d, e) =>
                 {
                     (d as Element3DCore).SceneNode.ModelMatrix = (Matrix)e.NewValue;
@@ -56,7 +59,7 @@ namespace HelixToolkit.UWP
         /// <summary>
         /// 
         /// </summary>
-        public new Matrix Transform3D
+        public Matrix HxTransform3D
         {
             get { return (Matrix)this.GetValue(Transform3DProperty); }
             set { this.SetValue(Transform3DProperty, value); }
@@ -82,9 +85,12 @@ namespace HelixToolkit.UWP
             {
                 (d as Element3D).SceneNode.RenderOrder = (ushort)Math.Max(0, Math.Min(ushort.MaxValue, (int)e.NewValue));
             }));
+
         #endregion
         private static readonly Size oneSize = new Size(1, 1);
 
+        private ContentPresenter presenter;
+        private FrameworkElement child;
         /// <summary>
         /// Initializes a new instance of the <see cref="Element3D"/> class.
         /// </summary>
@@ -101,6 +107,26 @@ namespace HelixToolkit.UWP
                 SceneNode.IsHitTestVisible = (bool)s.GetValue(e);
             });
             OnSceneNodeCreated += Element3D_OnSceneNodeCreated;
+        }
+
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+            presenter = GetTemplateChild("PART_Container") as ContentPresenter;
+            if (presenter == null)
+            {
+                throw new Exception("Template must contain a ContentPresenter named as PART_Container.");
+            }
+            presenter.Content = child;
+        }
+
+        protected void AttachChild(FrameworkElement child)
+        {
+            this.child = child;
+            if (presenter != null)
+            {
+                presenter.Content = child;
+            }
         }
 
         private void Element3D_OnSceneNodeCreated(object sender, SceneNodeCreatedEventArgs e)

--- a/Source/HelixToolkit.UWP/Model/Element3D/Abstract/GroupElement3D.cs
+++ b/Source/HelixToolkit.UWP/Model/Element3D/Abstract/GroupElement3D.cs
@@ -11,7 +11,8 @@ using Windows.UI.Xaml.Markup;
 namespace HelixToolkit.UWP
 {
     using Model.Scene;
-    
+    using Windows.UI.Xaml.Controls;
+
     /// <summary>
     /// 
     /// </summary>
@@ -22,7 +23,7 @@ namespace HelixToolkit.UWP
         /// <summary>
         /// ItemsSource for binding to collection. Please use ObservableElement3DCollection for observable, otherwise may cause memory leak.
         /// </summary>
-        public new static readonly DependencyProperty ItemsSourceProperty =
+        public static readonly DependencyProperty ItemsSourceProperty =
             DependencyProperty.Register("ItemsSource", typeof(IList<Element3D>), typeof(GroupElement3D),
                 new PropertyMetadata(null,
                     (d, e) => {
@@ -37,14 +38,14 @@ namespace HelixToolkit.UWP
             typeof(GroupElement3D), new PropertyMetadata(null, (s, e) =>
             {
                 var d = s as GroupElement3D;
-                if (e.OldValue != null)
+                if (e.OldValue is Element3D elem_old)
                 {
-                    d.Items.Remove(e.OldValue);
+                    d.Items.Remove(elem_old);
                 }
 
-                if (e.NewValue != null)
+                if (e.NewValue is Element3D elem)
                 {
-                    d.Items.Add(e.NewValue);
+                    d.Items.Add(elem);
                 }
                 (d.SceneNode as GroupNode).OctreeManager = e.NewValue == null ? null : (e.NewValue as IOctreeManagerWrapper).Manager;
             }));
@@ -52,7 +53,7 @@ namespace HelixToolkit.UWP
         /// <summary>
         /// ItemsSource for binding to collection. Please use ObservableElement3DCollection for observable, otherwise may cause memory leak.
         /// </summary>
-        public new IList<Element3D> ItemsSource
+        public IList<Element3D> ItemsSource
         {
             get { return (IList<Element3D>)this.GetValue(ItemsSourceProperty); }
             set { this.SetValue(ItemsSourceProperty, value); }
@@ -86,17 +87,21 @@ namespace HelixToolkit.UWP
             get;
         } = new ObservableElement3DCollection();
 
+        private readonly ItemsControl itemsControl = new ItemsControl();
+        public ItemCollection Items => itemsControl.Items;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GroupElement3D"/> class.
         /// </summary>
         public GroupElement3D()
         {
-            Children.CollectionChanged += Items_CollectionChanged;           
+            Children.CollectionChanged += Items_CollectionChanged;
         }
 
         protected override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
+            AttachChild(itemsControl);
             Items.Clear();
             foreach (var item in Children)
             {
@@ -105,9 +110,9 @@ namespace HelixToolkit.UWP
                     Items.Add(item);
                 }
             }
-            if(OctreeManager != null)
+            if(OctreeManager is Element3D elem)
             {
-                Items.Add(OctreeManager);
+                Items.Add(elem);
             }
         }
 
@@ -133,14 +138,14 @@ namespace HelixToolkit.UWP
                         {
                             if (node.RemoveChildNode(item.SceneNode))
                             {
-                                Items.Remove(item);
+                                Items?.Remove(item);
                             }
                         }
                     }
                     break;
                 case NotifyCollectionChangedAction.Reset:
-                    Items.Clear();
-                    node.Clear();
+                    Items?.Clear();
+                    node?.Clear();
                     break;
             }
 
@@ -153,13 +158,13 @@ namespace HelixToolkit.UWP
                         {
                             if (node.AddChildNode(item.SceneNode))
                             {
-                                Items.Add(item);
+                                Items?.Add(item);
                             }
                         }
                     }
-                    if (OctreeManager != null)
+                    if (OctreeManager is Element3D elem)
                     {
-                        Items.Add(OctreeManager);
+                        Items?.Add(elem);
                     }
                     break;
                 case NotifyCollectionChangedAction.Add:
@@ -168,7 +173,7 @@ namespace HelixToolkit.UWP
                     {
                         if (node.AddChildNode(item.SceneNode))
                         {
-                            Items.Add(item);
+                            Items?.Add(item);
                         }
                     }
                     break;

--- a/Source/HelixToolkit.UWP/Model/Element3D/Element3DPresenter.cs
+++ b/Source/HelixToolkit.UWP/Model/Element3D/Element3DPresenter.cs
@@ -4,6 +4,7 @@ using Windows.UI.Xaml.Markup;
 namespace HelixToolkit.UWP
 {
     using Model.Scene;
+    using Windows.UI.Xaml.Controls;
 
     /// <summary>
     /// 
@@ -12,39 +13,45 @@ namespace HelixToolkit.UWP
     [ContentProperty(Name = "Content")]
     public class Element3DPresenter : Element3D
     {
-        /// <summary>
-        /// Gets or sets the content.
-        /// </summary>
-        /// <value>
-        /// The content.
-        /// </value>
         public Element3D Content
         {
-            get { return (Element3D)GetValue(ContentProperty); }
-            set { SetValue(ContentProperty, value); }
+            get
+            {
+                return (Element3D)GetValue(ContentProperty);
+            }
+            set
+            {
+                SetValue(ContentProperty, value);
+            }
         }
 
-        /// <summary>
-        /// The content property
-        /// </summary>
         public static readonly DependencyProperty ContentProperty =
             DependencyProperty.Register("Content", typeof(Element3D), typeof(Element3DPresenter), new PropertyMetadata(null, (d, e) =>
             {
-                var model = d as Element3DPresenter;
-                if (e.OldValue != null)
-                {
-                    model.Items.Remove(e.OldValue);
-                    if (e.OldValue is Element3D ele)
-                    { (model.SceneNode as GroupNode).RemoveChildNode(ele.SceneNode); }
-                }
-                if (e.NewValue != null)
-                {
-                    model.Items.Add(e.NewValue);
-                    if (e.NewValue is Element3D ele)
-                    { (model.SceneNode as GroupNode).AddChildNode(ele.SceneNode); }
-                }
+                (d as Element3DPresenter).Element3DPresenter_ContentChanged(d, e.NewValue as Element3D);
             }));
 
+
+        private Element3D currentContent;
+
+        public Element3DPresenter()
+        {
+        }
+
+        private void Element3DPresenter_ContentChanged(object sender, Element3D content)
+        {
+            if (currentContent != null)
+            {
+                (SceneNode as GroupNode).RemoveChildNode(currentContent.SceneNode);
+                AttachChild(null);
+            }
+            if (Content is Element3D elem)
+            {
+                currentContent = elem;
+                (SceneNode as GroupNode).AddChildNode(elem.SceneNode);
+                AttachChild(elem);
+            }
+        }
 
         protected override SceneNode OnCreateSceneNode()
         {

--- a/Source/HelixToolkit.UWP/Model/Element3D/GroupModel3D.cs
+++ b/Source/HelixToolkit.UWP/Model/Element3D/GroupModel3D.cs
@@ -16,7 +16,6 @@ namespace HelixToolkit.UWP
     {
         public GroupModel3D()
         {
-            this.DefaultStyleKey = typeof(GroupModel3D);
         }
     }
 }

--- a/Source/HelixToolkit.UWP/Themes/Generic.xaml
+++ b/Source/HelixToolkit.UWP/Themes/Generic.xaml
@@ -47,7 +47,7 @@
                                 SizeScale="{TemplateBinding CoordinateSystemSize}" />
                         </controls1:HelixItemsControl>
                         <controls1:HelixItemsControl x:Name="PART_ItemsContainer" IsHitTestVisible="False" />
-                        <ContentPresenter x:Name="PART_HostPresenter" IsHitTestVisible="False" />
+                        <ContentPresenter x:Name="PART_HostPresenter" IsHitTestVisible="False" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"/>
                         <TextBox
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center"
@@ -62,16 +62,16 @@
         </Setter>
     </Style>
 
-    <!--<Style TargetType="controls:Element3D">
+    <Style TargetType="controls:Element3D">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:Element3D">
-                    <controls1:HelixItemsControl x:Name="PART_ItemsContainer" IsHitTestVisible="False" />
+                    <ContentPresenter x:Name="PART_Container" IsHitTestVisible="False" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
-    <Style TargetType="controls:GroupModel3D">
+    <!--<Style TargetType="controls:GroupModel3D">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="controls:GroupModel3D">
@@ -80,6 +80,7 @@
             </Setter.Value>
         </Setter>
     </Style>-->
+
     <local:PerspectiveCamera
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:local="using:HelixToolkit.UWP"

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFCanvas.cs
@@ -78,6 +78,33 @@ namespace HelixToolkit.Wpf.SharpDX
         public IRenderHost RenderHost { private set; get; }
         private Window parentWindow;
         private readonly bool belongsToParentWindow;
+        private double dpiScale = 1;
+        public double DpiScale
+        {
+            set
+            {
+                dpiScale = value;
+                if (RenderHost != null)
+                {
+                    RenderHost.DpiScale = (float)value;
+                }
+            }
+            get => dpiScale;
+        }
+
+        private bool enableDpiScale = true;
+        public bool EnableDpiScale
+        {
+            set
+            {
+                enableDpiScale = value;
+                if (RenderHost != null)
+                {
+                    RenderHost.DpiScale = value ? (float)DpiScale : 1;
+                }
+            }
+            get => enableDpiScale;
+        }
 
         /// <summary>
         /// Fired whenever an exception occurred on this object.
@@ -98,6 +125,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 RenderHost = new DX11ImageSourceRenderHost();
             }
+            RenderHost.DpiScale = EnableDpiScale ? (float)DpiScale : 1;
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
             RenderHost.StartRenderLoop += RenderHost_StartRenderLoop;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFSurfaceSwapChain.cs
@@ -58,6 +58,19 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private readonly CompositionTargetEx compositionTarget = new CompositionTargetEx();
 
+        private bool enableDpiScale = true;
+        public bool EnableDpiScale
+        {
+            set
+            {
+                enableDpiScale = value;
+                if (renderHost != null)
+                {
+                    renderHost.DpiScale = value ? (float)DpiScale : 1;
+                }
+            }
+            get => enableDpiScale;
+        }
         /// <summary>
         /// 
         /// </summary>
@@ -65,6 +78,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+            DpiScaleChanged += DPFSurfaceSwapChain_DpiScaleChanged;
             surfaceD3D = new RenderControl(this);
             Child = surfaceD3D;
             if (deferredRendering)
@@ -76,11 +90,20 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 renderHost = new SwapChainRenderHost(surfaceD3D.Handle);
             }
+            RenderHost.DpiScale = EnableDpiScale ? (float)DpiScale : 1;
             RenderHost.StartRenderLoop += RenderHost_StartRenderLoop;
             RenderHost.StopRenderLoop += RenderHost_StopRenderLoop;
             RenderHost.ExceptionOccurred += (s, e) => { HandleExceptionOccured(e.Exception); };
 
             belongsToParentWindow = attachedToWindow;
+        }
+
+        private void DPFSurfaceSwapChain_DpiScaleChanged(object sender, double e)
+        {
+            if (RenderHost != null)
+            {
+                RenderHost.DpiScale = EnableDpiScale ? (float)e : 1;
+            }
         }
 
         public DPFSurfaceSwapChain(Func<IntPtr, IRenderHost> createRenderHost, bool attachedToWindow = true)
@@ -89,6 +112,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Unloaded += OnUnloaded;
             surfaceD3D = new RenderControl();
             Child = surfaceD3D;
+            RenderHost.DpiScale = EnableDpiScale ? (float)DpiScale : 1;
             renderHost = createRenderHost(surfaceD3D.Handle);
             RenderHost.StartRenderLoop += RenderHost_StartRenderLoop;
             RenderHost.StopRenderLoop += RenderHost_StopRenderLoop;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/IRenderCanvas.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/IRenderCanvas.cs
@@ -15,6 +15,26 @@ namespace HelixToolkit.Wpf.SharpDX
         public interface IRenderCanvas
         {
             /// <summary>
+            /// Gets or sets the dpi scale.
+            /// </summary>
+            /// <value>
+            /// The dpi scale.
+            /// </value>
+            double DpiScale
+            {
+                set; get;
+            }
+            /// <summary>
+            /// Gets or sets a value indicating whether [enable dpi scale].
+            /// </summary>
+            /// <value>
+            ///   <c>true</c> if [enable dpi scale]; otherwise, <c>false</c>.
+            /// </value>
+            bool EnableDpiScale
+            {
+                set; get;
+            }
+            /// <summary>
             /// Gets the render host.
             /// </summary>
             /// <value>

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
@@ -1219,6 +1219,32 @@ namespace HelixToolkit.Wpf.SharpDX
             DependencyProperty.Register("BelongsToParentWindow", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true));
 
         /// <summary>
+        /// The dpi scale
+        /// </summary>
+        public static readonly DependencyProperty DpiScaleProperty =
+            DependencyProperty.Register("DpiScale", typeof(double), typeof(Viewport3DX), new PropertyMetadata(1.0, (d, e) =>
+            {
+                var viewport = d as Viewport3DX;
+                if (viewport.hostPresenter != null && viewport.hostPresenter.Content is IRenderCanvas canvas)
+                {
+                    canvas.DpiScale = (double)e.NewValue;
+                }
+            }));
+
+        /// <summary>
+        /// The enable high dpi rendering property
+        /// </summary>
+        public static readonly DependencyProperty EnableHighDpiRenderingProperty =
+            DependencyProperty.Register("EnableHighDpiRendering", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) =>
+            {
+                var viewport = d as Viewport3DX;
+                if (viewport.hostPresenter != null && viewport.hostPresenter.Content is IRenderCanvas canvas)
+                {
+                    canvas.EnableDpiScale = (bool)e.NewValue;
+                }
+            }));
+
+        /// <summary>
         /// Background Color
         /// </summary>
         public Color BackgroundColor
@@ -3095,6 +3121,44 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             get { return (bool)GetValue(BelongsToParentWindowProperty); }
             set { SetValue(BelongsToParentWindowProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the dpi scale. For example, if dpi scale is set to 200% in windows, this value must be set to 2.
+        /// </summary>
+        /// <value>
+        /// The dpi scale.
+        /// </value>
+        public double DpiScale
+        {
+            set
+            {
+                SetValue(DpiScaleProperty, value);
+            }
+            get
+            {
+                return (double)GetValue(DpiScaleProperty);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [enable high dpi rendering].
+        /// Enable this option if you want to render high definition image with using high definition monitor and using dpi scaling in windows.
+        /// This option may impact rendering performance due to high resolution.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable high dpi rendering]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableHighDpiRendering
+        {
+            get
+            {
+                return (bool)GetValue(EnableHighDpiRenderingProperty);
+            }
+            set
+            {
+                SetValue(EnableHighDpiRenderingProperty, value);
+            }
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
@@ -3144,7 +3144,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <summary>
         /// Gets or sets a value indicating whether [enable high dpi rendering].
         /// Enable this option if you want to render high definition image with using high definition monitor and using dpi scaling in windows.
-        /// This option may impact rendering performance due to high resolution.
+        /// This option may impact rendering performance due to higher resolution.
         /// </summary>
         /// <value>
         ///   <c>true</c> if [enable high dpi rendering]; otherwise, <c>false</c>.

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
@@ -628,24 +628,20 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 renderCanvas.ExceptionOccurred -= this.HandleRenderException;
             }
-
+            PresentationSource source = PresentationSource.FromVisual(this);
+            if (source != null)
+            {
+                DpiScale = Math.Max(DpiScale, Math.Max(source.CompositionTarget.TransformToDevice.M11, source.CompositionTarget.TransformToDevice.M22));
+            }
             if (EnableSwapChainRendering)
             {
-                double dpiXScale = 1;
-                double dpiYScale = 1;
-                PresentationSource source = PresentationSource.FromVisual(this);
-                if (source != null)
-                {
-                    dpiXScale = 1.0 / source.CompositionTarget.TransformToDevice.M11;
-                    dpiYScale = 1.0 / source.CompositionTarget.TransformToDevice.M22;
-                }
-                hostPresenter.Content = new DPFSurfaceSwapChain(EnableDeferredRendering, BelongsToParentWindow) { DPIXScale = dpiXScale, DPIYScale = dpiYScale };
+                hostPresenter.Content = new DPFSurfaceSwapChain(EnableDeferredRendering, BelongsToParentWindow) { DpiScale = DpiScale };
             }
             else
             {
-                hostPresenter.Content = new DPFCanvas(EnableDeferredRendering, BelongsToParentWindow);
+                hostPresenter.Content = new DPFCanvas(EnableDeferredRendering, BelongsToParentWindow) { DpiScale = DpiScale };
             }
-
+            
             if (this.renderHostInternal != null)
             {
                 this.renderHostInternal.Rendered -= this.RaiseRenderHostRendered;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
@@ -649,6 +649,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
 
             renderCanvas = (IRenderCanvas)this.hostPresenter.Content;
+            renderCanvas.EnableDpiScale = EnableHighDpiRendering;
             this.renderHostInternal = renderCanvas.RenderHost;
             renderCanvas.ExceptionOccurred += this.HandleRenderException;
             if (this.renderHostInternal != null)

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/WinformHostExtend.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/WinformHostExtend.cs
@@ -31,10 +31,23 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             protected UIElement ParentControl { set; get; }
 
-            public double DPIXScale { set; get; } = 1;
+            private double dpiScale = 1;
+            public double DpiScale
+            {
+                set
+                {
+                    if (dpiScale == value)
+                    {
+                        return;
+                    }
+                    dpiScale = value;
+                    DpiScaleChanged?.Invoke(this, value);
+                }
+                get => dpiScale;
+            }
 
-            public double DPIYScale { set; get; } = 1;
-
+            protected event EventHandler<double> DpiScaleChanged;
+            
             public WinformHostExtend()
             {
                 ChildChanged += OnChildChanged;
@@ -61,7 +74,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
             private void OnMouseMove(object sender, System.Windows.Forms.MouseEventArgs e)
             {
-                RaiseEvent(new FormMouseMoveEventArgs(FormMouseMoveEvent, new Point(e.Location.X * DPIXScale, e.Location.Y * DPIYScale), e.X, e.Y, e.Delta) { Source = this });
+                RaiseEvent(new FormMouseMoveEventArgs(FormMouseMoveEvent, new Point(e.Location.X / DpiScale, e.Location.Y / DpiScale), e.X, e.Y, e.Delta) { Source = this });
             }
 
             private void OnMouseWheel(object sender, System.Windows.Forms.MouseEventArgs e)

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Controls/CanvasMock.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Controls/CanvasMock.cs
@@ -19,6 +19,14 @@ namespace HelixToolkit.Wpf.SharpDX.Tests.Controls
     class CanvasMock : IRenderCanvas
     {
         public IRenderHost RenderHost { private set; get; } = new DefaultRenderHost();
+        public double DpiScale
+        {
+            set; get;
+        }
+        public bool EnableDpiScale
+        {
+            set; get;
+        }
 
         public event EventHandler<RelayExceptionEventArgs> ExceptionOccurred;
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Properties/Settings.Designer.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace HelixToolkit.Wpf.SharpDX.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
1. Support High DPI rendering under DPI Scaling. Default is set to enabled. To disable this feature, set `Viewport3DX.EnableHighDpiRendering = false`.  #1404 

2. Fix UWP runtime error. #1365. In order to fix runtime error, `Element3D.Transform3D` has to be changed to `Element3D.HxTransform3D` to avoid property conflicts.