### PR TITLE
Fixes DataTemplate3D not supporting Binding-elements

### DIFF
--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/DataTemplate3D.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/DataTemplate3D.cs
@@ -72,8 +72,8 @@ namespace DataTemplateDemo
             if (listOfBindingPaths == null)
             {
                 // find and cache all bindings paths
-                listOfBindingPaths = FindBindingsInTree(contentXamlSerialized)
-                                        .Concat(FindMutiBindingsInTree(contentXamlSerialized))
+                listOfBindingPaths = FindInlineBindingsInTree(contentXamlSerialized)
+                                        .Concat(FindElementBindingsInTree(contentXamlSerialized))
                                         .ToArray();
             }
 
@@ -184,10 +184,11 @@ namespace DataTemplateDemo
         }
         /// <summary>
         /// Finds bound attributes in the xml document representing the object.
+        /// The bindings must be inlined as an attribute expression.
         /// </summary>
         /// <param name="xmlDoc">An <see cref="XmlDocument"/>.</param>
         /// <returns>A list of paths that have a data binding expression.</returns>
-        private IEnumerable<List<PathInfo>> FindBindingsInTree(XmlDocument xmlDoc)
+        private IEnumerable<List<PathInfo>> FindInlineBindingsInTree(XmlDocument xmlDoc)
         {
             foreach (var attr in xmlDoc.TraverseAllNodes().SelectMany(n => n.Attributes.Cast<XmlAttribute>()))
             {
@@ -210,15 +211,16 @@ namespace DataTemplateDemo
             }
         }
         /// <summary>
-        /// Finds bound attributes in the xml document representing the object.
+        /// Finds bound attributes and elements (nodes) in the xml document representing the object.
+        /// The bindings must be normal xml elements and not inlined as an attribute expression.
         /// </summary>
         /// <param name="xmlDoc">An <see cref="XmlDocument"/>.</param>
         /// <returns>A list of paths that have a data multi binding expression.</returns>
-        private IEnumerable<List<PathInfo>> FindMutiBindingsInTree(XmlDocument xmlDoc)
+        private IEnumerable<List<PathInfo>> FindElementBindingsInTree(XmlDocument xmlDoc)
         {
             foreach (var node in xmlDoc.TraverseAllNodes())
             {
-                if (node.Name.EndsWith("MultiBinding"))
+                if (node.Name.EndsWith("Binding"))
                 {
                     var nodes = new List<PathInfo>();
 

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/Element.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/Element.cs
@@ -27,6 +27,11 @@ namespace DataTemplateDemo
         public Point3D Position { get; set; }
 
         /// <summary>
+        /// Gets ors sets the postions collection.
+        /// </summary>
+        public Point3DCollection Positions { get; set; }
+
+        /// <summary>
         /// Gets or sets the radius.
         /// </summary>
         public double Radius { get; set; }

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MainWindow.xaml
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MainWindow.xaml
@@ -8,6 +8,14 @@
         <local:DataTemplate3D x:Key="Template1">
             <h:SphereVisual3D Center="{Binding Position}" Material="{Binding Material}" Radius="{Binding Radius}"/>
         </local:DataTemplate3D>
+        <local:DataTemplate3D x:Key="Template2">
+            <h:MeshGeometryVisual3D>
+                <h:MeshGeometryVisual3D.MeshGeometry>
+                    <MeshGeometry3D Positions="{Binding Positions}"></MeshGeometry3D>
+                    <!--<MeshGeometry3D Positions="-100,100,85 -100,-100,85 100,-100,85 100,100,85"/>-->
+                </h:MeshGeometryVisual3D.MeshGeometry>
+            </h:MeshGeometryVisual3D>
+        </local:DataTemplate3D>
 
         <local:DataTemplate3D x:Key="{x:Type local:CubeElement}">
             <h:CubeVisual3D Center="{Binding Position}" SideLength="0.6">
@@ -81,6 +89,7 @@
         <h:HelixViewport3D Grid.Row="1" ZoomExtentsWhenLoaded="True">
             <h:SunLight/>
             <local:ItemsVisual3D ItemTemplate="{StaticResource Template1}" ItemsSource="{Binding FixedElements}"/>
+            <local:ItemsVisual3D ItemTemplate="{StaticResource Template2}" ItemsSource="{Binding FixedElementsPositonsBinding}"/>
             <local:ItemsVisual3D ItemsSource="{Binding ObservableElements}" RefreshChildrenOnChange="{Binding IsChecked, ElementName=refreshOnChange, Mode=OneWay}" />
         </h:HelixViewport3D>
     </Grid>

--- a/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MainWindow.xaml.cs
+++ b/Source/Examples/WPF/ExampleBrowser/Examples/DataTemplate/MainWindow.xaml.cs
@@ -55,6 +55,19 @@ namespace DataTemplateDemo
                                          Radius = 0.6
                                      }
                              };
+            this.FixedElementsPositonsBinding = new List<Element>
+                            {
+                                new Element
+                                     {
+                                         Positions = new Point3DCollection
+                                         {
+                                             new Point3D(-1, 1, 1.85),
+                                             new Point3D(-1, -1, 1.85),
+                                             new Point3D(1, -1, 1.85),
+                                             new Point3D(1, 1, 1.85)
+                                         }
+                                     },
+                            };
             this.DataContext = this;
             this.AddElementCommand = new DelegateCommand(() =>
             {
@@ -134,5 +147,11 @@ namespace DataTemplateDemo
         /// </summary>
         /// <value>The fixed elements.</value>
         public IList<Element> FixedElements { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fixed elements.
+        /// </summary>
+        /// <value>The fixed elements.</value>
+        public IList<Element> FixedElementsPositonsBinding { get; set; }
     }
 }


### PR DESCRIPTION
As described in #1479 DataTemplate3D could not handle bindings that are represented in the form
```
<av:Binding Path="Positions" />
```

The actual change is in FindElementBindingsInTree method now checking for EndsWith("Binding") only, not EndsWith("MultiBinding"). The other changes are for testing.