### PR TITLE
Bugfix export without material (Part2)

### DIFF
--- a/Source/HelixToolkit.SharpDX.Assimp.Shared/ExporterPartial_Mesh.cs
+++ b/Source/HelixToolkit.SharpDX.Assimp.Shared/ExporterPartial_Mesh.cs
@@ -52,7 +52,7 @@ namespace HelixToolkit.UWP
             private MeshInfo OnCreateMeshInfo(HxScene.GeometryNode geoNode)
             {
                 MeshInfo info = null;
-                if (geoNode is HxScene.MaterialGeometryNode materialNode)
+                if (geoNode is HxScene.MaterialGeometryNode materialNode && materialNode.Material != null)
                 {
                     var key = GetMaterialGeoKey(geoNode, out var materialIndex, out var geoIndex);
                     if (!meshInfos.TryGetValue(key, out var existing))


### PR DESCRIPTION
Fixed a bug where the exporter crashed trying to export a MaterialGeometryNode without material.
Do not create a MeshInfo when there is no material on the node - forgot this change in my first change.

Tested with FileLoadDemo - works as expected.