### PR TITLE
Issue/#1340 points and lines invisible on mirrored transformation

### DIFF
--- a/Source/Examples/WPF/ExampleBrowser/Examples/PointsAndLines/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/PointsAndLines/MainWindow.xaml
@@ -16,6 +16,9 @@
                 <MenuItem Header="3DTools.ScreenSpaceLines3D" IsCheckable="True" IsChecked="{Binding ShowScreenSpaceLines3D}"/>
                 <MenuItem Header="Petzold.Media3D.Wirelines" IsCheckable="True" IsChecked="{Binding ShowWireLines}"/>
             </MenuItem>
+            <MenuItem Header="Transformations">
+                <MenuItem Header="mirror at YZ Plane (issue #1340)" IsCheckable="True" IsChecked="{Binding IsMirrored}" />
+            </MenuItem>
         </Menu>
         <DockPanel DockPanel.Dock="Bottom">
             <TextBlock DockPanel.Dock="Left" Text="{Binding NumberOfPoints, StringFormat='N = {0}'}" Width="80" Margin="2" TextAlignment="Center"/>

--- a/Source/Examples/WPF/ExampleBrowser/Examples/PointsAndLines/MainWindow.xaml.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/PointsAndLines/MainWindow.xaml.cs
@@ -65,6 +65,8 @@ namespace PointsAndLinesDemo
 
         public bool ShowWireLines { get; set; }
 
+        public bool IsMirrored { get; set; }
+
         public Point3DCollection Points
         {
             get
@@ -179,21 +181,25 @@ namespace PointsAndLinesDemo
             if (this.linesVisual != null)
             {
                 this.linesVisual.Points = this.Points;
+                this.linesVisual.Transform = IsMirrored ? new ScaleTransform3D(-1, 1, 1) : new ScaleTransform3D(1, 1, 1);
             }
 
             if (this.pointsVisual != null)
             {
                 this.pointsVisual.Points = this.Points;
+                this.pointsVisual.Transform = IsMirrored ? new ScaleTransform3D(-1, 1, 1) : new ScaleTransform3D(1, 1, 1);
             }
 
             if (this.screenSpaceLines != null)
             {
                 this.screenSpaceLines.Points = this.Points;
+                this.screenSpaceLines.Transform = IsMirrored ? new ScaleTransform3D(-1, 1, 1) : new ScaleTransform3D(1, 1, 1);
             }
 
             if (this.wireLines != null)
             {
                 this.wireLines.Lines = this.Points;
+                this.wireLines.Transform = IsMirrored ? new ScaleTransform3D(-1, 1, 1) : new ScaleTransform3D(1, 1, 1);
             }
         }
 

--- a/Source/HelixToolkit.Wpf.Shared/Visual3Ds/ScreenSpaceVisuals/ScreenSpaceVisual3D.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Visual3Ds/ScreenSpaceVisuals/ScreenSpaceVisual3D.cs
@@ -293,6 +293,7 @@ namespace HelixToolkit.Wpf
             mg.Children.Add(new EmissiveMaterial(new SolidColorBrush(this.Color)));
             mg.Freeze();
             this.Model.Material = mg;
+            this.Model.BackMaterial = mg;
         }
 
         /// <summary>


### PR DESCRIPTION
BugFix for issue #1340 - points and lines become invisible on mirrored transformation

Due to the mirror transformation the Triangle Indices calculation is reversed. So we look on the back side of the triangles. 
Unfortunately the BackMaterial was not set. So the Visuals become invisible. The fix set the Material and the BackMaterial to the same value.

I have added an option into the WPF "Points and Lines" example. There you can switch on/off the mirror scaling.