### PR TITLE
Small bugfix in WPF Example Browser - Creating Screenshot failure (F12 key) solved

### DIFF
--- a/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml.cs
+++ b/Source/Examples/WPF/ExampleBrowser/MainWindow.xaml.cs
@@ -74,7 +74,7 @@ namespace ExampleBrowser
                 {
                     if (args.Key == Key.F12)
                     {
-                        CreateThumbnail(window, 120, Path.Combine(@"..\..\..\Images\", example.ThumbnailFileName));
+                        CreateThumbnail(window, 120, Path.Combine(@"..\..\Images\", example.ThumbnailFileName));
                         MessageBox.Show(window, "Demo image updated. Now add `" + example.ThumbnailFileName + "` as a resource in the Images folder in the ExampleBrowser project.");
                         e.Handled = true;
                     }


### PR DESCRIPTION
The Screenshot function in the WPF Example Browser had failed with an "General Exception on GDI+".
I found that the relative path to the 'Images' folder was wrong.  I have removed one '..\' and now the snapshoot function is working again.