### PR TITLE
Expanded CrossSectionDemo.

### DIFF
--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionPlaneManipulator3D.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionPlaneManipulator3D.cs
@@ -7,6 +7,7 @@ using System;
 using System.Windows.Input;
 using HelixToolkit.Wpf.SharpDX.Model.Scene;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace CrossSectionDemo
 {
@@ -34,6 +35,24 @@ namespace CrossSectionDemo
                         model.UpdateTransform(false);
                     }
                 }));
+
+
+
+        /// <summary>
+        /// This is used to demonstrate the code to constraint the rotation against a fixed axis instead 
+        /// of a free gimble. If left null a free trakcball approach is used, otherwise the rotation
+        /// is determined around the specified axis.
+        /// </summary>
+        public Vector3? ConstrainAxis
+        {
+            get { return (Vector3?)GetValue(ConstrainAxisProperty); }
+            set { SetValue(ConstrainAxisProperty, value); }
+        }
+
+        // Using a DependencyProperty as the backing store for ConstrainAxis.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ConstrainAxisProperty =
+            DependencyProperty.Register("ConstrainAxis", typeof(Vector3?), typeof(CrossSectionPlaneManipulator3D), new PropertyMetadata(null));
+
 
         public double SizeScale
         {
@@ -310,44 +329,75 @@ namespace CrossSectionDemo
             double z2 = 1 - (x * x) - (y * y);
             double z = z2 > 0 ? Math.Sqrt(z2) : 0;
 
-            return new Vector3((float)x, (float)y, (float)z);
+            return new Vector3((float)x, (float)y, (float)z); 
         }
 
         private void RotateTrackball(Point p1, Point p2, Vector3 rotateAround)
         {
             // http://viewport3d.com/trackball.htm
             // http://www.codeplex.com/3DTools/Thread/View.aspx?ThreadId=22310
-            var v1 = ProjectToTrackball(p1, viewport.ActualWidth, viewport.ActualHeight);
-            var v2 = ProjectToTrackball(p2, viewport.ActualWidth, viewport.ActualHeight);
 
-            // transform the trackball coordinates to view space
-            var viewZ = camera.CameraInternal.LookDirection;
-            var viewX = Vector3.Cross(camera.CameraInternal.UpDirection, viewZ);
-            var viewY = Vector3.Cross(viewX, viewZ);
-            viewX.Normalize();
-            viewY.Normalize();
-            viewZ.Normalize();
-            var u1 = (viewZ * v1.Z) + (viewX * v1.X) + (viewY * v1.Y);
-            var u2 = (viewZ * v2.Z) + (viewX * v2.X) + (viewY * v2.Y);
-
-            // Could also use the Camera ViewMatrix
-            // var vm = Viewport3DHelper.GetViewMatrix(this.ActualCamera);
-            // vm.Invert();
-            // var ct = new MatrixTransform3D(vm);
-            // var u1 = ct.Transform(v1);
-            // var u2 = ct.Transform(v2);
-
-            // Find the rotation axis and angle
-            var axis = Vector3.Cross(u1, u2);
-            if (axis.LengthSquared() < 1e-8)
+            Vector3 v1, v2;
+            if (ConstrainAxis.HasValue)
             {
-                return;
-            }
+                // preparing to compute the ratio to the screen
+                var diag = Math.Sqrt(
+                    viewport.ActualWidth * viewport.ActualWidth +
+                    viewport.ActualHeight * viewport.ActualHeight
+                    );
 
-            var angle = u1.AngleBetween(u2);
-            // Create the transform
-            currentRotation *= Matrix.RotationAxis(Vector3.Normalize(axis), (float)(angle * this.RotationSensitivity * 5));
-            UpdateTransform();
+                // can we project the constraintAxis onto the view?
+                var t3 = Vector3.TransformCoordinate(ConstrainAxis.Value, camera.CameraInternal.GetViewMatrix());
+                var dir = new Vector2(t3.X, t3.Y); // axis of Constraint in view coordinates
+                
+                var pp1 = p1.ToVector2(); // computing distance perpendicular to axis in view coordinates
+                var r1 =  pp1 - (pp1 * dir);
+
+                var pp2 = p2.ToVector2(); // computing distance perpendicular to axis in view coordinates
+                var r2 = pp2 - (pp2 * dir);
+
+                var angle = (r2.Length() - r1.Length()) / diag * 4;
+                // Create the transform
+                currentRotation *= Matrix.RotationAxis(Vector3.Normalize(ConstrainAxis.Value), (float)(angle * this.RotationSensitivity * 5));
+                UpdateTransform();
+            }
+            else
+            {
+                v1 = ProjectToTrackball(p1, viewport.ActualWidth, viewport.ActualHeight);
+                v2 = ProjectToTrackball(p2, viewport.ActualWidth, viewport.ActualHeight);
+
+                // transform the trackball coordinates to view space
+                var viewZ = camera.CameraInternal.LookDirection;
+                var viewX = Vector3.Cross(camera.CameraInternal.UpDirection, viewZ);
+                var viewY = Vector3.Cross(viewX, viewZ);
+                viewX.Normalize();
+                viewY.Normalize();
+                viewZ.Normalize();
+                var u1 = (viewZ * v1.Z) + (viewX * v1.X) + (viewY * v1.Y);
+                var u2 = (viewZ * v2.Z) + (viewX * v2.X) + (viewY * v2.Y);
+
+                // Could also use the Camera ViewMatrix
+                // var vm = Viewport3DHelper.GetViewMatrix(this.ActualCamera);
+                // vm.Invert();
+                // var ct = new MatrixTransform3D(vm);
+                // var u1 = ct.Transform(v1);
+                // var u2 = ct.Transform(v2);
+
+                // Find the rotation axis and angle
+                var axis = Vector3.Cross(u1, u2);
+                if (axis.LengthSquared() < 1e-8)
+                {
+                    return;
+                }
+
+                var angle = u1.AngleBetween(u2);
+                // Create the transform
+                currentRotation *= Matrix.RotationAxis(Vector3.Normalize(axis), (float)(angle * this.RotationSensitivity * 5));
+                UpdateTransform();
+            }
+            
+
+           
         }
 
         private void UpdateCutPlane()

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainViewModel.cs
@@ -155,6 +155,10 @@
             binding.Mode = mode;
             BindingOperations.SetBinding(dobj, property, binding);
         }
+
+        private Vector3? constraintVector = new Vector3(0,1,0);
+
+        public Vector3? ConstraintVector { get => constraintVector; set => SetValue(ref constraintVector, value); }
     }
 
 }

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:hx="http://helix-toolkit.org/wpf/SharpDX"
     xmlns:local="clr-namespace:CrossSectionDemo"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" d:DataContext="{d:DesignInstance Type=local:MainViewModel}"
     Title="CrossSectionDemo"
     Width="800"
     Height="600"
@@ -85,6 +85,7 @@
                 SizeScale="10" />
             <local:CrossSectionPlaneManipulator3D
                 CornerScale="4"
+                ConstrainAxis="{Binding ConstraintVector}"
                 CutPlane="{Binding Plane2, Mode=TwoWay}"
                 EdgeThicknessScale="4"
                 IsRendering="{Binding EnablePlane2}"


### PR DESCRIPTION
Since I needed it for one of my projects I thought it would be useful to share back a rotation constraint demo.

I've Expanded the CrossSectionDemo code to include the case of rotation constraint around an axis.

One of the two planes rotates freely, the other has a constrained rotation around a vertical axis.
Perhaps this might eventually be moved to one of the manipulations demo, but it might still useful here.