### PR TITLE
Fix BatchedMeshGeometryModel3D blinking when BatchedGeometries update

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Core/Batching/StaticGeometryBatchingBufferBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Batching/StaticGeometryBatchingBufferBase.cs
@@ -209,11 +209,12 @@ namespace HelixToolkit.UWP
             /// <param name="deviceResources">The device resources.</param>
             /// <returns></returns>
             public bool AttachBuffers(DeviceContextProxy context, ref int vertexBufferStartSlot, IDeviceResources deviceResources)
-            {        
-                if (!Commit(context) && vertexBufferBindings.Length > 0)
+            {
+                Commit(context);
+                if (vertexBufferBindings.Length > 0)
                 {
                     context.SetVertexBuffers(vertexBufferStartSlot, vertexBufferBindings);
-                    ++vertexBufferStartSlot;
+                    vertexBufferStartSlot += vertexBufferBindings.Length;
                 }
                 else
                 {


### PR DESCRIPTION
`StaticGeometryBatchingBufferBase<BatchedGeometry, VertStruct>.Commit(DeviceContextProxy)` return value is always equal to `isGeometryChanged`. The `if (!Commit(context)` condition in `AttachBuffers` causes the renderer to skip rendering the node in the first frame after the geometries update, and the new geometries will only be rendered to the second and subsequent frames. This causes a noticeable 'blink' immediately after we update `BatchedMeshGeometryModel3D.BatchedGeometries`.

To avoid the 'blink', we need to render the node regardless of whether the geometries did change or not.
