### PR TITLE
Frustum test bug fix. Move FXAA to the end of rendering.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingFrustumExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/BoundingFrustumExtensions.cs
@@ -63,19 +63,29 @@ namespace HelixToolkit.UWP
         /// <param name="sphere">The sphere.</param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Intersects(ref BoundingFrustum frustum, ref BoundingBox box, ref BoundingSphere sphere)
+        public static bool IsInOrIntersectFrustum(ref BoundingFrustum frustum, ref BoundingBox box, ref BoundingSphere sphere)
         {
             for (int i = 0; i < 6; i++)
             {
-                var plane = frustum.GetPlane(i);         
-                if (plane.Intersects(ref sphere) == PlaneIntersectionType.Back)
+                var plane = frustum.GetPlane(i);
+                var sphereRet = plane.Intersects(ref sphere);
+                if (sphereRet == PlaneIntersectionType.Back)
                 {
                     return false;
                 }
+                else if (sphereRet == PlaneIntersectionType.Intersecting)
+                {
+                    return true;
+                }
                 GetBoxToPlanePVertexNVertex(ref box, ref plane.Normal, out Vector3 p, out Vector3 n);
-                if (Collision.PlaneIntersectsPoint(ref plane, ref p) == PlaneIntersectionType.Back)
+                var boxRet = Collision.PlaneIntersectsPoint(ref plane, ref p);
+                if (boxRet == PlaneIntersectionType.Back)
                 {
                     return false;
+                }
+                else if (boxRet == PlaneIntersectionType.Intersecting)
+                {
+                    return true;
                 }
             }
             return true;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
@@ -526,7 +526,7 @@ namespace HelixToolkit.UWP
                 {
                     return true;
                 }
-                return BoundingFrustumExtensions.Intersects(ref viewFrustum, ref BoundManager.BoundsWithTransform, ref BoundManager.BoundsSphereWithTransform);
+                return BoundingFrustumExtensions.IsInOrIntersectFrustum(ref viewFrustum, ref BoundManager.BoundsWithTransform, ref BoundManager.BoundsSphereWithTransform);
             }
 
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BatchedMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BatchedMeshNode.cs
@@ -668,7 +668,7 @@ namespace HelixToolkit.UWP
                 {
                     return true;
                 }
-                return BoundingFrustumExtensions.Intersects(ref viewFrustum, ref boundsWithTransform, ref boundsSphereWithTransform);
+                return BoundingFrustumExtensions.IsInOrIntersectFrustum(ref viewFrustum, ref boundsWithTransform, ref boundsSphereWithTransform);
             }
 
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -256,13 +256,6 @@ namespace HelixToolkit.UWP
                 {
                     renderables[i].Render(context, ImmediateContext);
                 }
-
-                if (context.RenderHost.FeatureLevel >= global::SharpDX.Direct3D.FeatureLevel.Level_11_0
-                  && context.RenderHost.RenderConfiguration.FXAALevel != FXAALevel.None)
-                {
-                    postFXAACore.FXAALevel = context.RenderHost.RenderConfiguration.FXAALevel;
-                    postFXAACore.Render(context, ImmediateContext);
-                }
             }
             /// <summary>
             /// Renders to ping pong buffer.
@@ -316,6 +309,12 @@ namespace HelixToolkit.UWP
             /// <param name="parameter">The parameter.</param>
             public virtual void RenderToBackBuffer(RenderContext context, ref RenderParameter parameter)
             {
+                if (context.RenderHost.FeatureLevel >= global::SharpDX.Direct3D.FeatureLevel.Level_11_0
+                    && context.RenderHost.RenderConfiguration.FXAALevel != FXAALevel.None)
+                {
+                    postFXAACore.FXAALevel = context.RenderHost.RenderConfiguration.FXAALevel;
+                    postFXAACore.Render(context, ImmediateContext);
+                }
                 ImmediateContext.Flush();
                 var buffer = context.RenderHost.RenderBuffer;
                 if (parameter.IsMSAATexture)


### PR DESCRIPTION
1. Frustum test bug fix. 
2. Move FXAA to the end of rendering. #1554