### PR TITLE
Fix render bitmap custom size (sharp dx) #1439 

### DIFF
--- a/Source/Examples/WPF.SharpDX/FileLoadDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/FileLoadDemo/MainViewModel.cs
@@ -61,19 +61,6 @@ namespace FileLoadDemo
             }
         }
 
-        private bool swapchain = true;
-        public bool SwapChainRendering
-        {
-            get
-            {
-                return swapchain;
-            }
-            set
-            {
-                SetValue(ref swapchain, value);
-            }
-        }
-
         private bool renderEnvironmentMap = true;
         public bool RenderEnvironmentMap
         {

--- a/Source/Examples/WPF.SharpDX/FileLoadDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/FileLoadDemo/MainViewModel.cs
@@ -15,6 +15,7 @@ namespace FileLoadDemo
     using HelixToolkit.Wpf.SharpDX.Model;
     using HelixToolkit.Wpf.SharpDX.Model.Scene;
     using Microsoft.Win32;
+    using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
@@ -91,6 +92,10 @@ namespace FileLoadDemo
 
         public ICommand ExportCommand { private set; get; }
 
+        public ICommand CopyAsBitmapCommand { private set; get; }
+
+        public ICommand CopyAsHiresBitmapCommand { private set; get; }      
+
         private bool isLoading = false;
         public bool IsLoading
         {
@@ -159,9 +164,12 @@ namespace FileLoadDemo
         private List<BoneSkinMeshNode> skeletonNodes = new List<BoneSkinMeshNode>();
         private CompositionTargetEx compositeHelper = new CompositionTargetEx();
 
+        private MainWindow mainWindow = null;
 
-        public MainViewModel()
+        public MainViewModel(MainWindow window)
         {
+            mainWindow = window;
+
             this.OpenFileCommand = new DelegateCommand(this.OpenFile);
             EffectsManager = new DefaultEffectsManager();
             Camera = new OrthographicCamera()
@@ -179,7 +187,44 @@ namespace FileLoadDemo
                 (Camera as OrthographicCamera).NearPlaneDistance = 0.1f;
             });
             ExportCommand = new DelegateCommand(() => { ExportFile(); });
+
+            CopyAsBitmapCommand = new DelegateCommand(() => { CopyAsBitmapToClipBoard(mainWindow.view); });
+            CopyAsHiresBitmapCommand = new DelegateCommand(() => { CopyAsHiResBitmapToClipBoard(mainWindow.view); });
+
             EnvironmentMap = LoadFileToMemory("Cubemap_Grandcanyon.dds");
+        }
+
+        private void CopyAsBitmapToClipBoard(Viewport3DX viewport)
+        {
+            var bitmap = ViewportExtensions.RenderBitmap(viewport);
+            try
+            {
+                Clipboard.Clear();
+                Clipboard.SetImage(bitmap);
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+            }
+        }
+
+        private void CopyAsHiResBitmapToClipBoard(Viewport3DX viewport)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var bitmap = ViewportExtensions.RenderBitmap(viewport,1920,1080);
+            try
+            {
+                Clipboard.Clear();
+                Clipboard.SetImage(bitmap);
+                stopwatch.Stop();
+                Debug.WriteLine($"creating bitmap needs {stopwatch.ElapsedMilliseconds} ms");
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+            }
         }
 
         private void OpenFile()

--- a/Source/Examples/WPF.SharpDX/FileLoadDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/FileLoadDemo/MainViewModel.cs
@@ -50,7 +50,7 @@ namespace FileLoadDemo
         {
             set
             {
-                if(SetValue(ref renderFlat, value))
+                if (SetValue(ref renderFlat, value))
                 {
                     RenderFlatFunct(value);
                 }
@@ -61,16 +61,29 @@ namespace FileLoadDemo
             }
         }
 
+        private bool swapchain = true;
+        public bool SwapChainRendering
+        {
+            get
+            {
+                return swapchain;
+            }
+            set
+            {
+                SetValue(ref swapchain, value);
+            }
+        }
+
         private bool renderEnvironmentMap = true;
         public bool RenderEnvironmentMap
         {
             set
             {
-                if(SetValue(ref renderEnvironmentMap, value) && scene!=null && scene.Root != null)
+                if (SetValue(ref renderEnvironmentMap, value) && scene != null && scene.Root != null)
                 {
-                    foreach(var node in scene.Root.Traverse())
+                    foreach (var node in scene.Root.Traverse())
                     {
-                        if(node is MaterialGeometryNode m && m.Material is PBRMaterialCore material)
+                        if (node is MaterialGeometryNode m && m.Material is PBRMaterialCore material)
                         {
                             material.RenderEnvironmentMap = value;
                         }
@@ -94,7 +107,7 @@ namespace FileLoadDemo
 
         public ICommand CopyAsBitmapCommand { private set; get; }
 
-        public ICommand CopyAsHiresBitmapCommand { private set; get; }      
+        public ICommand CopyAsHiresBitmapCommand { private set; get; }
 
         private bool isLoading = false;
         public bool IsLoading
@@ -132,7 +145,7 @@ namespace FileLoadDemo
         {
             set
             {
-                if(SetValue(ref selectedAnimation, value))
+                if (SetValue(ref selectedAnimation, value))
                 {
                     StopAnimation();
                     if (value != null)
@@ -213,7 +226,7 @@ namespace FileLoadDemo
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            var bitmap = ViewportExtensions.RenderBitmap(viewport,1920,1080);
+            var bitmap = ViewportExtensions.RenderBitmap(viewport, 1920, 1080);
             try
             {
                 Clipboard.Clear();
@@ -265,7 +278,7 @@ namespace FileLoadDemo
                                     {
                                         pbr.RenderEnvironmentMap = RenderEnvironmentMap;
                                     }
-                                    else if(m.Material is PhongMaterialCore phong)
+                                    else if (m.Material is PhongMaterialCore phong)
                                     {
                                         phong.RenderEnvironmentMap = RenderEnvironmentMap;
                                     }
@@ -273,18 +286,18 @@ namespace FileLoadDemo
                             }
                         }
                         GroupModel.AddNode(scene.Root);
-                        if(scene.HasAnimation)
+                        if (scene.HasAnimation)
                         {
-                            foreach(var ani in scene.Animations)
+                            foreach (var ani in scene.Animations)
                             {
                                 Animations.Add(ani);
                             }
                         }
-                        foreach(var n in scene.Root.Traverse())
+                        foreach (var n in scene.Root.Traverse())
                         {
                             n.Tag = new AttachedNodeViewModel(n);
                         }
-                    }                  
+                    }
                 }
                 else if (result.IsFaulted && result.Exception != null)
                 {
@@ -305,7 +318,7 @@ namespace FileLoadDemo
 
         private void CompositeHelper_Rendering(object sender, System.Windows.Media.RenderingEventArgs e)
         {
-            if(animationUpdater != null)
+            if (animationUpdater != null)
             {
                 animationUpdater.Update(Stopwatch.GetTimestamp(), Stopwatch.Frequency);
             }
@@ -348,7 +361,8 @@ namespace FileLoadDemo
                 path = d.FileName;
                 return d.FilterIndex - 1;//This is tarting from 1. So must minus 1
             }
-            else {
+            else
+            {
                 path = "";
                 return -1;
             }
@@ -356,10 +370,10 @@ namespace FileLoadDemo
 
         private void ShowWireframeFunct(bool show)
         {
-            foreach(var node in GroupModel.GroupNode.Items.PreorderDFT((node) =>
-            {
-                return node.IsRenderable;
-            }))
+            foreach (var node in GroupModel.GroupNode.Items.PreorderDFT((node) =>
+             {
+                 return node.IsRenderable;
+             }))
             {
                 if (node is MeshNode m)
                 {

--- a/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml
@@ -26,7 +26,10 @@
             CameraMode="Inspect"
             CameraRotationMode="Trackball"
             EffectsManager="{Binding EffectsManager}"
+            EnableSwapChainRendering="{Binding SwapChainRendering}"
             FXAALevel="Low">
+            <!-- EnableSwapChainRendering="{Binding SwapChainRendering}" is OK (no bug on rendering with different resolution) -->
+            <!-- EnableSwapChainRendering="true" fails! (only black screen on rendering with different resolution) -->
             <hx:Viewport3DX.InputBindings>
                 <KeyBinding Key="B" Command="hx:ViewportCommands.BackView" />
                 <KeyBinding Key="F" Command="hx:ViewportCommands.FrontView" />
@@ -96,6 +99,7 @@
                 <CheckBox Margin="4" IsChecked="{Binding ElementName=view, Path=EnableSSAO}">Enable SSAO</CheckBox>
                 <CheckBox Margin="4" IsChecked="{Binding RenderEnvironmentMap}">Render EnvironmentMap</CheckBox>
                 <CheckBox Margin="4" IsChecked="{Binding RenderFlat}">Flat Shading</CheckBox>
+                <CheckBox Margin="4" IsChecked="{Binding SwapChainRendering}">Enable SwapChain rendering</CheckBox>
                 <Separator />
                 <CheckBox Margin="4" IsChecked="{Binding EnableAnimation}">Enable Animation</CheckBox>
                 <TextBlock>Animations</TextBlock>

--- a/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml
@@ -69,6 +69,10 @@
                 <MenuItem Command="{Binding OpenFileCommand}" Header="Open File" />
                 <MenuItem Command="{Binding ExportCommand}" Header="Export" />
             </MenuItem>
+            <MenuItem Header="Edit">
+                <MenuItem Command="{Binding CopyAsBitmapCommand}" Header="Copy As Bitmap (Window Size)" />
+                <MenuItem Command="{Binding CopyAsHiresBitmapCommand}" Header="Copy as Hiresolution Bitmap (1920x1080)" />
+            </MenuItem>
         </Menu>
 
         <Grid

--- a/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml
@@ -26,10 +26,8 @@
             CameraMode="Inspect"
             CameraRotationMode="Trackball"
             EffectsManager="{Binding EffectsManager}"
-            EnableSwapChainRendering="{Binding SwapChainRendering}"
+            EnableSwapChainRendering="True"
             FXAALevel="Low">
-            <!-- EnableSwapChainRendering="{Binding SwapChainRendering}" is OK (no bug on rendering with different resolution) -->
-            <!-- EnableSwapChainRendering="true" fails! (only black screen on rendering with different resolution) -->
             <hx:Viewport3DX.InputBindings>
                 <KeyBinding Key="B" Command="hx:ViewportCommands.BackView" />
                 <KeyBinding Key="F" Command="hx:ViewportCommands.FrontView" />
@@ -99,7 +97,6 @@
                 <CheckBox Margin="4" IsChecked="{Binding ElementName=view, Path=EnableSSAO}">Enable SSAO</CheckBox>
                 <CheckBox Margin="4" IsChecked="{Binding RenderEnvironmentMap}">Render EnvironmentMap</CheckBox>
                 <CheckBox Margin="4" IsChecked="{Binding RenderFlat}">Flat Shading</CheckBox>
-                <CheckBox Margin="4" IsChecked="{Binding SwapChainRendering}">Enable SwapChain rendering</CheckBox>
                 <Separator />
                 <CheckBox Margin="4" IsChecked="{Binding EnableAnimation}">Enable Animation</CheckBox>
                 <TextBlock>Animations</TextBlock>

--- a/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/FileLoadDemo/MainWindow.xaml.cs
@@ -21,7 +21,8 @@ namespace FileLoadDemo
         public MainWindow()
         {
             InitializeComponent();
-            this.DataContext = new MainViewModel();
+            this.DataContext = new MainViewModel(this);
+            
             view.AddHandler(Element3D.MouseDown3DEvent, new RoutedEventHandler((s,e)=> 
             {
                 var arg = e as MouseDown3DEventArgs;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/ViewportExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/ViewportExtensions.cs
@@ -401,6 +401,11 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     if (view.RenderHost != null && view.RenderHost.IsRendering)
                     {
+                        if (view.EnableSwapChainRendering)
+                        {
+                            view.RenderHost.UpdateAndRender();
+                            // be sure to render the Scene before capture, otherwise the image is just black
+                        }
                         ScreenCapture.SaveWICTextureToBitmapStream(view.RenderHost.EffectsManager, view.RenderHost.RenderBuffer.BackBuffer.Resource as Texture2D, memoryStream);
                         var bitmap = new BitmapImage();
                         bitmap.BeginInit();


### PR DESCRIPTION
This fix was a little bit tricky, because it seems to be a timing issue first. 

The bug only appears, if the swapchain rendering was enabled. And a first hotfix was to use a Property Binding instead of directly setting `EnableSwaipChainRendering = "True"`.
After some time of searching, I realized, that the image is black, just because the rendering has not run after changing the size. Knowing this, the fix was easy.

Kind regards,
Christof