### PR TITLE
Critical bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 1. Bugfix export without material (Assimp)
 1. Fixed bounding box is not updated properly. #1555 (WPF.SharpDX/UWP/Core) 
 1. Fixed Frustum test bug. (WPF.SharpDX/UWP/Core) 
+1. Fix shadow map OrthoWidth dependency property is setting to wrong property in scene node.(WPF.SharpDX/UWP)
 
 ## [2.15.0] - 2021-02-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Please use the following template to report bugs.
 
 ## News
 
+
+#### 2021-04-24
+[v2.16.0](https://github.com/helix-toolkit/helix-toolkit/tree/release/2.16.0) releases are available on nuget. [Release Note](/CHANGELOG.md)
+- [WPF](https://www.nuget.org/packages/HelixToolkit.Wpf/2.16.0)
+- [Core.WPF](https://www.nuget.org/packages/HelixToolkit.Core.Wpf/2.16.0)
+- [WPF.Input](https://www.nuget.org/packages/HelixToolkit.Wpf.Input/2.16.0)
+- [WPF.SharpDX](https://www.nuget.org/packages/HelixToolkit.Wpf.SharpDX/2.16.0)
+- [UWP](https://www.nuget.org/packages/HelixToolkit.UWP/2.16.0)
+- [SharpDX.Core](https://www.nuget.org/packages/HelixToolkit.SharpDX.Core/2.16.0)
+- [SharpDX.Core.Wpf](https://www.nuget.org/packages/HelixToolkit.SharpDX.Core.Wpf/2.16.0)
+- [SharpDX.Assimp](https://www.nuget.org/packages/HelixToolkit.SharpDX.Assimp/2.16.0)
+
 #### 2021-02-20
 [v2.15.0](https://github.com/helix-toolkit/helix-toolkit/tree/release/2.15.0) releases are available on nuget. [Release Note](/CHANGELOG.md)
 - [WPF](https://www.nuget.org/packages/HelixToolkit.Wpf/2.15.0)
@@ -109,16 +121,5 @@ Please use the following template to report bugs.
 - [SharpDX.Core](https://www.nuget.org/packages/HelixToolkit.SharpDX.Core/2.14.0)
 - [SharpDX.Core.Wpf](https://www.nuget.org/packages/HelixToolkit.SharpDX.Core.Wpf/2.14.0)
 - [SharpDX.Assimp](https://www.nuget.org/packages/HelixToolkit.SharpDX.Assimp/2.14.0)
-
-#### 2020-10-17
-[v2.13.1](https://github.com/helix-toolkit/helix-toolkit/tree/release/2.13.1) releases are available on nuget. [Release Note](/CHANGELOG.md)
-- [WPF](https://www.nuget.org/packages/HelixToolkit.Wpf/2.13.1)
-- [Core.WPF](https://www.nuget.org/packages/HelixToolkit.Core.Wpf/2.13.1)
-- [WPF.Input](https://www.nuget.org/packages/HelixToolkit.Wpf.Input/2.13.1)
-- [WPF.SharpDX](https://www.nuget.org/packages/HelixToolkit.Wpf.SharpDX/2.13.1)
-- [UWP](https://www.nuget.org/packages/HelixToolkit.UWP/2.13.1)
-- [SharpDX.Core](https://www.nuget.org/packages/HelixToolkit.SharpDX.Core/2.13.1)
-- [SharpDX.Core.Wpf](https://www.nuget.org/packages/HelixToolkit.SharpDX.Core.Wpf/2.13.1)
-- [SharpDX.Assimp](https://www.nuget.org/packages/HelixToolkit.SharpDX.Assimp/2.13.1)
 
 #### Changes (Please refer to [Release Note](https://github.com/helix-toolkit/helix-toolkit/blob/master/CHANGELOG.md) for details)


### PR DESCRIPTION
1. Fix RenderContext.BoundingFrustum for non-perspective cameras. 
2. Handle too many SurfaceD3D_IsFrontBufferAvailableChanged 