### PR TITLE
Handle too many SurfaceD3D_IsFrontBufferAvailableChanged

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DX11ImageSourceRenderHost.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DX11ImageSourceRenderHost.cs
@@ -110,13 +110,16 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
             }
 
+            private bool lastSurfaceD3DIsFrontBufferAvailable;
             private void SurfaceD3D_IsFrontBufferAvailableChanged(object sender, System.Windows.DependencyPropertyChangedEventArgs e)
             {
-                if (EffectsManager == null)
+                bool newValue = (bool)(e.NewValue);
+                if (EffectsManager == null ||newValue==lastSurfaceD3DIsFrontBufferAvailable)
                 {
                     return;
                 }
-                Logger.Log(HelixToolkit.Logger.LogLevel.Warning, $"SurfaceD3D front buffer changed. Value = {(bool)e.NewValue}");
+               
+                Logger.Log(HelixToolkit.Logger.LogLevel.Warning, $"SurfaceD3D front buffer changed. Value = {newValue}, last value {lastSurfaceD3DIsFrontBufferAvailable}");
                 if (surfaceD3D != null)
                 {
                     hasBackBuffer = false;
@@ -124,7 +127,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     surfaceD3D.IsFrontBufferAvailableChanged -= SurfaceD3D_IsFrontBufferAvailableChanged;
                     RemoveAndDispose(ref surfaceD3D);
                 }
-                if ((bool)e.NewValue)
+                if (newValue)
                 {
                     frontBufferChange = false;
                     try
@@ -154,6 +157,8 @@ namespace HelixToolkit.Wpf.SharpDX
                         EndD3D();
                     }
                 }
+
+                lastSurfaceD3DIsFrontBufferAvailable = newValue;
             }
 
             protected override void OnDispose(bool disposeManagedResources)


### PR DESCRIPTION
[This commit ](https://github.com/helix-toolkit/helix-toolkit/commit/3cbb378cac8ae557966ebc79827274b394b00ae8) seems to cause an infinite chain of calls to `DX11ImageSourceArgs.SurfaceD3D_IsFrontBufferAvailableChanged()` when connected with RDP.

This merge request solved the problem in the simplest possible way by saving the old value and only running the rest of the code in the event handler if there is an actual change. Note that `e.OldValue` has a different value than `lastSurfaceD3DIsFrontBufferAvailable` for all events except the first int the chain.

This feels like a hack. I suspect that the large number of events are related to [this deletion](https://github.com/helix-toolkit/helix-toolkit/commit/3cbb378cac8ae557966ebc79827274b394b00ae8#diff-b2c1ac517d2b01a3da3aaacd285547a3557249b1437c77d6cab81b67360a440eL122), but it looks like those rows where removed for a reason. I'm a bit disappointed with myself that I tested #1533 when not on RDP but I forgot to test it while using RDP from home :-).

This is what the log looks like when starting CrossSectionDemo (before the changes in this merge request):
```
Step into: Stepping over non-user code 'CrossSectionDemo.App..ctor'
Step into: Stepping over non-user code 'CrossSectionDemo.App.InitializeComponent'
Build static tree time =8,7582; Total = 31
Build static tree time =0,0659; Total = 5
Level: Information; Class: EffectsManager; Caller: GetBestAdapter; Line: 439; Text: Trying to get best adapter. Number of adapters: 2;
Level: Information; Class: EffectsManager; Caller: GetBestAdapter; Line: 444; Text: Adapter 0: Description: AMD Radeon Pro WX 3100; VendorId: 4098; Video Mem: 4076 MB; System Mem: 0 MB; Shared Mem: 16243 MB; Num Outputs: 2;
Level: Information; Class: EffectsManager; Caller: GetBestAdapter; Line: 461; Text: Feature Level: Level_11_0;
Level: Information; Class: EffectsManager; Caller: GetBestAdapter; Line: 444; Text: Adapter 1: Description: Microsoft Basic Render Driver; VendorId: 5140; Video Mem: 0 MB; System Mem: 0 MB; Shared Mem: 16243 MB; Num Outputs: 0;
Level: Information; Class: EffectsManager; Caller: GetBestAdapter; Line: 461; Text: Feature Level: Level_11_0;
Level: Information; Class: EffectsManager; Caller: GetBestAdapter; Line: 478; Text: Best Adapter: 0;
Level: Information; Class: EffectsManager; Caller: Initialize; Line: 271; Text: Adapter Index = 0;
Level: Information; Class: EffectsManager; Caller: Initialize; Line: 306; Text: Direct3D device initilized. DriverType: Hardware; FeatureLevel: Level_11_0;
Level: Information; Class: EffectsManager; Caller: Initialize; Line: 309; Text: Initializing resource pools;
Level: Information; Class: EffectsManager; Caller: Initialize; Line: 331; Text: Initializing Direct2D resources;
Created new TextureModel. Guid: 9aec872e-44e3-465a-a090-b449228c59b0
Created new TextureModel. Guid: 8c64f43a-bfef-416f-af4d-655014124890
Created new TextureModel. Guid: 4db369fd-2cf6-45dc-a33c-a8d62616bd34
Created new TextureModel. Guid: bcce8fef-4945-4b53-8599-ef4f18281390
Created new TextureModel. Guid: 5c345777-c737-47df-a6bc-e73e7d3ab446
Created new TextureModel. Guid: ab360391-156f-4a72-8d61-aaf308bc40f2
Created new TextureModel. Guid: 5b1f1125-c38e-43d8-acd7-3fdc5078f4ed
Build static tree time =2502,4897; Total = 72044
Created new TextureModel. Guid: 3f106117-7fc3-4f55-94eb-cc60af4a9146
Level: Information; Class: DX11RenderHostBase; Caller: EffectsManager; Line: 204; Text: Set new EffectsManager;;
Level: Information; Class: DX11RenderHostBase; Caller: StartD3D; Line: 817; Text: Width = 0; Height = 0;;
Level: Information; Class: DX11RenderHostBase; Caller: CreateAndBindBuffers; Line: 865; Text: ;
Level: Information; Class: DefaultRenderHost; Caller: CreateRenderBuffer; Line: 73; Text: DX11Texture2DRenderBufferProxy;
Create new D3DImageSource
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartD3D; Line: 840; Text: Initialized.;
Level: Information; Class: DX11RenderHostBase; Caller: AttachRenderable; Line: 922; Text: ;
Buffer not found, create new buffer. GeomoetryGUID = 7e26c6ba-ebcd-4caa-81f3-fae00a692d49
Buffer not found, create new buffer. GeomoetryGUID = ae32c9de-d431-4fb9-807c-8601fb7173c5
Buffer not found, create new buffer. GeomoetryGUID = 2fa01a6a-56d5-41fb-9b80-e1136cedc17d
Buffer not found, create new buffer. GeomoetryGUID = 39c2b745-7d3a-4a17-b97e-d4bca812f9aa
Existing buffer found, GeomoetryGUID = 2fa01a6a-56d5-41fb-9b80-e1136cedc17d
Existing buffer found, GeomoetryGUID = 39c2b745-7d3a-4a17-b97e-d4bca812f9aa
Buffer not found, create new buffer. GeomoetryGUID = 1b671afe-e200-4cc9-bc3c-b8117fb728d5
Buffer not found, create new buffer. GeomoetryGUID = dd400286-2e74-472d-a3bb-8fad8cdd0f47
Buffer not found, create new buffer. GeomoetryGUID = 395ff9c9-5d36-4b21-8017-38e83e1f62e0
Created new TextureModel. Guid: d95830f0-a722-4e5f-bbf6-3fe9804543b7
Creating new texture resource
Buffer not found, create new buffer. GeomoetryGUID = b1ed5b1d-7e4c-45eb-a904-476210b2e331
Buffer not found, create new buffer. GeomoetryGUID = 7d699668-8c02-4146-b066-0549dbd07a00
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Level: Warning; Class: ; Caller: SurfaceD3D_IsFrontBufferAvailableChanged; Line: 122; Text: SurfaceD3D front buffer changed. Value = False, last value False;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 0; Height = 0;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Create new D3DImageSource
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 695; Height = 561;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Flatten Scene Graph
Get PerFrameRenderables
Created new thread buffer. Type: HelixToolkit.Wpf.SharpDX.DefaultVertex; Size: 42823 kB.
Get PerFrameRenderables
Level: Warning; Class: ; Caller: SurfaceD3D_IsFrontBufferAvailableChanged; Line: 122; Text: SurfaceD3D front buffer changed. Value = False, last value False;
Level: Warning; Class: ; Caller: PostRender; Line: 55; Text: Back buffer is not set.;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 0; Height = 0;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Create new D3DImageSource
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 695; Height = 561;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Flatten Scene Graph
Get PerFrameRenderables
Level: Warning; Class: ; Caller: SurfaceD3D_IsFrontBufferAvailableChanged; Line: 122; Text: SurfaceD3D front buffer changed. Value = False, last value False;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 0; Height = 0;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Create new D3DImageSource
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 695; Height = 561;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Flatten Scene Graph
Get PerFrameRenderables
Level: Warning; Class: ; Caller: SurfaceD3D_IsFrontBufferAvailableChanged; Line: 122; Text: SurfaceD3D front buffer changed. Value = False, last value False;
Level: Warning; Class: ; Caller: PostRender; Line: 55; Text: Back buffer is not set.;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 0; Height = 0;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Create new D3DImageSource
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 695; Height = 561;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Flatten Scene Graph
Get PerFrameRenderables
Level: Warning; Class: ; Caller: SurfaceD3D_IsFrontBufferAvailableChanged; Line: 122; Text: SurfaceD3D front buffer changed. Value = False, last value False;
Level: Warning; Class: ; Caller: PostRender; Line: 55; Text: Back buffer is not set.;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 0; Height = 0;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Create new D3DImageSource
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 695; Height = 561;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Flatten Scene Graph
Get PerFrameRenderables
Level: Warning; Class: ; Caller: SurfaceD3D_IsFrontBufferAvailableChanged; Line: 122; Text: SurfaceD3D front buffer changed. Value = False, last value False;
Level: Warning; Class: ; Caller: PostRender; Line: 55; Text: Back buffer is not set.;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 0; Height = 0;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Create new D3DImageSource
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
Level: Information; Class: DX11RenderHostBase; Caller: Resize; Line: 1031; Text: Width = 695; Height = 561;;
Level: Information; Class: DX11RenderHostBase; Caller: StopRendering; Line: 985; Text: ;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: ; Caller: DX11ImageSourceRenderer_OnNewBufferCreated; Line: 105; Text: New back buffer is set.;
Level: Information; Class: DX11RenderHostBase; Caller: StartRendering; Line: 852; Text: ;
```