### PR TITLE
Improve per thread buffer management. Allow geometry data clean up after loading into GPU.

### DIFF
--- a/Source/HelixToolkit.AppVeyor.sln
+++ b/Source/HelixToolkit.AppVeyor.sln
@@ -165,6 +165,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreWpfDemo", "Examples\WPF
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelixToolkit.Native.ShaderBuilder", "HelixToolkit.Native.ShaderBuilder\HelixToolkit.Native.ShaderBuilder.csproj", "{1B767276-2943-49C0-B883-755081951F01}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MorphTargetAnimationDemo", "Examples\WPF.SharpDX\MorphTargetAnimation\MorphTargetAnimationDemo.csproj", "{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		HelixToolkit.SharpDX.SharedModel\HelixToolkit.SharpDX.SharedModel.projitems*{1aefcb64-e997-425a-8c84-dc93263cc4a7}*SharedItemsImports = 13
@@ -1441,6 +1443,26 @@ Global
 		{1B767276-2943-49C0-B883-755081951F01}.Release|x64.Build.0 = Release|Any CPU
 		{1B767276-2943-49C0-B883-755081951F01}.Release|x86.ActiveCfg = Release|Any CPU
 		{1B767276-2943-49C0-B883-755081951F01}.Release|x86.Build.0 = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|ARM.Build.0 = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|x64.Build.0 = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Debug|x86.Build.0 = Debug|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|ARM.ActiveCfg = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|ARM.Build.0 = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|ARM64.Build.0 = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|x64.ActiveCfg = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|x64.Build.0 = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|x86.ActiveCfg = Release|Any CPU
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1518,6 +1540,7 @@ Global
 		{856AF702-208F-4D92-9534-4D8C91F49A99} = {B025344D-2B79-4456-9668-F4950BCA498F}
 		{F9EAE3B1-1D31-418D-8F87-ED9D2EBF5EFB} = {9444ACDF-A920-4E01-9929-A450F6B1C266}
 		{1B767276-2943-49C0-B883-755081951F01} = {5730542A-FBE8-4176-B8C4-7FF801B27E99}
+		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F} = {8DB21D26-08EA-4A24-BDE8-FFE08F2C30EE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FDED8F31-C7C8-41E4-ACAC-293F326BAE9F}

--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/Configurations.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/Configurations.cs
@@ -178,6 +178,11 @@ namespace HelixToolkit.UWP
             /// </summary>
             public bool IsSourceMatrixColumnMajor = true;
 
+            /// <summary>
+            /// The build octree automatically during loading.
+            /// </summary>
+            public bool BuildOctree = true;
+
             public ITextureIO TextureLoader;
             /// <summary>
             /// Initializes a new instance of the <see cref="ImporterConfiguration"/> class.

--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/ImporterPartial_Mesh.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/ImporterPartial_Mesh.cs
@@ -193,7 +193,10 @@ namespace HelixToolkit.UWP
                 }
 
                 hMesh.UpdateBounds();
-                hMesh.UpdateOctree();
+                if (configuration.BuildOctree)
+                {
+                    hMesh.UpdateOctree();
+                }
                 return hMesh;
             }
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/GeometryBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/GeometryBufferModel.cs
@@ -245,7 +245,7 @@ namespace HelixToolkit.UWP
                                     updateVBinding = true;  
                                 }
                             }      
-                        }  
+                        }
                         if (updateVBinding)
                         {
                             VertexBufferBindings = OnCreateVertexBufferBinding();
@@ -267,6 +267,10 @@ namespace HelixToolkit.UWP
                         IndexChanged = false;                    
                         IndexBufferUpdated?.Invoke(this, EventArgs.Empty);
                     }               
+                }
+                if (bufferUpdated && Geometry != null && Geometry.IsTransient)
+                {
+                    Geometry.ClearAllGeometryData();
                 }
                 return bufferUpdated;
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/LineBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/LineBufferModel.cs
@@ -92,8 +92,6 @@ namespace HelixToolkit.UWP
         /// </summary>
         public class DefaultLineGeometryBufferModel : LineGeometryBufferModel<LinesVertex>
         {
-            [ThreadStatic]
-            private static LinesVertex[] vertexArrayBuffer = null;
             /// <summary>
             /// Initializes a new instance of the <see cref="DefaultLineGeometryBufferModel"/> class.
             /// </summary>
@@ -159,10 +157,8 @@ namespace HelixToolkit.UWP
             {
                 var positions = geometry.Positions;
                 var vertexCount = geometry.Positions.Count;
-                var array =  vertexArrayBuffer != null && vertexArrayBuffer.Length >= vertexCount ? vertexArrayBuffer : new LinesVertex[vertexCount];
+                var array = ThreadBufferManager<LinesVertex>.GetBuffer(vertexCount);
                 var colors = geometry.Colors != null ? geometry.Colors.GetEnumerator() : Enumerable.Repeat(Color4.White, vertexCount).GetEnumerator();
-
-                vertexArrayBuffer = array;
 
                 for (var i = 0; i < vertexCount; i++)
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/MeshBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/MeshBufferModel.cs
@@ -119,8 +119,6 @@ namespace HelixToolkit.UWP
         /// </summary>
         public class DefaultMeshGeometryBufferModel : MeshGeometryBufferModel<DefaultVertex>
         {
-            [ThreadStatic]
-            private static DefaultVertex[] vertexArrayBuffer = null;
             private static readonly Vector2[] emptyTextureArray = new Vector2[0];
             private static readonly Vector4[] emptyColorArray = new Vector4[0];
 
@@ -234,8 +232,7 @@ namespace HelixToolkit.UWP
                 var tangents = geometry.Tangents != null ? geometry.Tangents.GetEnumerator() : Enumerable.Repeat(Vector3.Zero, vertexCount).GetEnumerator();
                 var bitangents = geometry.BiTangents != null ? geometry.BiTangents.GetEnumerator() : Enumerable.Repeat(Vector3.Zero, vertexCount).GetEnumerator();
 
-                var array = vertexArrayBuffer != null && vertexArrayBuffer.Length >= vertexCount ? vertexArrayBuffer : new DefaultVertex[vertexCount];
-                vertexArrayBuffer = array;
+                var array = ThreadBufferManager<DefaultVertex>.GetBuffer(vertexCount);
                 for (var i = 0; i < vertexCount; i++)
                 {
                     positions.MoveNext();

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/PointBufferModel.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/PointBufferModel.cs
@@ -77,8 +77,6 @@ namespace HelixToolkit.UWP
         /// </summary>
         public class DefaultPointGeometryBufferModel : PointGeometryBufferModel<PointsVertex>
         {
-            [ThreadStatic]
-            private static PointsVertex[] vertexArrayBuffer;
             /// <summary>
             /// Initializes a new instance of the <see cref="DefaultPointGeometryBufferModel"/> class.
             /// </summary>
@@ -127,9 +125,9 @@ namespace HelixToolkit.UWP
             {
                 var positions = geometry.Positions;
                 var vertexCount = geometry.Positions.Count;
-                var array = vertexArrayBuffer != null && vertexArrayBuffer.Length >= vertexCount ? vertexArrayBuffer : new PointsVertex[vertexCount];
+                var array = ThreadBufferManager<PointsVertex>.GetBuffer(vertexCount);
                 var colors = geometry.Colors != null ? geometry.Colors.GetEnumerator() : Enumerable.Repeat(Color4.White, vertexCount).GetEnumerator();
-                vertexArrayBuffer = array;
+
                 for (var i = 0; i < vertexCount; i++)
                 {
                     colors.MoveNext();

--- a/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/ThreadBufferManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Buffers/ThreadBufferManager.cs
@@ -1,0 +1,132 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    namespace Core
+    {
+        public static class ThreadBufferManagerConfig
+        {
+            /// <summary>
+            /// Gets or sets the maximum size to retain the buffer in memory.
+            /// If requested size is larger than this value, buffer will be temporary instead of being retained for reuse.
+            /// 
+            /// </summary>
+            /// <value>
+            /// The maximum size to retain mb.
+            /// </value>
+            public static int MaximumSizeToRetainMb
+            {
+                set;
+                get;
+            } = 64;
+            /// <summary>
+            /// Gets or sets the minimum size to retain the buffer in memory.
+            /// If requested size is smaller than this value, buffer will always be retained for reuse.
+            /// </summary>
+            /// <value>
+            /// The minimum size to retain mb.
+            /// </value>
+            public static int MinimumSizeToRetainMb
+            {
+                set;
+                get;
+            } = 4;
+            /// <summary>
+            /// Gets or sets the minimum buffer release threshold by seconds.
+            /// Buffer will not be released automatically if it has been used within last N seconds.
+            /// </summary>
+            /// <value>
+            /// The minimum buffer release threshold by seconds.
+            /// </value>
+            public static int MinimumAutoReleaseThresholdSeconds
+            {
+                set; get;
+            } = 10;
+
+            /// <summary>
+            /// Gets or sets the size reduction multiplier.
+            /// If buffer is not being used more than <see cref="MinimumAutoReleaseThresholdSeconds"/> seconds,
+            /// and new request size is smaller than buffer size / <see cref="SizeReductionDividend"/> but larger than <see cref="MinimumSizeToRetainMb"/>,
+            /// buffer will be released after usage.
+            /// </summary>
+            /// <value>
+            /// The size reduction multiplier.
+            /// </value>
+            public static float SizeReductionDividend
+            {
+                set; get;
+            } = 2;
+        }
+
+        public static class ThreadBufferManager<T> where T : struct
+        {
+#if !NETFX_CORE
+            public static readonly int StructSize = Marshal.SizeOf(typeof(T));
+#else
+            public static readonly int StructSize = Marshal.SizeOf<T>();
+#endif
+
+            private const int MByteToByte = 1024 * 1024;
+            public static int MaximumElementCount
+            {
+                get => ThreadBufferManagerConfig.MaximumSizeToRetainMb * MByteToByte / StructSize;
+            }
+
+            public static int MinimumElementCount
+            {
+                get => ThreadBufferManagerConfig.MinimumSizeToRetainMb * MByteToByte / StructSize;
+            }
+
+            [ThreadStatic]
+            private static T[] buffer = null;
+
+            private static long lastUsed = 0;
+
+            public static T[] GetBuffer(int requestCount)
+            {
+                var array = buffer != null && buffer.Length >= requestCount ? buffer : new T[requestCount];
+                if (requestCount > MaximumElementCount)
+                {
+                    Debug.WriteLine("Requested buffer size is larger than max retain size.");
+                    return array;
+                }
+                if (lastUsed == 0)
+                {
+                    lastUsed = Stopwatch.GetTimestamp();
+                    buffer = array;
+                    return array;
+                }
+
+                if (array.Length > MinimumElementCount
+                    && array.Length > ThreadBufferManagerConfig.SizeReductionDividend * requestCount)
+                {
+                    long diff = Stopwatch.GetTimestamp() - lastUsed;
+                    if (diff / Stopwatch.Frequency > ThreadBufferManagerConfig.MinimumAutoReleaseThresholdSeconds)
+                    {
+                        Debug.WriteLine("Disposing thread buffer.");
+                        buffer = null;
+                        lastUsed = 0;                       
+                        return array;
+                    }
+                }
+
+                buffer = array;
+                lastUsed = Stopwatch.GetTimestamp();
+                return array;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\MeshBufferModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\PointBufferModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\SpriteBufferModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\Buffers\ThreadBufferManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Components\CoreComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Components\ConstantBufferComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\CrossSectionMeshRenderCore.cs" />
@@ -116,7 +117,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IPoolManagers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IPostEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRandomVector.cs" />
-	<Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderMatrices.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderMatrices.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IViewport3DX.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderable2D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interface\IRenderCoreParams.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Animations/KeyFrameUpdater.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Animations/KeyFrameUpdater.cs
@@ -320,8 +320,6 @@ namespace HelixToolkit.UWP
                     {
                         continue;
                     }
-                    if (i == 0)
-                    Console.WriteLine($"Index: ${idxTime.Index}");
                     ref var currFrame = ref frames[idxTime.Index];
                     if (count == 1)
                     {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Collection/FastList.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Collection/FastList.cs
@@ -553,6 +553,10 @@ namespace HelixToolkit.UWP
 
         public void TrimExcess()
         {
+            if (Count == Capacity)
+            {
+                return;
+            }
             var curr = Items;
             Items = Count == 0 ? empty : new T[Count];
             if (Count > 0)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Collection/FastList.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Collection/FastList.cs
@@ -553,11 +553,13 @@ namespace HelixToolkit.UWP
 
         public void TrimExcess()
         {
-            var num = (int) (Items.Length*0.9);
-            if (_size < num)
+            var curr = Items;
+            Items = Count == 0 ? empty : new T[Count];
+            if (Count > 0)
             {
-                Capacity = _size;
+                Array.Copy(curr, 0, Items, 0, Count);
             }
+            Capacity = Count;
         }
 
         public bool TrueForAll(Predicate<T> match)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BillboardBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/BillboardBase.cs
@@ -136,6 +136,10 @@ namespace HelixToolkit.UWP
             ref Ray rayWS, ref List<HitTestResult> hits,
             object originalSource, int count)
         {
+            if (BillboardVertices == null || BillboardVertices.Count == 0)
+            {
+                return false;
+            }
             var h = false;
             var result = new BillboardHitResult
             {
@@ -191,6 +195,14 @@ namespace HelixToolkit.UWP
             result.TextInfoIndex = index;
             result.Type = Type;
         }
+
+        protected override void OnClearAllGeometryData()
+        {
+            base.OnClearAllGeometryData();
+            BillboardVertices?.Clear();
+            (BillboardVertices as FastList<BillboardVertex>)?.TrimExcess();
+        }
+
         /// <summary>
         /// Hits the size of the test non fixed.
         /// </summary>
@@ -205,6 +217,10 @@ namespace HelixToolkit.UWP
             ref Ray rayWS, ref List<HitTestResult> hits,
             object originalSource, int count)
         {
+            if (BillboardVertices == null || BillboardVertices.Count == 0)
+            {
+                return false;
+            }
             var h = false;
             var result = new BillboardHitResult
             {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
@@ -289,6 +289,19 @@ namespace HelixToolkit.UWP
         {
             RaisePropertyChanged(nameof(TextureCoordinates));
         }
+
+        protected override void OnClearAllGeometryData()
+        {
+            base.OnClearAllGeometryData();
+            Normals?.Clear();
+            Normals?.TrimExcess();
+            TextureCoordinates?.Clear();
+            TextureCoordinates?.TrimExcess();
+            Tangents?.Clear();
+            Tangents?.TrimExcess();
+            BiTangents?.Clear();
+            BiTangents?.TrimExcess();
+        }
     }
 
 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/ParametricSurface3DNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/ParametricSurface3DNode.cs
@@ -82,6 +82,7 @@ namespace HelixToolkit.UWP
                 {
                     var mesh = OnTesselatingAsync(token);
                     mesh.Normals = mesh.CalculateNormals();
+                    mesh.SetAsTransient();
                     mesh?.UpdateOctree();
                     mesh?.UpdateBounds();
                     return mesh;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/ParametricSurface3DNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/ParametricSurface3DNode.cs
@@ -82,7 +82,6 @@ namespace HelixToolkit.UWP
                 {
                     var mesh = OnTesselatingAsync(token);
                     mesh.Normals = mesh.CalculateNormals();
-                    mesh.SetAsTransient();
                     mesh?.UpdateOctree();
                     mesh?.UpdateBounds();
                     return mesh;


### PR DESCRIPTION
1. Improve per thread buffer management.
2. Support geometry clear up after loading into GPU for view only. #1449 (Restriction: View only, no hit test support, geometry must not be shared with multiple models. )