### PR TITLE
Fix cursor is wrong after pressing multiple mouse button simultaneously

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/FrameStatistics.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/FrameStatistics.cs
@@ -93,10 +93,10 @@ namespace HelixToolkit.UWP
             /// The update frequency.
             /// </value>
             public uint UpdateFrequency { set; get; } = 30;
-
+            private double total = 0;
             private double movingAverage = 0;
             private uint counter = 0;
-            private const int RingBufferSize = 60;
+            private const int RingBufferSize = 120;
             private readonly SimpleRingBuffer<double> ringBuffer = new SimpleRingBuffer<double>(RingBufferSize);
             /// <summary>
             /// Pushes the specified latency by milliseconds.
@@ -111,11 +111,12 @@ namespace HelixToolkit.UWP
                 }
                 if (ringBuffer.IsFull())
                 {
-                    movingAverage -= (ringBuffer.First - movingAverage) / ringBuffer.Count;
+                    total -= ringBuffer.First;
                     ringBuffer.RemoveFirst();
                 }
                 ringBuffer.Add(latency);
-                movingAverage += (latency - movingAverage) / ringBuffer.Count; // moving average        
+                total += latency;
+                movingAverage = total / ringBuffer.Count; // moving average        
                 movingAverage = Math.Min(1000, Math.Max(0, movingAverage));
                 counter = (++counter) % UpdateFrequency;
                 if (counter == 0)
@@ -129,6 +130,7 @@ namespace HelixToolkit.UWP
                 AverageValue = 0;
                 movingAverage = 0;
                 counter = 0;
+                total = 0;
                 ringBuffer.Clear();
             }
         }

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
@@ -1,6 +1,7 @@
 ﻿using SharpDX;
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using Point = Windows.Foundation.Point;
 using Point3D = SharpDX.Vector3;
 using Vector3D = SharpDX.Vector3;
@@ -544,7 +545,10 @@ namespace HelixToolkit.UWP
         /// Implemented as a list since we want to remove items at the bottom of the stack.
         /// </remarks>
         private readonly SimpleRingBuffer<CameraSetting> cameraHistory = new SimpleRingBuffer<CameraSetting>(100);
-
+        /// <summary>
+        /// Records series of mouse down cursor changes. And play back during mouse up.
+        /// </summary>
+        internal Stack<CoreCursor> CursorHistory { get; } = new Stack<CoreCursor>();
         /// <summary>
         /// Decides if combined manipulation is allowed.
         /// </summary>

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/MouseGestureHandler.cs
@@ -19,7 +19,7 @@ namespace HelixToolkit.UWP
     using System;
     using Windows.UI.Xaml.Input;
     using System.Collections.Generic;
-
+    using XamlWin = Windows.UI.Xaml.Window;
     /// <summary>
     /// An abstract base class for the mouse gesture handlers.
     /// </summary>
@@ -159,11 +159,6 @@ namespace HelixToolkit.UWP
                 return this.Controller.ZoomSensitivity;
             }
         }
-
-        /// <summary>
-        /// Gets or sets the old cursor.
-        /// </summary>
-        private CoreCursor OldCursor { get; set; }
 
         private List<HitTestResult> hits = new List<HitTestResult>();
         /// <summary>
@@ -347,8 +342,8 @@ namespace HelixToolkit.UWP
         {
             this.Started(e.GetCurrentPoint(this.Controller.Viewport).Position);
 
-            this.OldCursor = Windows.UI.Xaml.Window.Current.CoreWindow.PointerCursor;
-            Windows.UI.Xaml.Window.Current.CoreWindow.PointerCursor = new CoreCursor(this.GetCursor(), OldCursor.Id);
+            this.Controller.CursorHistory.Push(XamlWin.Current.CoreWindow.PointerCursor);
+            XamlWin.Current.CoreWindow.PointerCursor = new CoreCursor(this.GetCursor(), XamlWin.Current.CoreWindow.PointerCursor.Id);
         }
 
         /// <summary>
@@ -379,7 +374,7 @@ namespace HelixToolkit.UWP
             this.Controller.Viewport.PointerMoved -= this.OnMouseMove;
             this.Controller.Viewport.PointerReleased -= this.OnMouseUp;
             this.Controller.Viewport.ReleasePointerCapture(e.Pointer);
-            Windows.UI.Xaml.Window.Current.CoreWindow.PointerCursor = this.OldCursor;
+            XamlWin.Current.CoreWindow.PointerCursor = Controller.CursorHistory.Pop();
             this.Completed(e.GetCurrentPoint(this.Controller.Viewport).Position);
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
+using System.Collections.Generic;
 
 using Vector3 = global::SharpDX.Vector3;
 using Vector2 = global::SharpDX.Vector2;
@@ -170,6 +171,11 @@ namespace HelixToolkit.Wpf.SharpDX
         private static readonly Point PointZero = new Point(0, 0);
         private static readonly Vector2 VectorZero = new Vector2();
         private static readonly Vector3 Vector3DZero = new Vector3();
+
+        /// <summary>
+        /// Records series of mouse down cursor changes. And play back during mouse up.
+        /// </summary>
+        internal Stack<Cursor> CursorHistory { get; } = new Stack<Cursor>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CameraController" /> class.

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/MouseGestureHandler.cs
@@ -170,11 +170,6 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        /// <summary>
-        /// Gets or sets the old cursor.
-        /// </summary>
-        private Cursor OldCursor { get; set; }
-
         protected List<HitTestResult> hits = new List<HitTestResult>();
 
         /// <summary>
@@ -348,7 +343,7 @@ namespace HelixToolkit.Wpf.SharpDX
         {
             this.Started(Mouse.GetPosition(this.Viewport));
 
-            this.OldCursor = this.Viewport.Cursor;
+            Controller.CursorHistory.Push(this.Viewport.Cursor);
             this.Viewport.Cursor = this.GetCursor();
         }
 
@@ -380,7 +375,7 @@ namespace HelixToolkit.Wpf.SharpDX
             this.Viewport.MouseMove -= this.OnMouseMove;
             this.Viewport.MouseUp -= this.OnMouseUp;
             this.Viewport.ReleaseMouseCapture();
-            this.Viewport.Cursor = this.OldCursor;
+            this.Viewport.Cursor = Controller.CursorHistory.Count > 0 ? Controller.CursorHistory.Pop() : null;
             this.Completed(Mouse.GetPosition(this.Viewport));
         }
 


### PR DESCRIPTION
1. Fix cursor is wrong after pressing multiple mouse button simultaneously. #1527
2. Update FPS calculation.