### PR TITLE
Fix build - Update NuGet version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ dotnet_csproj:
   informational_version: '{version}'
   
 before_build:
-  - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+  - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/v5.8.0/nuget.exe
   - nuget restore .\Source\HelixToolkit.AppVeyor.sln
   - gitversion /l console /output buildserver /updateAssemblyInfo
   


### PR DESCRIPTION
- Update NuGet version from recommended latest v5.7.0 to v5.8.0
- Support .Net SDK 5

Without updating NuGet, there are errors `NETSDK1005`.
See https://ci.appveyor.com/project/JeremyAnsel/helix-toolkit/builds/36317547
