### PR TITLE
Missing property in ShallowCopy

### DIFF
--- a/Source/Examples/WPF.SharpDX/BatchedMeshDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/BatchedMeshDemo/MainWindow.xaml
@@ -22,6 +22,8 @@
             BackgroundColor="Black"
             Camera="{Binding Camera}"
             EffectsManager="{Binding EffectsManager}"
+            RotateAroundMouseDownPoint="True"
+            ZoomAroundMouseDownPoint="True"
             IsShadowMappingEnabled="True"
             ShowFrameDetails="True"
             ShowViewCube="True">

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/HitTestResult.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/HitTestResult.cs
@@ -83,6 +83,7 @@ namespace HelixToolkit.UWP
         {
             Distance = result.Distance;
             ModelHit = result.ModelHit;
+            PointHit = result.PointHit;
             NormalAtHit = result.NormalAtHit;
             IsValid = result.IsValid;
             Tag = result.Tag;


### PR DESCRIPTION
Hello, 

bd3f0a24899b4fc8b863e0733301fb69944023aa introduced a regression in the RotateAroundMouseDownPoint and ZoomAroundMouseDownPoint for BatchedMeshes, due to a property not being assigned in the ShallowCopy function.

This PR fixes the regression.

Thanks,
Claudio