### PR TITLE
Fix topmost group is not rendered correctly if screenspaced group is being rendered before it. #1623

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Core/TopMostMeshRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/TopMostMeshRenderCore.cs
@@ -44,6 +44,8 @@ namespace HelixToolkit.UWP
                 dsView.Dispose();
                 var globalTrans = context.GlobalTransform;
                 globalTransformCB.Upload(deviceContext, ref globalTrans);
+                deviceContext.SetViewport(0, 0, context.ActualWidth, context.ActualHeight);
+                deviceContext.SetScissorRectangle(0, 0, (int)context.ActualWidth, (int)context.ActualHeight);
             }
 
             protected override bool OnAttach(IRenderTechnique technique)


### PR DESCRIPTION
Fix topmost group is not rendered correctly if screenspaced group is being rendered before it. #1623