### PR TITLE
Bugfix export without material

### DIFF
--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/ExporterPartial_Material.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/ExporterPartial_Material.cs
@@ -34,7 +34,7 @@ namespace HelixToolkit.UWP
                 if (node is HxScene.MaterialGeometryNode geo)
                 {
                     material = geo.Material;
-                    return true;
+                    return material != null;
                 }
                 else
                 {


### PR DESCRIPTION
Fixed a bug where the exporter crashed trying to export a MaterialGeometryNode without material.
Return false if the geometry has no material.