### PR TITLE
Adds top most rendering support and auto cover complete scene for shadow map

### DIFF
--- a/Source/Examples/WPF.SharpDX/BillboardDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/BillboardDemo/MainWindow.xaml
@@ -65,19 +65,22 @@
                 CullMode="Back"
                 Geometry="{Binding SphereModel}"
                 Material="{Binding EarthMaterial}" />
-            <hx:BillboardTextModel3D FixedSize="False" Geometry="{Binding FlagsBillboard}" />
-            <hx:BillboardTextModel3D
-                FixedSize="False"
-                Geometry="{Binding SelectedFlagBillboard}"
-                IsHitTestVisible="False" />
-            <hx:BillboardTextModel3D FixedSize="True" Geometry="{Binding LandmarkBillboards}" />
-            <hx:BillboardTextModel3D FixedSize="True" Geometry="{Binding LandmarkBillboards2}" />
-            <hx:BillboardTextModel3D
-                FixedSize="True"
-                Geometry="{Binding BatchedText}"
-                IsHitTestVisible="False" />
+            <hx:TopMostGroup3D x:Name="topMostGroup" EnableTopMost="False">
+                <hx:BillboardTextModel3D FixedSize="False" Geometry="{Binding FlagsBillboard}" />
+                <hx:BillboardTextModel3D
+                    FixedSize="False"
+                    Geometry="{Binding SelectedFlagBillboard}"
+                    IsHitTestVisible="False" />
+                <hx:BillboardTextModel3D FixedSize="True" Geometry="{Binding LandmarkBillboards}" />
+                <hx:BillboardTextModel3D FixedSize="True" Geometry="{Binding LandmarkBillboards2}" />
+                <hx:BillboardTextModel3D
+                    FixedSize="True"
+                    Geometry="{Binding BatchedText}"
+                    IsHitTestVisible="False" />
+            </hx:TopMostGroup3D>
         </hx:Viewport3DX>
         <StackPanel Grid.Column="1" Orientation="Vertical">
+            <CheckBox IsChecked="{Binding ElementName=topMostGroup, Path=EnableTopMost}">Billboard Top most</CheckBox>
             <TextBlock Margin="2" Foreground="Blue">Drag Flag onto Earth</TextBlock>
             <Separator />
             <ListBox

--- a/Source/Examples/WPF.SharpDX/LightingDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/LightingDemo/MainWindow.xaml
@@ -54,7 +54,7 @@
                 <MouseBinding Command="hx:ViewportCommands.Zoom" Gesture="MiddleClick" />
                 <MouseBinding Command="hx:ViewportCommands.Pan" Gesture="LeftClick" />
             </hx:Viewport3DX.InputBindings>
-            <hx:ShadowMap3D />
+            <hx:ShadowMap3D AutoCoverCompleteScene="True" IsSceneDynamic="True"/>
             <!--<hx:AmbientLight3D Color="{Binding AmbientLightColor}" />-->
             <hx:DirectionalLight3D
                 Direction="{Binding Light1Direction}"

--- a/Source/HelixToolkit.SharpDX.Shared/Core/TopMostMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/TopMostMeshRenderCore.cs
@@ -1,0 +1,55 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2021 Helix Toolkit contributors
+*/
+using SharpDX.Direct3D11;
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    namespace Core
+    {
+        using Shaders;
+        using Render;
+        using Components;
+        /// <summary>
+        /// Clears the depth buffer and reset global transform.
+        /// </summary>
+        public class TopMostMeshRenderCore: RenderCore
+        {
+            private readonly ConstantBufferComponent globalTransformCB;
+            public TopMostMeshRenderCore() : base(RenderType.ScreenSpaced)
+            {
+                globalTransformCB = AddComponent(new ConstantBufferComponent(new ConstantBufferDescription(DefaultBufferNames.GlobalTransformCB, GlobalTransformStruct.SizeInBytes)));
+            }
+            public override void Render(RenderContext context, DeviceContextProxy deviceContext)
+            {
+                if (RenderType != RenderType.ScreenSpaced)
+                {
+                    return;
+                }
+                deviceContext.GetDepthStencilView(out DepthStencilView dsView);
+                if (dsView == null)
+                {
+                    return;
+                }
+
+                deviceContext.ClearDepthStencilView(dsView, DepthStencilClearFlags.Depth, 1f, 0);
+                dsView.Dispose();
+                var globalTrans = context.GlobalTransform;
+                globalTransformCB.Upload(deviceContext, ref globalTrans);
+            }
+
+            protected override bool OnAttach(IRenderTechnique technique)
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -48,6 +48,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\DynamicCubeMapCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\EmptyRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\AxisPlaneGridCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\TopMostMeshRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\InstancingBillboardRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\InstancingMeshRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\Lights\DirectionalLightCore.cs" />
@@ -191,6 +192,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\ContinuousRenderNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\DynamicCodeSurface3DNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\AxisPlaneGridNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\TopMostGroupNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\PostEffects\NodePostEffectXRayGrid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\ScreenQuadNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\Sprite2DNode.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -355,7 +355,10 @@ namespace HelixToolkit.UWP
         /// The render buffer.
         /// </value>
         DX11RenderBufferProxyBase RenderBuffer { get; }
-
+        /// <summary>
+        /// Occurs when [scene graph updated].
+        /// </summary>
+        event EventHandler SceneGraphUpdated;
         /// <summary>
         /// Clears the render target.
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
@@ -122,7 +122,43 @@ namespace HelixToolkit.UWP
             {
                 set; get;
             } = null;
-
+            /// <summary>
+            /// Gets or sets a value indicating whether shadow map should automatically cover complete scene. Only effective with directional light.
+            /// <para>Limitation: Currently unable to properly cover BoneSkinned model animation.</para>
+            /// </summary>
+            /// <value>
+            ///   <c>true</c> if [automatic cover complete scene]; otherwise, <c>false</c>.
+            /// </value>
+            public bool AutoCoverCompleteScene
+            {
+                set; get;
+            } = false;
+            /// <summary>
+            /// Gets or sets a value indicating whether the scene is dynamic. Only effective if <see cref="AutoCoverCompleteScene"/> is true.
+            /// <para>Setting to true will force shadow map to update the shadow camera for each frame. May impact the performance.</para>
+            /// </summary>
+            /// <value>
+            ///   <c>true</c> if scene is dynamic; otherwise, <c>false</c>.
+            /// </value>
+            public bool IsSceneDynamic
+            {
+                set; get;
+            } = false;
+            /// <summary>
+            /// Gets or sets the shadow cast scene scale. Only effective if <see cref="AutoCoverCompleteScene"/> is true.
+            /// <para>
+            /// This is used if the mesh render shadow is much bigger than the meshes casting shadow.
+            /// The shadow cast camera has to cover the shadow rendering region, otherwise the shadow maybe cut off.
+            /// Increase the value to increase the shadow cast camera rendering region.
+            /// </para>
+            /// </summary>
+            /// <value>
+            /// Region scale for shadow cast.
+            /// </value>
+            public float CastSceneScale
+            {
+                set; get;
+            } = 2f;
             /// <summary>
             /// Called when [create render core].
             /// </summary>
@@ -138,7 +174,7 @@ namespace HelixToolkit.UWP
 
             private readonly OrthographicCameraCore orthoCamera = new OrthographicCameraCore() { NearPlaneDistance = 1, FarPlaneDistance = 500 };
             private readonly PerspectiveCameraCore persCamera = new PerspectiveCameraCore() { NearPlaneDistance = 1, FarPlaneDistance = 500 };
-
+            private bool sceneChanged = false;
             /// <summary>
             /// Assigns the default values to core.
             /// </summary>
@@ -165,7 +201,23 @@ namespace HelixToolkit.UWP
             {
                 base.OnAttach(host);
                 shadowCore = RenderCore as ShadowMapCore;
+                host.SceneGraphUpdated += Host_SceneGraphUpdated;
+                sceneChanged = true;
                 return true;
+            }
+
+            protected override void OnDetach()
+            {
+                if (RenderHost != null)
+                {
+                    RenderHost.SceneGraphUpdated -= Host_SceneGraphUpdated;
+                }
+                base.OnDetach();
+            }
+
+            private void Host_SceneGraphUpdated(object sender, System.EventArgs e)
+            {
+                sceneChanged = true;
             }
 
             /// <summary>
@@ -176,6 +228,88 @@ namespace HelixToolkit.UWP
             protected override bool CanRender(RenderContext context)
             {
                 return base.CanRender(context) && RenderHost.IsShadowMapEnabled;
+            }
+
+            private BoundingBox FindSceneBound(FastList<SceneNode> nodes)
+            {
+                var box = new BoundingBox();
+                if (nodes.Count > 0)
+                {
+                    foreach (var node in nodes.Where(x => x is IThrowingShadow k && k.IsThrowingShadow))
+                    {
+                        if (node.BoundsWithTransform.Minimum == node.BoundsWithTransform.Maximum)
+                        {
+                            continue;
+                        }
+                        if (box.Minimum == box.Maximum)
+                        {
+                            box = node.BoundsWithTransform;
+                        }
+                        else
+                        {
+                            box = BoundingBox.Merge(box, node.BoundsWithTransform);
+                        }
+                    }
+                }
+                return box;
+            }
+
+            private unsafe bool CreateCameraFromBound(ref BoundingBox box, ref Vector3 lookDir)
+            {
+                if (box.Maximum == box.Minimum)
+                {
+                    return false;
+                }
+                var center = box.Center;
+                var dist = 0.0f;
+                var points = stackalloc Vector3[8];
+                points[0] = box.Minimum;
+                points[1] = box.Maximum;
+                points[2] = new Vector3(box.Minimum.X, box.Minimum.Y, box.Maximum.Z);
+                points[3] = new Vector3(box.Minimum.X, box.Maximum.Y, box.Maximum.Z);
+                points[4] = new Vector3(box.Maximum.X, box.Maximum.Y, box.Minimum.Z);
+                points[5] = new Vector3(box.Maximum.X, box.Minimum.Y, box.Minimum.Z);
+                points[6] = new Vector3(box.Minimum.X, box.Maximum.Y, box.Minimum.Z);
+                points[7] = new Vector3(box.Maximum.X, box.Minimum.Y, box.Maximum.Z);
+                var plane = new Plane(center, lookDir);
+                Vector3 farthest = Vector3.Zero;
+                float farestDist = 0f;
+
+                for (int i = 0; i < 8; ++i)
+                {
+                    Vector3.Dot(ref plane.Normal, ref points[i], out var dot);
+                    dot += plane.D;
+                    if (dot > 0)
+                    {
+                        continue;
+                    }
+                    float t = dot - plane.D;
+                    var v = points[i] - (t * plane.Normal);
+                    var vDist = v.Length();
+                    if (vDist > farestDist)
+                    {
+                        farthest = points[i];
+                        farestDist = vDist;
+                    }
+                }
+
+                dist = farestDist * CastSceneScale + 0.1f;
+                var pos = center + (-lookDir * dist);
+                orthoCamera.Position = pos;
+                orthoCamera.LookDirection = center - pos;
+                orthoCamera.Width = dist * 2;
+                orthoCamera.NearPlaneDistance = 0.1f;
+                orthoCamera.FarPlaneDistance = dist * 2;
+                orthoCamera.UpDirection = lookDir.FindAnyPerpendicular();
+                return true;
+            }
+
+            private void SetOrthoCameraParameters(ref Vector3 lookDir)
+            {
+                orthoCamera.LookDirection = lookDir * distance;
+                orthoCamera.Position = -lookDir * distance;
+                orthoCamera.UpDirection = Vector3.UnitZ;
+                orthoCamera.Width = orthoWidth;
             }
 
             private void Core_OnUpdateLightSource(object sender, ShadowMapCore.UpdateLightSourceEventArgs e)
@@ -189,12 +323,24 @@ namespace HelixToolkit.UWP
                         if (light.LightType == LightType.Directional)
                         {
                             var dlight = light.RenderCore as DirectionalLightCore;
-                            var dir = Vector3.TransformNormal(dlight.Direction, dlight.ModelMatrix).Normalized() * distance;
-                            orthoCamera.LookDirection = dir;
-                            orthoCamera.Position = -dir;
-                            orthoCamera.UpDirection = Vector3.UnitZ;
-                            orthoCamera.Width = orthoWidth;
-                            camera = orthoCamera;
+                            var dir = Vector3.TransformNormal(dlight.Direction, dlight.ModelMatrix).Normalized();
+                            if (AutoCoverCompleteScene)
+                            {
+                                if (sceneChanged || IsSceneDynamic)
+                                {
+                                    sceneChanged = false;
+                                    var boundingBox = FindSceneBound(e.Context.RenderHost.PerFrameOpaqueNodes);
+                                    if (!CreateCameraFromBound(ref boundingBox, ref dir))
+                                    {
+                                        SetOrthoCameraParameters(ref dir);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                SetOrthoCameraParameters(ref dir);
+                            }
+                            camera = orthoCamera;  
                             break;
                         }
                         else if (light.LightType == LightType.Spot)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/TopMostGroupNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/TopMostGroupNode.cs
@@ -1,0 +1,49 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2021 Helix Toolkit contributors
+*/
+using SharpDX;
+using System;
+using System.Collections.Generic;
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    namespace Model.Scene
+    {
+        using Core;
+        using Cameras;
+        /// <summary>
+        /// Provides a way to render child elements always on top of other elements.
+        /// This is rendered at the same level of screen spaced group items.
+        /// Child items do not support post effects.
+        /// </summary>
+        public class TopMostGroupNode : GroupNode
+        {
+            private bool enableTopMost = false;
+            public bool EnableTopMost
+            {
+                set
+                {
+                    if (SetAffectsRender(ref enableTopMost, value))
+                    {
+                        RenderType = value ? RenderType.ScreenSpaced : RenderType.Opaque;
+                    }
+                }
+                get => enableTopMost;
+            }
+            protected override RenderCore OnCreateRenderCore()
+            {
+                var core = new TopMostMeshRenderCore();
+                return core;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -220,7 +220,10 @@ namespace HelixToolkit.UWP
                 base.PreRender(invalidateSceneGraph, invalidatePerFrameRenderables);
 
                 SeparateRenderables(RenderContext, invalidateSceneGraph, invalidatePerFrameRenderables);
-
+                if (invalidateSceneGraph)
+                {
+                    TriggerSceneGraphUpdated();
+                }
                 asyncTask = Task.Factory.StartNew(() =>
                 {
                     renderer?.UpdateNotRenderParallel(RenderContext, perFrameFlattenedScene);

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -561,6 +561,8 @@ namespace HelixToolkit.UWP
             private readonly Func<IDevice3DResources, IRenderer> createRendererFunction;
 
             public event EventHandler<BoolArgs> FrustumEnabledChanged;
+
+            public event EventHandler SceneGraphUpdated;
     #endregion
 
     #region Private variables
@@ -1093,6 +1095,11 @@ namespace HelixToolkit.UWP
                         EffectsManager?.Reinitialize();
                     }
                 }, null);
+            }
+
+            protected void TriggerSceneGraphUpdated()
+            {
+                SceneGraphUpdated?.Invoke(this, EventArgs.Empty);
             }
             /// <summary>
             /// Releases unmanaged and - optionally - managed resources.

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
@@ -95,6 +95,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// Occurs when each render frame finished rendering.
         /// </summary>
         public event EventHandler Rendered;
+
+        public event EventHandler SceneGraphUpdated;
 #pragma warning restore 0067
         /// <summary>
         /// Gets the unique identifier.

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/TopMostGroup3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/TopMostGroup3D.cs
@@ -1,0 +1,64 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2021 Helix Toolkit contributors
+*/
+#if NETFX_CORE
+using Windows.UI.Xaml;
+namespace HelixToolkit.UWP
+#else
+#if COREWPF
+using HelixToolkit.SharpDX.Core.Model.Scene;
+#endif
+using System.Windows;
+namespace HelixToolkit.Wpf.SharpDX
+#endif
+{
+#if !COREWPF
+    using Model.Scene;
+#endif
+    using Model;
+    /// <summary>
+    /// Provides a way to render child elements always on top of other elements
+    /// This is rendered at the same level of screen spaced group items.
+    /// Child items do not support post effects.
+    /// </summary>
+    public class TopMostGroup3D : GroupModel3D
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether [enable top most mode].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [enable top most mode]; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnableTopMost
+        {
+            get
+            {
+                return (bool)GetValue(EnableTopMostProperty);
+            }
+            set
+            {
+                SetValue(EnableTopMostProperty, value);
+            }
+        }
+
+        // Using a DependencyProperty as the backing store for EnableTopMost.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty EnableTopMostProperty =
+            DependencyProperty.Register("EnableTopMost", typeof(bool), typeof(TopMostGroup3D), new PropertyMetadata(true, (d, e) => 
+            {
+                ((d as Element3DCore).SceneNode as TopMostGroupNode).EnableTopMost = (bool)e.NewValue;
+            }));
+
+
+        protected override SceneNode OnCreateSceneNode()
+        {
+            return new TopMostGroupNode();
+        }
+
+        protected override void AssignDefaultValuesToSceneNode(SceneNode node)
+        {
+            (node as TopMostGroupNode).EnableTopMost = EnableTopMost;
+            base.AssignDefaultValuesToSceneNode(node);
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.SharedModel/HelixToolkit.SharpDX.SharedModel.projitems
+++ b/Source/HelixToolkit.SharpDX.SharedModel/HelixToolkit.SharpDX.SharedModel.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\AxisPlaneGridModel3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\PointGeometryModel3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\PointMaterialGeometryModel3D.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Element3D\TopMostGroup3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\PostEffects\PostEffectBloom.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\PostEffects\PostEffectMeshBorderHighlight.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Element3D\PostEffects\PostEffectMeshOutlineBlur.cs" />

--- a/Source/HelixToolkit.SharpDX.SharedModel/Light3D/ShadowMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Light3D/ShadowMap3D.cs
@@ -26,7 +26,7 @@ namespace HelixToolkit.Wpf.SharpDX
     /// </summary>
     public class ShadowMap3D : Element3D
     {
-        
+
         /// <summary>
         /// The resolution property
         /// </summary>
@@ -42,7 +42,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The bias property
         /// </summary>
         public static readonly DependencyProperty BiasProperty =
-                DependencyProperty.Register("Bias", typeof(double), typeof(ShadowMap3D), new PropertyMetadata(0.0015, (d, e)=>
+                DependencyProperty.Register("Bias", typeof(double), typeof(ShadowMap3D), new PropertyMetadata(0.0015, (d, e) =>
                 {
                     ((d as Element3DCore).SceneNode as ShadowMapNode).Bias = (float)(double)e.NewValue;
                 }));
@@ -50,7 +50,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// The intensity property
         /// </summary>
         public static readonly DependencyProperty IntensityProperty =
-                DependencyProperty.Register("Intensity", typeof(double), typeof(ShadowMap3D), new PropertyMetadata(0.5, (d, e)=>
+                DependencyProperty.Register("Intensity", typeof(double), typeof(ShadowMap3D), new PropertyMetadata(0.5, (d, e) =>
                 {
                     ((d as Element3DCore).SceneNode as ShadowMapNode).Intensity = (float)(double)e.NewValue;
                 }));
@@ -100,6 +100,21 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 ((d as Element3DCore).SceneNode as ShadowMapNode).NearField = (float)(double)e.NewValue;
             }));
+
+        public static readonly DependencyProperty AutoCoverCompleteSceneProperty =
+            DependencyProperty.Register("AutoCoverCompleteScene", typeof(bool), typeof(ShadowMap3D), new PropertyMetadata(false, (d, e) => {
+
+            }));
+
+
+
+
+        // Using a DependencyProperty as the backing store for IsSceneDynamic.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty IsSceneDynamicProperty =
+            DependencyProperty.Register("IsSceneDynamic", typeof(bool), typeof(ShadowMap3D), new PropertyMetadata(false, (d, e) => {
+            
+            }));
+
 
 
         /// <summary>
@@ -186,6 +201,45 @@ namespace HelixToolkit.Wpf.SharpDX
             set { this.SetValue(LightCameraProperty, value); }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether shadow map should automatically cover complete scene. Only effective with directional light.
+        /// <para>Limitation: Currently unable to properly cover BoneSkinned model animation.</para>
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [automaticcally cover complete scene]; otherwise, <c>false</c>.
+        /// </value>
+        public bool AutoCoverCompleteScene
+        {
+            get
+            {
+                return (bool)GetValue(AutoCoverCompleteSceneProperty);
+            }
+            set
+            {
+                SetValue(AutoCoverCompleteSceneProperty, value);
+            }
+        }
+
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the scene is dynamic. Only effective if <see cref="AutoCoverCompleteScene"/> is true.
+        /// <para>Setting to true will force shadow map to update the shadow camera for each frame. May impact the performance.</para>
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if scene is dynamic; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsSceneDynamic
+        {
+            get
+            {
+                return (bool)GetValue(IsSceneDynamicProperty);
+            }
+            set
+            {
+                SetValue(IsSceneDynamicProperty, value);
+            }
+        }
+
         protected override SceneNode OnCreateSceneNode()
         {
             return new ShadowMapNode();
@@ -206,6 +260,8 @@ namespace HelixToolkit.Wpf.SharpDX
                 n.OrthoWidth = (float)OrthoWidth;
                 n.FarField = (float)FarFieldDistance;
                 n.NearField = (float)NearFieldDistance;
+                n.AutoCoverCompleteScene = AutoCoverCompleteScene;
+                n.IsSceneDynamic = IsSceneDynamic;
             }
             base.AssignDefaultValuesToSceneNode(core);
         }

--- a/Source/HelixToolkit.SharpDX.sln
+++ b/Source/HelixToolkit.SharpDX.sln
@@ -135,12 +135,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelixToolkit.Native.ShaderB
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MorphTargetAnimationDemo", "Examples\WPF.SharpDX\MorphTargetAnimation\MorphTargetAnimationDemo.csproj", "{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelixToolkit.SharpDX.Core.Wpf", "HelixToolkit.SharpDX.Core.Wpf\HelixToolkit.SharpDX.Core.Wpf.csproj", "{3442C8B8-68B2-44CA-B61F-386851C484DC}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		HelixToolkit.SharpDX.SharedModel\HelixToolkit.SharpDX.SharedModel.projitems*{1aefcb64-e997-425a-8c84-dc93263cc4a7}*SharedItemsImports = 13
 		HelixToolkit.Wpf.SharpDX.Shared\HelixToolkit.Wpf.SharpDX.Shared.projitems*{1bd60704-10f4-45ef-ac5c-083350b3012b}*SharedItemsImports = 13
 		HelixToolkit.SharpDX.Shared\HelixToolkit.SharpDX.Shared.projitems*{1eaf532e-d750-497b-bb8f-ee85359c78a2}*SharedItemsImports = 13
 		HelixToolkit.SharpDX.Assimp.Shared\HelixToolkit.SharpDX.Assimp.Shared.projitems*{24b939fb-0696-472f-90a5-84cc393ead0c}*SharedItemsImports = 5
+		HelixToolkit.SharpDX.SharedModel\HelixToolkit.SharpDX.SharedModel.projitems*{3442c8b8-68b2-44ca-b61f-386851c484dc}*SharedItemsImports = 5
+		HelixToolkit.Wpf.SharpDX.Shared\HelixToolkit.Wpf.SharpDX.Shared.projitems*{3442c8b8-68b2-44ca-b61f-386851c484dc}*SharedItemsImports = 5
 		HelixToolkit.Shared\HelixToolkit.Shared.projitems*{363664d9-5f18-45c7-b937-2dcee6f93261}*SharedItemsImports = 5
 		HelixToolkit.SharpDX.Shared\HelixToolkit.SharpDX.Shared.projitems*{363664d9-5f18-45c7-b937-2dcee6f93261}*SharedItemsImports = 5
 		HelixToolkit.Shared\HelixToolkit.Shared.projitems*{39740654-f5f1-4936-b4ea-9bc97d4cde37}*SharedItemsImports = 4
@@ -1238,6 +1242,26 @@ Global
 		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|x64.Build.0 = Release|Any CPU
 		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|x86.ActiveCfg = Release|Any CPU
 		{1D2B4988-A4CC-4C87-BE4F-7E1210E2F21F}.Release|x86.Build.0 = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|ARM.Build.0 = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|ARM.ActiveCfg = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|ARM.Build.0 = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|ARM64.Build.0 = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|x64.Build.0 = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{3442C8B8-68B2-44CA-B61F-386851C484DC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
1. Adds top most rendering support. #1572
2. Auto cover complete scene support for shadow map. (Limitations: Only supports directional light. Not able to properly covers dynamic scene with bone skinned animation.)