### PR TITLE
Do not create artifacts on pull request

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ after_build:
   - nuget pack Source\HelixToolkit.SharpDX.Core.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.SharpDX.Core.Wpf.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
   - nuget pack Source\HelixToolkit.SharpDX.Assimp.nuspec -version "%GitVersion_NuGetVersion%" -Symbols -SymbolPackageFormat snupkg
-  - if "%APPVEYOR_REPO_NAME%" == "helix-toolkit/helix-toolkit" Source\build-dist-examples.cmd
+  - if "%APPVEYOR_REPO_NAME%" == "helix-toolkit/helix-toolkit" if not defined APPVEYOR_PULL_REQUEST_NUMBER Source\build-dist-examples.cmd
 
 artifacts:
   - path: '*.nupkg'


### PR DESCRIPTION
The build sometimes ends with the error `Maximum allowed artifact storage size of 50000 Mb will be exceeded.`.
By disabling the creation of the artifacts on pull request, the error will appears less often.
Getting the artifacts generated by a pull request build is generally not needed.