### PR TITLE
Proposal: Make projects in new format (vs2017) also use the global AssemblyInfo.cs

### DIFF
--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.csproj
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.csproj
@@ -2,7 +2,14 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="..\AssemblyInfo.cs">
+            <Link>Properties\AssemblyInfo.cs</Link>
+        </Compile>
+    </ItemGroup>
 
     <ItemGroup>
         <HLSLShader Include="CS\csParticleInsert.hlsl">

--- a/Source/HelixToolkit.SharpDX.Core.Assimp/HelixToolkit.SharpDX.Core.Assimp.csproj
+++ b/Source/HelixToolkit.SharpDX.Core.Assimp/HelixToolkit.SharpDX.Core.Assimp.csproj
@@ -16,6 +16,7 @@
     <PackageTags>SharpDX; DirectX; 3D;</PackageTags>
     <DelaySign>false</DelaySign>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)|$(Configuration)|$(Platform)'=='netstandard1.3|Release|AnyCPU'">
@@ -69,6 +70,9 @@
   </ItemGroup>
     <ItemGroup>
         <None Include="..\HelixToolkit.snk" />
+        <Compile Include="..\AssemblyInfo.cs">
+            <Link>Properties\AssemblyInfo.cs</Link>
+        </Compile>
     </ItemGroup>
   <Import Project="..\HelixToolkit.SharpDX.Assimp.Shared\HelixToolkit.SharpDX.Assimp.Shared.projitems" Label="Shared" />
 

--- a/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
+++ b/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
         <None Include="..\HelixToolkit.snk" />
+        <Compile Include="..\AssemblyInfo.cs">
+            <Link>Properties\AssemblyInfo.cs</Link>
+        </Compile>
     </ItemGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
@@ -19,6 +22,7 @@
     <RootNamespace>HelixToolkit.SharpDX.Core</RootNamespace>
     <DelaySign>false</DelaySign>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)|$(Configuration)|$(Platform)'=='netstandard1.3|Debug|AnyCPU'">

--- a/Source/HelixToolkit/HelixToolkit.csproj
+++ b/Source/HelixToolkit/HelixToolkit.csproj
@@ -13,6 +13,7 @@
         <PackageTags></PackageTags>
         <Authors>HelixToolkit Contributors</Authors>
         <Company>HelixToolkit</Company>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
       <DocumentationFile>bin\Release\netstandard1.1\HelixToolkit.xml</DocumentationFile>
@@ -22,5 +23,10 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+      <Compile Include="..\AssemblyInfo.cs">
+          <Link>Properties\AssemblyInfo.cs</Link>
+      </Compile>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
I propose to make projects in new format (vs2017) also use the global AssemblyInfo.cs to pull file version information from a single point. I know, AppVeyor pulls the version from git and puts them them to the different places...
```
gitversion /l console /output buildserver /updateAssemblyInfo
...
msbuild Source/HelixToolkit.AppVeyor.sln "/property:Platform=Any CPU" "/property:Version=%GitVersion_NuGetVersion%" /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:SourceLinkCreate=true
...
nuget pack Source\HelixToolkit.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
```
... but it would make my life easier, since I'm using HelixToolkit in source code (svn repo).
