### PR TITLE
Relax manipulator binding target type to `Element3D` instead of `GeometryModel3D`.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/UIManipulator3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/UIManipulator3D.cs
@@ -152,7 +152,7 @@ namespace HelixToolkit.Wpf.SharpDX
         /// <param name="source">
         /// Source Visual3D which receives the manipulator transforms. 
         /// </param>
-        public void Bind(GeometryModel3D source)
+        public void Bind(Element3D source)
         {
             BindingOperations.SetBinding(this, TargetTransformProperty, new Binding("Transform") { Source = source });
             BindingOperations.SetBinding(this, TransformProperty, new Binding("Transform") { Source = source });


### PR DESCRIPTION
Relax manipulator binding target type to `Element3D` instead of `GeometryModel3D`.