### PR TITLE
Fix data binding fails on button2D  #1385

### DIFF
--- a/Source/Examples/WPF.SharpDX/D2DScreenMenuExample/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/D2DScreenMenuExample/MainWindow.xaml
@@ -16,7 +16,8 @@
         <hx:Viewport3DX Name="view1"
             Camera="{Binding Camera}"
             EffectsManager="{Binding EffectsManager}"
-            EnableSwapChainRendering="False">
+            EnableSwapChainRendering="True"
+            EnableDesignModeRendering="True">
             <hx:DirectionalLight3D Direction="{Binding VM3D.Light1Direction}" Color="{Binding VM3D.Light1Color}" />
             <hx:DirectionalLight3D Direction="{Binding VM3D.Light2Direction}" Color="{Binding VM3D.Light2Color}" />
             <hx:DirectionalLight3D Direction="{Binding VM3D.Light3Direction}" Color="{Binding VM3D.Light3Color}" />
@@ -56,7 +57,7 @@
                             VerticalAlignment="Top"
                             Orientation="Vertical">
                             <hx2D:StackPanel2D VerticalAlignment="Center" Orientation="Horizontal">
-                                <hx2D:Button2D Margin="10" VerticalAlignment="Center" Width="60" Height="30">Button 3</hx2D:Button2D>
+                                <hx2D:Button2D Margin="10" VerticalAlignment="Center" Width="60" Height="30" Content2D="{Binding VM2D.Text}"></hx2D:Button2D>
                                 <hx2D:Button2D Margin="10" VerticalAlignment="Center" Width="60" Height="30">Button 4</hx2D:Button2D>
                             </hx2D:StackPanel2D>                        
                             <hx2D:Button2D Margin="10" HorizontalAlignment="Center">Button4</hx2D:Button2D>

--- a/Source/Examples/WPF.SharpDX/D2DScreenMenuExample/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/D2DScreenMenuExample/MainWindow.xaml
@@ -13,11 +13,21 @@
     Background="Black"
     mc:Ignorable="d">
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="*"></RowDefinition>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Background="AntiqueWhite">
+            <CheckBox IsChecked="{Binding ElementName=view1, Path=EnableDpiScale}" HorizontalAlignment="Left" VerticalAlignment="Center">High Dpi</CheckBox>
+            <Label Margin="25,0,0,0">Test Binding:</Label>
+            <TextBox x:Name="tb" Width="200" VerticalContentAlignment="Center">Btn 3</TextBox>
+        </StackPanel>
         <hx:Viewport3DX Name="view1"
-            Camera="{Binding Camera}"
-            EffectsManager="{Binding EffectsManager}"
-            EnableSwapChainRendering="True"
-            EnableDesignModeRendering="True">
+                        Grid.Row="1"
+                        Camera="{Binding Camera}"
+                        EffectsManager="{Binding EffectsManager}"
+                        EnableSwapChainRendering="True"
+                        EnableDesignModeRendering="False">
             <hx:DirectionalLight3D Direction="{Binding VM3D.Light1Direction}" Color="{Binding VM3D.Light1Color}" />
             <hx:DirectionalLight3D Direction="{Binding VM3D.Light2Direction}" Color="{Binding VM3D.Light2Color}" />
             <hx:DirectionalLight3D Direction="{Binding VM3D.Light3Direction}" Color="{Binding VM3D.Light3Color}" />
@@ -57,7 +67,8 @@
                             VerticalAlignment="Top"
                             Orientation="Vertical">
                             <hx2D:StackPanel2D VerticalAlignment="Center" Orientation="Horizontal">
-                                <hx2D:Button2D Margin="10" VerticalAlignment="Center" Width="60" Height="30" Content2D="{Binding VM2D.Text}"></hx2D:Button2D>
+                                <hx2D:Button2D Margin="10" VerticalAlignment="Center" Width="60" Height="30" 
+                                               Content2D="{Binding ElementName=tb, Path=Text}"></hx2D:Button2D>
                                 <hx2D:Button2D Margin="10" VerticalAlignment="Center" Width="60" Height="30">Button 4</hx2D:Button2D>
                             </hx2D:StackPanel2D>                        
                             <hx2D:Button2D Margin="10" HorizontalAlignment="Center">Button4</hx2D:Button2D>
@@ -85,6 +96,5 @@
                 </hx2D:Panel2D>
             </hx:Viewport3DX.Content2D>
         </hx:Viewport3DX>
-        <CheckBox IsChecked="{Binding ElementName=view1, Path=EnableDpiScale}" HorizontalAlignment="Left" VerticalAlignment="Top">High Dpi</CheckBox>
     </Grid>
 </Window>

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements2D/Abstract/ContentElement2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements2D/Abstract/ContentElement2D.cs
@@ -44,10 +44,11 @@ namespace HelixToolkit.Wpf.SharpDX
                     {
                         return e;
                     }
-                    else
+                    if (e != null)
                     {
                         return new TextModel2D() { Text = e.ToString() };
                     }
+                    return null;
                 }));
 
             [Bindable(true)]

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements2D/Abstract/ContentElement2D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements2D/Abstract/ContentElement2D.cs
@@ -21,35 +21,31 @@ namespace HelixToolkit.Wpf.SharpDX
         [ContentProperty("Content2D")]
         public abstract class ContentElement2D : Element2D
         {
-            public static readonly DependencyProperty Content2DProperty = DependencyProperty.Register("Content2D", typeof(object), typeof(ContentElement2D), 
-                new PropertyMetadata(null, (d,e)=>
-                {
-                    var model = d as ContentElement2D;
-                    var node = model.SceneNode as ContentNode2D;
-                    if(e.OldValue is Element2D old)
+            public static readonly DependencyProperty Content2DProperty = DependencyProperty.Register("Content2D",
+                typeof(object), typeof(ContentElement2D), new PropertyMetadata(null,
+                    propertyChangedCallback: (d, e) =>
                     {
-                        model.RemoveLogicalChild(old);                    
-                        node.Content = null;
-                    }
-                    if(e.NewValue is Element2D newElement)
+                        if (!(d is ContentElement2D model)) return;
+                        if (!(model.SceneNode is ContentNode2D node)) return;
+                        if (e.OldValue is Element2D old)
+                        {
+                            model.RemoveLogicalChild(old);
+                            node.Content = null;
+                        }
+
+                        if (e.NewValue is Element2D newElement)
+                        {
+                            model.AddLogicalChild(newElement);
+                            node.Content = newElement;
+                            model.SetupBindings(newElement);
+                        }
+
+                        model.InvalidateMeasure();
+                    },
+                    coerceValueCallback: (d,e) =>
                     {
-                        model.AddLogicalChild(newElement);
-                        node.Content = newElement;
-                        model.SetupBindings(newElement);
-                    }
-                },
-                    (d, e)=>
-                {
-                    if(e is Element2D)
-                    {
-                        return e;
-                    }
-                    if (e != null)
-                    {
-                        return new TextModel2D() { Text = e.ToString() };
-                    }
-                    return null;
-                }));
+                        return e is Element2D ? e : new TextModel2D() {Text = e?.ToString()};
+                    }));
 
             [Bindable(true)]
             public object Content2D
@@ -60,7 +56,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
                 get
                 {
-                    return (Element2D)GetValue(Content2DProperty);
+                    return GetValue(Content2DProperty);
                 }
             }
 


### PR DESCRIPTION
I have added a binding to the D2DScreenMenuExample. With this binding I was able to reproduce the bug.

To solve the issue it I have added a null check in the `coerceValueCallback` method and two additional null checks in the `propertyChangedCallback` method.

Now this simple binding is working.