### PR TITLE
Fix RenderContext.BoundingFrustum for non-perspective cameras.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
@@ -415,11 +415,11 @@ namespace HelixToolkit.UWP
             // viewport: W,H,1/W,1/H
             globalTransform.Viewport = new Vector4((float)ActualWidth, (float)ActualHeight, 1f / (float)ActualWidth, 1f / (float)ActualHeight);
             CameraParams = this.camera.CreateCameraParams(aspectRatio);
-            BoundingFrustum = BoundingFrustum.FromCamera(CameraParams);
+            BoundingFrustum = new BoundingFrustum(ViewMatrix * ProjectionMatrix);
             // frustum: FOV,AR,N,F
             globalTransform.Frustum = new Vector4(CameraParams.FOV, CameraParams.AspectRatio, CameraParams.ZNear, CameraParams.ZFar);
             globalTransform.EyePos = CameraParams.Position;
-            IsPerspective = CameraParams.FOV < (Math.PI / 2 - 1e-4);
+            IsPerspective = !BoundingFrustum.IsOrthographic;
             globalTransform.IsPerspective = IsPerspective;
         }
 


### PR DESCRIPTION
`BoundingFrustum.FromCamera()` relies on the perspective camera parameters. It results in incorrect frustum for the orthographic camera. This, in turn, leads to incorrect frustum tests and some objects become invisible.

Construct the `BoundingFrustum` from the view-projection matrix instead. This produces correct frustum for both perspective and orthographic cameras. This merge request also fixes `RenderContext.IsPerspective`: the perspective camera does not necessarily have FOV < 𝜋/2.