### PR TITLE
Added null check in IRenderMetricesExtensions.UnProject()

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/IRenderMetricesExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/IRenderMetricesExtensions.cs
@@ -25,6 +25,12 @@ namespace HelixToolkit.UWP
         /// <returns></returns>
         public static bool UnProject(this IRenderMatrices renderMatrices, Vector2 point2d, out Ray ray)//, out Vector3 pointNear, out Vector3 pointFar)
         {
+            if (renderMatrices == null)
+            {
+                ray = new Ray();
+                return false;
+            }
+
             renderMatrices.Update();
             var px = point2d.X;
             var py = point2d.Y;

--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/IViewportExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/IViewportExtensions.cs
@@ -172,7 +172,8 @@ namespace HelixToolkit.UWP
         /// <returns></returns>
         public static bool UnProject(this IViewport3DX viewport, Vector2 point2d, out Ray ray)
         {
-            if (viewport.RenderHost != null)
+            var renderContext = viewport.RenderHost?.RenderContext;
+            if (renderContext != null)
             {
                 return viewport.RenderHost.RenderContext.UnProject(point2d, out ray);
             }


### PR DESCRIPTION
I got the following stack trace when starting my application. It is probably a symptom of initializing objects in the wrong order, but since there was a pattern for handling null I added some more checks. Don't bother releasing a bug fix of the NuGet for me, I've only seen this once but the small change should prevent it from happening again.

```
System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=HelixToolkit.SharpDX.Core
  StackTrace:
   at HelixToolkit.SharpDX.Core.IRenderMetricesExtensions.UnProject(IRenderMatrices renderMatrices, Vector2 point2d, Ray& ray)
   at HelixToolkit.SharpDX.Core.IViewportExtensions.UnProject(IViewport3DX viewport, Vector2 point2d, Ray& ray)
   at HelixToolkit.SharpDX.Core.IViewportExtensions.FindHitsInFrustum(IViewport3DX viewport, Vector2 pos, List`1& hits)
   at HelixToolkit.SharpDX.Core.IViewportExtensions.FindNearest(IViewport3DX viewport, Vector2 position, Vector3& point, Vector3& normal, Object& model)
   at HelixToolkit.Wpf.SharpDX.ViewportExtensions.FindNearestPoint(Viewport3DX viewport, Point position)
   at HelixToolkit.Wpf.SharpDX.Viewport3DX.FindNearestPoint(Point pt)
   at HelixToolkit.Wpf.SharpDX.Viewport3DX.UpdateCurrentPosition(Point pt)
   at HelixToolkit.Wpf.SharpDX.Viewport3DX.OnMouseMove(MouseEventArgs e)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at System.Windows.Input.InputManager.ProcessStagingArea()
   at System.Windows.Input.MouseDevice.Synchronize()
   at System.Windows.Input.Mouse.Synchronize()
   at System.Windows.Controls.Primitives.Track.OnIsEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
   at System.Windows.FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   at System.Windows.DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
   at System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
   at System.Windows.DependencyObject.CoerceValue(DependencyProperty dp)
   at System.Windows.FrameworkElement.InvalidateForceInheritPropertyOnChildren(DependencyProperty property)
   at System.Windows.UIElement.OnIsEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
   at System.Windows.FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   at System.Windows.DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
   at System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
   at System.Windows.DependencyObject.CoerceValue(DependencyProperty dp)
   at System.Windows.UIElement.InvalidateForceInheritPropertyOnChildren(Visual v, DependencyProperty property)
   at System.Windows.Media.Visual.InvalidateForceInheritPropertyOnChildren(DependencyProperty property)
   at System.Windows.FrameworkElement.InvalidateForceInheritPropertyOnChildren(DependencyProperty property)
   at System.Windows.UIElement.OnIsEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
   at System.Windows.FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   at System.Windows.DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
   at System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
   at System.Windows.DependencyObject.CoerceValue(DependencyProperty dp)
   at System.Windows.Controls.Primitives.ScrollBar.ViewChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
   at System.Windows.FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   at System.Windows.DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
   at System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
   at System.Windows.DependencyObject.InvalidateProperty(DependencyProperty dp, Boolean preserveCurrentValue)
   at System.Windows.StyleHelper.InvalidateDependents(Style ownerStyle, FrameworkTemplate frameworkTemplate, DependencyObject container, DependencyProperty dp, FrugalStructList`1& dependents, Boolean invalidateOnlyContainer)
   at System.Windows.StyleHelper.OnTriggerSourcePropertyInvalidated(Style ownerStyle, FrameworkTemplate frameworkTemplate, DependencyObject container, DependencyProperty dp, DependencyPropertyChangedEventArgs changedArgs, Boolean invalidateOnlyContainer, FrugalStructList`1& triggerSourceRecordFromChildIndex, FrugalMap& propertyTriggersWithActions, Int32 sourceChildIndex)
   at System.Windows.FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   at System.Windows.DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
   at System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
   at System.Windows.DependencyObject.SetValueCommon(DependencyProperty dp, Object value, PropertyMetadata metadata, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType, Boolean isInternal)
   at System.Windows.DependencyObject.SetValue(DependencyPropertyKey key, Object value)
   at System.Windows.Controls.ScrollViewer.OnLayoutUpdated(Object sender, EventArgs e)
   at System.Windows.ContextLayoutManager.fireLayoutUpdateEvent()
   at System.Windows.ContextLayoutManager.UpdateLayout()
   at System.Windows.ContextLayoutManager.UpdateLayoutCallback(Object arg)
   at System.Windows.Media.MediaContext.FireInvokeOnRenderCallbacks()
   at System.Windows.Media.MediaContext.RenderMessageHandlerCore(Object resizedCompositionTarget)
   at System.Windows.Media.MediaContext.RenderMessageHandler(Object resizedCompositionTarget)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
   at MS.Internal.CulturePreservingExecutionContext.CallbackWrapper(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Windows.Threading.DispatcherOperation.Invoke()
   at System.Windows.Threading.Dispatcher.ProcessQueue()
  at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.Run()
   at System.Windows.Application.RunDispatcher(Object ignore)
   at System.Windows.Application.RunInternal(Window window)
   at System.Windows.Application.Run()
```