### PR TITLE
Feature/mouse event priority

### DIFF
--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionPlaneManipulator3D.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionPlaneManipulator3D.cs
@@ -219,19 +219,23 @@ namespace CrossSectionDemo
                 Geometry = EdgeHGeometry,
                 CullMode = SharpDX.Direct3D11.CullMode.Back,
             };
-            //this.edgeHandle.MouseMove3D += OnEdgeMouse3DMove;
-            //this.edgeHandle.MouseUp3D += OnEdgeMouse3DUp;
-            //this.edgeHandle.MouseDown3D += OnEdgeMouse3DDown;
-            MouseGesture CutCmdMouseGesture = new MouseGesture(MouseAction.MiddleClick);
-            MouseBinding CutMouseBinding = new MouseBinding(
+#if TRUE
+            this.edgeHandle.MouseMove3D += OnEdgeMouse3DMove;
+            this.edgeHandle.MouseUp3D += OnEdgeMouse3DUp;
+            this.edgeHandle.MouseDown3D += OnEdgeMouse3DDown;
+#else
+
+            MouseGesture leftMouseGesture = new MouseGesture(MouseAction.LeftClick);
+            MouseBinding theBinding = new MouseBinding(
                 Cmd,
-                CutCmdMouseGesture
+                leftMouseGesture
                 );
             if (edgeHandle.InputBindings != null)
             {
-                edgeHandle.InputBindings.Add(CutMouseBinding);
+                edgeHandle.InputBindings.Add(theBinding);
             }
-            
+#endif
+
             // completing setup
             this.Children.Add(cornerHandle);
             this.Children.Add(edgeHandle);
@@ -286,6 +290,7 @@ namespace CrossSectionDemo
         {
             if (e is Mouse3DEventArgs arg)
             {
+                arg.OriginalInputEventArgs.Handled = true;
                 viewport = arg.Viewport;
                 camera = viewport.Camera;
                 startPoint = arg.Position;
@@ -301,6 +306,10 @@ namespace CrossSectionDemo
 
         private void OnEdgeMouse3DUp(object sender, RoutedEventArgs e)
         {
+            if (e is Mouse3DEventArgs me)
+            {
+                me.OriginalInputEventArgs.Handled = true;
+            }
             if (isCaptured && EdgeMaterial is DiffuseMaterial m)
             {
                 m.DiffuseColor = orgColor;
@@ -308,12 +317,14 @@ namespace CrossSectionDemo
             isCaptured = false;
             viewport = null;
             camera = null;
+            e.Handled = true;
         }
 
         private void OnEdgeMouse3DMove(object sender, RoutedEventArgs e)
         {
             if (isCaptured && e is Mouse3DEventArgs arg && arg.Viewport == viewport)
             {
+                arg.OriginalInputEventArgs.Handled = true;
                 RotateTrackball(startPoint, arg.Position, currentTranslation.TranslationVector);
                 startPoint = arg.Position;
                 e.Handled=true;
@@ -324,6 +335,7 @@ namespace CrossSectionDemo
         {
             if (e is Mouse3DEventArgs arg)
             {
+                arg.OriginalInputEventArgs.Handled = true;
                 viewport = arg.Viewport;
                 camera = viewport.Camera;
                 startHitPoint = arg.HitTestResult.PointHit;
@@ -339,6 +351,10 @@ namespace CrossSectionDemo
 
         private void OnNodeMouse3DUp(object sender, RoutedEventArgs e)
         {
+            if (e is Mouse3DEventArgs me)
+            {
+                me.OriginalInputEventArgs.Handled = true;
+            }
             if (isCaptured && CornerMaterial is DiffuseMaterial m)
             {
                 m.DiffuseColor = orgColor;
@@ -352,10 +368,12 @@ namespace CrossSectionDemo
         {
             if (isCaptured && e is Mouse3DEventArgs arg && arg.Viewport == viewport)
             {
+                arg.OriginalInputEventArgs.Handled = true;
                 var newHit = viewport.UnProjectOnPlane(arg.Position, startHitPoint.ToPoint3D(), camera.LookDirection);
                 if (newHit.HasValue)
                 {
                     var newPos = newHit.Value.ToVector3();
+                    newPos = new Vector3(newPos.X, startHitPoint.Y, newPos.Z); // trying to constraint elevation
                     var offset = newPos - startHitPoint;
                     startHitPoint = newPos;
                     currentTranslation.TranslationVector += offset;

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionPlaneManipulator3D.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionPlaneManipulator3D.cs
@@ -170,8 +170,40 @@ namespace CrossSectionDemo
             EdgeHGeometry.UpdateOctree();
         }
 
+        public static ICommand Cmd
+        {
+            get
+            {
+                if (cmd == null)
+                {
+                    cmd = new myCmd();    
+                }
+                return cmd;
+            }
+        }
+
+        private static ICommand cmd = null;
+
+        private class myCmd : ICommand
+        {
+            public event EventHandler CanExecuteChanged;
+
+            public bool CanExecute(object parameter)
+            {
+                return true;
+            }
+
+            public void Execute(object parameter)
+            {
+                
+            }
+        }
+
+
+
         public CrossSectionPlaneManipulator3D()
         {
+            // corner manipulation is used to move the plane along its normal
             this.cornerHandle = new MeshGeometryModel3D()
             {
                 Geometry = NodeGeometry,
@@ -181,14 +213,26 @@ namespace CrossSectionDemo
             this.cornerHandle.MouseUp3D += OnNodeMouse3DUp;
             this.cornerHandle.MouseDown3D += OnNodeMouse3DDown;
 
+            // edge manipulation is used to rotate the plane
             this.edgeHandle = new MeshGeometryModel3D()
             {
                 Geometry = EdgeHGeometry,
                 CullMode = SharpDX.Direct3D11.CullMode.Back,
             };
-            this.edgeHandle.MouseMove3D += OnEdgeMouse3DMove;
-            this.edgeHandle.MouseUp3D += OnEdgeMouse3DUp;
-            this.edgeHandle.MouseDown3D += OnEdgeMouse3DDown;
+            //this.edgeHandle.MouseMove3D += OnEdgeMouse3DMove;
+            //this.edgeHandle.MouseUp3D += OnEdgeMouse3DUp;
+            //this.edgeHandle.MouseDown3D += OnEdgeMouse3DDown;
+            MouseGesture CutCmdMouseGesture = new MouseGesture(MouseAction.MiddleClick);
+            MouseBinding CutMouseBinding = new MouseBinding(
+                Cmd,
+                CutCmdMouseGesture
+                );
+            if (edgeHandle.InputBindings != null)
+            {
+                edgeHandle.InputBindings.Add(CutMouseBinding);
+            }
+            
+            // completing setup
             this.Children.Add(cornerHandle);
             this.Children.Add(edgeHandle);
 
@@ -272,6 +316,7 @@ namespace CrossSectionDemo
             {
                 RotateTrackball(startPoint, arg.Position, currentTranslation.TranslationVector);
                 startPoint = arg.Position;
+                e.Handled=true;
             }
         }
 

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionPlaneManipulator3D.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionPlaneManipulator3D.cs
@@ -170,36 +170,6 @@ namespace CrossSectionDemo
             EdgeHGeometry.UpdateOctree();
         }
 
-        public static ICommand Cmd
-        {
-            get
-            {
-                if (cmd == null)
-                {
-                    cmd = new myCmd();    
-                }
-                return cmd;
-            }
-        }
-
-        private static ICommand cmd = null;
-
-        private class myCmd : ICommand
-        {
-            public event EventHandler CanExecuteChanged;
-
-            public bool CanExecute(object parameter)
-            {
-                return true;
-            }
-
-            public void Execute(object parameter)
-            {
-                
-            }
-        }
-
-
 
         public CrossSectionPlaneManipulator3D()
         {
@@ -219,22 +189,11 @@ namespace CrossSectionDemo
                 Geometry = EdgeHGeometry,
                 CullMode = SharpDX.Direct3D11.CullMode.Back,
             };
-#if TRUE
+
             this.edgeHandle.MouseMove3D += OnEdgeMouse3DMove;
             this.edgeHandle.MouseUp3D += OnEdgeMouse3DUp;
             this.edgeHandle.MouseDown3D += OnEdgeMouse3DDown;
-#else
 
-            MouseGesture leftMouseGesture = new MouseGesture(MouseAction.LeftClick);
-            MouseBinding theBinding = new MouseBinding(
-                Cmd,
-                leftMouseGesture
-                );
-            if (edgeHandle.InputBindings != null)
-            {
-                edgeHandle.InputBindings.Add(theBinding);
-            }
-#endif
 
             // completing setup
             this.Children.Add(cornerHandle);
@@ -290,12 +249,11 @@ namespace CrossSectionDemo
         {
             if (e is Mouse3DEventArgs arg)
             {
-                arg.OriginalInputEventArgs.Handled = true;
+                arg.Handled = true;
                 viewport = arg.Viewport;
                 camera = viewport.Camera;
                 startPoint = arg.Position;
                 isCaptured = true;
-                e.Handled = true;
                 if(EdgeMaterial is DiffuseMaterial m)
                 {
                     orgColor = m.DiffuseColor;
@@ -306,28 +264,23 @@ namespace CrossSectionDemo
 
         private void OnEdgeMouse3DUp(object sender, RoutedEventArgs e)
         {
-            if (e is Mouse3DEventArgs me)
-            {
-                me.OriginalInputEventArgs.Handled = true;
-            }
-            if (isCaptured && EdgeMaterial is DiffuseMaterial m)
+            if (isCaptured && EdgeMaterial is DiffuseMaterial m && e is Mouse3DEventArgs arg)
             {
                 m.DiffuseColor = orgColor;
+                arg.Handled = true;
             }
             isCaptured = false;
             viewport = null;
             camera = null;
-            e.Handled = true;
         }
 
         private void OnEdgeMouse3DMove(object sender, RoutedEventArgs e)
         {
             if (isCaptured && e is Mouse3DEventArgs arg && arg.Viewport == viewport)
             {
-                arg.OriginalInputEventArgs.Handled = true;
                 RotateTrackball(startPoint, arg.Position, currentTranslation.TranslationVector);
                 startPoint = arg.Position;
-                e.Handled=true;
+                arg.Handled=true;
             }
         }
 
@@ -335,12 +288,11 @@ namespace CrossSectionDemo
         {
             if (e is Mouse3DEventArgs arg)
             {
-                arg.OriginalInputEventArgs.Handled = true;
                 viewport = arg.Viewport;
                 camera = viewport.Camera;
                 startHitPoint = arg.HitTestResult.PointHit;
                 isCaptured = true;
-                e.Handled = true;
+                arg.Handled = true;
                 if (CornerMaterial is DiffuseMaterial m)
                 {
                     orgColor = m.DiffuseColor;
@@ -351,13 +303,10 @@ namespace CrossSectionDemo
 
         private void OnNodeMouse3DUp(object sender, RoutedEventArgs e)
         {
-            if (e is Mouse3DEventArgs me)
-            {
-                me.OriginalInputEventArgs.Handled = true;
-            }
-            if (isCaptured && CornerMaterial is DiffuseMaterial m)
+            if (isCaptured && CornerMaterial is DiffuseMaterial m && e is Mouse3DEventArgs arg)
             {
                 m.DiffuseColor = orgColor;
+                arg.Handled = true;
             }
             isCaptured = false;
             viewport = null;
@@ -368,7 +317,6 @@ namespace CrossSectionDemo
         {
             if (isCaptured && e is Mouse3DEventArgs arg && arg.Viewport == viewport)
             {
-                arg.OriginalInputEventArgs.Handled = true;
                 var newHit = viewport.UnProjectOnPlane(arg.Position, startHitPoint.ToPoint3D(), camera.LookDirection);
                 if (newHit.HasValue)
                 {
@@ -378,7 +326,7 @@ namespace CrossSectionDemo
                     startHitPoint = newPos;
                     currentTranslation.TranslationVector += offset;
                     UpdateTransform();
-                    e.Handled = true;
+                    arg.Handled = true;
                 }
             }
         }

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml
@@ -43,7 +43,7 @@
                 <KeyBinding Key="L" Command="hx:ViewportCommands.LeftView" />
                 <KeyBinding Key="R" Command="hx:ViewportCommands.RightView" />
                 <KeyBinding Command="hx:ViewportCommands.ZoomExtents" Gesture="Control+E" />
-                <MouseBinding Command="hx:ViewportCommands.Rotate" Gesture="RightClick" />
+                <MouseBinding Command="hx:ViewportCommands.Rotate" Gesture="LeftClick" />
                 <MouseBinding Command="hx:ViewportCommands.Zoom" Gesture="MiddleClick" />
             </hx:Viewport3DX.InputBindings>
             <hx:DirectionalLight3D Direction="{Binding Camera.LookDirection}" Color="White" />

--- a/Source/HelixToolkit.UWP.Shared/Controls/MouseHandlers/CameraController.cs
+++ b/Source/HelixToolkit.UWP.Shared/Controls/MouseHandlers/CameraController.cs
@@ -1145,6 +1145,9 @@ namespace HelixToolkit.UWP
         /// </param>
         public void OnManipulationDelta(ManipulationDeltaRoutedEventArgs e)
         {
+            Debug.WriteLine("ManipulationDelta");
+            if (e.Handled)
+                return;
             // number of manipulators (fingers)
             if (Viewport.PointerCaptures == null)
             { return; }

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/MouseGestureHandler.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/MouseHandlers/MouseGestureHandler.cs
@@ -240,6 +240,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 return;
             }
+            
 
             this.Viewport.MouseMove -= this.OnMouseMove;
             this.Viewport.MouseUp -= this.OnMouseUp;
@@ -389,6 +390,8 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </param>
         protected virtual void OnMouseMove(object sender, MouseEventArgs e)
         {
+            if (e.Handled)
+                return;
             this.Delta(Mouse.GetPosition(this.Viewport));
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/Element3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/Element3D.cs
@@ -334,6 +334,22 @@ namespace HelixToolkit.Wpf.SharpDX
             get; private set;
         }
 
+        
+        public new bool Handled { // not overridable
+            get
+            {
+                return base.Handled;
+            }
+            set 
+            {
+                if (OriginalInputEventArgs != null)
+                    OriginalInputEventArgs.Handled = value; // ensuring that the original input event is also marked as Handled
+                base.Handled = value;
+            }
+        }   
+
+
+
         public Mouse3DEventArgs(RoutedEvent routedEvent, object source, HitTestResult hitTestResult, Point position, Viewport3DX viewport = null, InputEventArgs originalInputEventArgs = null)
             : base(routedEvent, source)
         {


### PR DESCRIPTION
Hello, 

I'm suggesting a change to the Handled property of Mouse3DEventArgs to propagate its value to OriginalInputEventArgs.
This makes for a more intuitive stopping of the mouse events.

Ideally, I would suggest this be made an `override` property, but unfortunately the base class is not `virtual`. 
So the right property is only changed if the `RoutedEventArgs` is cast to `Mouse3DEventArgs`.

Happy to make amendments to the code if needed.

Best,
Claudio