### PR TITLE
ZoomExtents: confusion between horizontal and vertical fov

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/ViewportExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/ViewportExtensions.cs
@@ -555,7 +555,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 double distv = radius / Math.Tan(0.5 * pcam.FieldOfView * Math.PI / 180);
                 double hfov = pcam.FieldOfView / viewport.ActualHeight * viewport.ActualWidth;
-                double disth = radius / Math.Tan(0.5 * vfov * Math.PI / 180);
+                double disth = radius / Math.Tan(0.5 * hfov * Math.PI / 180);
 
                 double dist = Math.Max(distv, disth);
                 var dir = pcam.LookDirection;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/ViewportExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/ViewportExtensions.cs
@@ -553,11 +553,11 @@ namespace HelixToolkit.Wpf.SharpDX
             var camera = viewport.Camera;
             if (camera is PerspectiveCamera pcam)
             {
-                double disth = radius / Math.Tan(0.5 * pcam.FieldOfView * Math.PI / 180);
-                double vfov = pcam.FieldOfView / viewport.ActualWidth * viewport.ActualHeight;
-                double distv = radius / Math.Tan(0.5 * vfov * Math.PI / 180);
+                double distv = radius / Math.Tan(0.5 * pcam.FieldOfView * Math.PI / 180);
+                double hfov = pcam.FieldOfView / viewport.ActualHeight * viewport.ActualWidth;
+                double disth = radius / Math.Tan(0.5 * vfov * Math.PI / 180);
 
-                double dist = Math.Max(disth, distv);
+                double dist = Math.Max(distv, disth);
                 var dir = pcam.LookDirection;
                 dir.Normalize();
                 pcam.LookAt(center, dir * dist, animationTime);


### PR DESCRIPTION
`PerspectiveCamera.FieldOfView` is the vertical field of view (y direction). To calculate the horizontal one, we need to do:

    double hfov = pcam.FieldOfView / viewport.ActualHeight * viewport.ActualWidth

If we have a view in paysage orientation (800 x 600 for example), hfov must be greater than vfov. Let says we have a 45° vertical field of view (I'm using degrees instead of radians to make it more clear):

    hfov = 45 / 600 x 800
    hfov = 0.075 x 800
    hfov = 60

Width and height must be reversed and the variables need to be renamed.