### PR TITLE
Clear mouse cursor in case mouse up event is not fired. 

### DIFF
--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/CameraController.cs
@@ -682,6 +682,7 @@ namespace HelixToolkit.UWP
         private static readonly Point PointZero = new Point(0, 0);
         private static readonly Vector2 VectorZero = new Vector2();
         private static readonly Vector3D Vector3DZero = new Vector3D();
+        internal List<MouseGestureHandler> MouseHandlers { get; } = new List<MouseGestureHandler>();
         public Viewport3DX Viewport { private set; get; }
 
         public CameraController(Viewport3DX viewport)
@@ -693,6 +694,12 @@ namespace HelixToolkit.UWP
             this.zoomHandler = new ZoomHandler(this);
             this.panHandler = new PanHandler(this);
             this.changeFieldOfViewHandler = new ZoomHandler(this, true);
+            MouseHandlers.Add(changeLookAtHandler);
+            MouseHandlers.Add(rotateHandler);
+            MouseHandlers.Add(zoomRectangleHandler);
+            MouseHandlers.Add(zoomHandler);
+            MouseHandlers.Add(panHandler);
+            MouseHandlers.Add(changeFieldOfViewHandler);
             this.Viewport.RegisterPropertyChangedCallback(Viewport3DX.CameraProperty, (d, e) => { ActualCamera = d.GetValue(e) as ProjectionCamera; });
             this.Viewport.RegisterPropertyChangedCallback(Viewport3DX.DefaultCameraProperty, (d, e) => { DefaultCamera = d.GetValue(e) as ProjectionCamera; });
             this.Viewport.SizeChanged += (s, e) =>
@@ -1307,6 +1314,13 @@ namespace HelixToolkit.UWP
             if(e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Touch)
             {
                 Viewport.ReleasePointerCapture(e.Pointer);
+                foreach(var handler in MouseHandlers)
+                {
+                    if (handler.IsActive)
+                    {
+
+                    }
+                }
             }
         }
 

--- a/Source/HelixToolkit.UWP/Controls/MouseHandlers/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.UWP/Controls/MouseHandlers/MouseGestureHandler.cs
@@ -161,6 +161,8 @@ namespace HelixToolkit.UWP
         }
 
         private List<HitTestResult> hits = new List<HitTestResult>();
+
+        public bool IsActive { private set; get; } = false;
         /// <summary>
         /// Occurs when the manipulation is completed.
         /// </summary>
@@ -175,6 +177,7 @@ namespace HelixToolkit.UWP
                 this.OnInertiaStarting(elapsed);
             }
             startTick = Stopwatch.GetTimestamp();
+            IsActive = false;
         }
 
         /// <summary>
@@ -229,6 +232,7 @@ namespace HelixToolkit.UWP
             inv = Camera.CreateLeftHandSystem ? -1 : 1;
             Controller.StopAnimations();
             Controller.PushCameraSetting();
+            IsActive = true;
         }
 
         /// <summary>
@@ -376,6 +380,20 @@ namespace HelixToolkit.UWP
             this.Controller.Viewport.ReleasePointerCapture(e.Pointer);
             XamlWin.Current.CoreWindow.PointerCursor = Controller.CursorHistory.Pop();
             this.Completed(e.GetCurrentPoint(this.Controller.Viewport).Position);
+            CheckCursorHistory();
+        }
+
+        private void CheckCursorHistory()
+        {
+            foreach (var handler in Controller.MouseHandlers)
+            {
+                if (handler.IsActive)
+                {
+                    return;
+                }
+            }
+            Controller.CursorHistory.Clear();
+            XamlWin.Current.CoreWindow.PointerCursor = null;
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraController.cs
@@ -176,7 +176,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Records series of mouse down cursor changes. And play back during mouse up.
         /// </summary>
         internal Stack<Cursor> CursorHistory { get; } = new Stack<Cursor>();
-
+        internal List<MouseGestureHandler> MouseHandlers { get; } = new List<MouseGestureHandler>();
         /// <summary>
         /// Initializes a new instance of the <see cref="CameraController" /> class.
         /// </summary>
@@ -573,7 +573,7 @@ namespace HelixToolkit.Wpf.SharpDX
         public bool EnablePinchZoom { set; get; } = true;
         public bool EnableThreeFingerPan { set; get; } = true;
         public bool PinchZoomAtCenter { set; get; } = false;
-#endregion
+        #endregion
 
         /// <summary>
         /// Adds the specified move force.
@@ -1278,6 +1278,12 @@ namespace HelixToolkit.Wpf.SharpDX
             this.panHandler = new PanHandler(this);
             this.changeFieldOfViewHandler = new ZoomHandler(this, true);
             this.setTargetHandler = new RotateHandler(this, true);
+            MouseHandlers.Add(changeLookAtHandler);
+            MouseHandlers.Add(rotateHandler);
+            MouseHandlers.Add(zoomRectangleHandler);
+            MouseHandlers.Add(zoomHandler);
+            MouseHandlers.Add(panHandler);
+            MouseHandlers.Add(changeFieldOfViewHandler);
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/MouseGestureHandler.cs
@@ -170,6 +170,8 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        public bool IsActive { private set; get; } = false;
+
         protected List<HitTestResult> hits = new List<HitTestResult>();
 
         /// <summary>
@@ -186,6 +188,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.OnInertiaStarting(elapsed);
             }
             startTick = Stopwatch.GetTimestamp();
+            IsActive = false;
         }
 
         /// <summary>
@@ -240,6 +243,7 @@ namespace HelixToolkit.Wpf.SharpDX
             Inv = Camera.CreateLeftHandSystem ? -1 : 1;
             Controller.StopAnimations();
             Controller.PushCameraSetting();
+            IsActive = true;
         }
 
         /// <summary>
@@ -377,6 +381,20 @@ namespace HelixToolkit.Wpf.SharpDX
             this.Viewport.ReleaseMouseCapture();
             this.Viewport.Cursor = Controller.CursorHistory.Count > 0 ? Controller.CursorHistory.Pop() : null;
             this.Completed(Mouse.GetPosition(this.Viewport));
+            CheckCursorHistory();
+        }
+
+        private void CheckCursorHistory()
+        {
+            foreach(var handler in Controller.MouseHandlers)
+            {
+                if (handler.IsActive)
+                {
+                    return;
+                }
+            }
+            Controller.CursorHistory.Clear();
+            this.Viewport.Cursor = null;
         }
 
         /// <summary>


### PR DESCRIPTION
Clear mouse cursor in case mouse up event is not fired. This happens if focus changed to another application after mouse down.