### PR TITLE
Add missing configuration to ItemsModel3D re-loading (ref #1185, #1643)

### DIFF
--- a/Source/HelixToolkit.UWP.Shared/Model/Element3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.UWP.Shared/Model/Element3D/ItemsModel3D.cs
@@ -164,6 +164,20 @@ namespace HelixToolkit.UWP
             {
                 Clear();
                 AddItems(ItemsSource);
+
+                itemsSource = ItemsSource;
+
+                if (ItemsSource is INotifyCollectionChanged n)
+                {
+                    n.CollectionChanged -= ItemsModel3D_CollectionChanged;
+                    n.CollectionChanged += ItemsModel3D_CollectionChanged;
+                }
+
+                if (Children.Count > 0)
+                {
+                    var groupNode = SceneNode as GroupNode;
+                    groupNode.OctreeManager?.RequestRebuild();
+                }
             }
         }
 


### PR DESCRIPTION
The code linked below causes the INotifyCollectionChanged event handler to be removed during Unloaded events, but it is not added back during Loaded events. In UWP, when navigating back and forth between pages, controls are unloaded when you leave the page and then reloaded when you return to that page. Thus, when returning to the page with a Helix Toolkit viewport, that viewport's ItemsModel3D nodes were now unresponsive to changes in their ItemsSource.

Double check me, but this merge request should resolve the issue.

https://github.com/helix-toolkit/helix-toolkit/pull/1643/commits/6548bd55b45e8a7b0b797500d8dc9eff9f57f31b#diff-e6c4c00f936cbef1f7e68bb423f3ee401fcf890c076bea7ecf84fc512d72b626R150-R178

Refer to #1185, #1643