### PR TITLE
Support depth peeling order independent transparency rendering

### DIFF
--- a/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/CoreTestApp.cs
@@ -68,8 +68,7 @@ namespace CoreTest
         private AmbientLightNode ambientLight;
         private const int NumItems = 400;
         private Random rnd = new Random((int)Stopwatch.GetTimestamp());
-        private Dictionary<string, MaterialCore> materials = new Dictionary<string, MaterialCore>();
-        private MaterialCore[] materialList;
+        private List<Tuple<bool, MaterialCore>> materials = new List<Tuple<bool, MaterialCore>>();
         private long previousTime;
         private bool resizeRequested = false;
         private CameraController cameraController;
@@ -189,19 +188,22 @@ namespace CoreTest
             groupPoints = new GroupNode();
             groupEffects = new GroupNode();
             InitializeMaterials();
-            materialList = materials.Values.ToArray();
-            var materialCount = materialList.Length;
+            var materialCount = materials.Count;
 
             for (int i = 0; i < NumItems; ++i)
             {
                 var transform = Matrix.Translation(new Vector3(rnd.NextFloat(-20, 20), rnd.NextFloat(-20, 20), rnd.NextFloat(-20, 20)));
-                groupSphere.AddChildNode(new MeshNode() { Geometry = sphere, Material = materialList[i % materialCount], ModelMatrix = transform, CullMode = SharpDX.Direct3D11.CullMode.Back });
+                var material = materials[i % materialCount];
+                groupSphere.AddChildNode(new MeshNode() { Geometry = sphere, IsTransparent = material.Item1, Material = material.Item2, 
+                    ModelMatrix = transform, CullMode = SharpDX.Direct3D11.CullMode.Back });
             }
 
             for (int i = 0; i < NumItems; ++i)
             {
                 var transform = Matrix.Translation(new Vector3(rnd.NextFloat(-50, 50), rnd.NextFloat(-50, 50), rnd.NextFloat(-50, 50)));
-                groupBox.AddChildNode(new MeshNode() { Geometry = box, Material = materialList[i % materialCount], ModelMatrix = transform, CullMode = SharpDX.Direct3D11.CullMode.Back });
+                var material = materials[i % materialCount];
+                groupBox.AddChildNode(new MeshNode() { Geometry = box, IsTransparent = material.Item1, Material = material.Item2, 
+                    ModelMatrix = transform, CullMode = SharpDX.Direct3D11.CullMode.Back });
             }
 
             for (int i = 0; i < NumItems; ++i)
@@ -254,16 +256,32 @@ namespace CoreTest
         {
             var diffuse = TextureModel.Create("TextureCheckerboard2.jpg");
             var normal = TextureModel.Create("TextureCheckerboard2_dot3.jpg");
-            materials.Add("red", new DiffuseMaterialCore() { DiffuseColor = Color.Red, DiffuseMap = diffuse });
-            materials.Add("green", new DiffuseMaterialCore() { DiffuseColor = Color.Green, DiffuseMap = diffuse });
-            materials.Add("blue", new DiffuseMaterialCore() { DiffuseColor = Color.Blue, DiffuseMap = diffuse });
-            materials.Add("DodgerBlue", new PhongMaterialCore() { DiffuseColor = Color.DodgerBlue, ReflectiveColor = Color.DarkGray, SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal });
-            materials.Add("Orange", new PhongMaterialCore() { DiffuseColor = Color.Orange, ReflectiveColor = Color.DarkGray, SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal });
-            materials.Add("PaleGreen", new PhongMaterialCore() { DiffuseColor = Color.PaleGreen, ReflectiveColor = Color.DarkGray, SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal });
-            materials.Add("normal", new NormalMaterialCore());
-            materials.Add("pbrBeige", new PBRMaterialCore() { AlbedoColor = Color.Beige, MetallicFactor = 0.8f, RoughnessFactor = 0.6f });
-            materials.Add("pbrBisque", new PBRMaterialCore() { AlbedoColor = Color.Bisque, MetallicFactor = 0.4f, RoughnessFactor = 0.9f });
-            materials.Add("pbrChartreuse", new PBRMaterialCore() { AlbedoColor = Color.Chartreuse, MetallicFactor = 0.2f, RoughnessFactor = 0.2f });
+            materials.Add(new Tuple<bool, MaterialCore>(false, new DiffuseMaterialCore() { DiffuseColor = Color.Red, DiffuseMap = diffuse }));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new DiffuseMaterialCore() { DiffuseColor = Color.Green, DiffuseMap = diffuse }));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new DiffuseMaterialCore() { DiffuseColor = Color.Blue, DiffuseMap = diffuse }));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new PhongMaterialCore() { DiffuseColor = Color.DodgerBlue, ReflectiveColor = Color.DarkGray, 
+                SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal }));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new PhongMaterialCore() { DiffuseColor = Color.Orange, ReflectiveColor = Color.DarkGray, 
+                SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal }));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new PhongMaterialCore() { DiffuseColor = Color.PaleGreen, ReflectiveColor = Color.DarkGray, 
+                SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal }));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new NormalMaterialCore()));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new PBRMaterialCore() { AlbedoColor = Color.Beige, MetallicFactor = 0.8f, RoughnessFactor = 0.6f }));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new PBRMaterialCore() { AlbedoColor = Color.Bisque, MetallicFactor = 0.4f, RoughnessFactor = 0.9f }));
+            materials.Add(new Tuple<bool, MaterialCore>(false, new PBRMaterialCore() { AlbedoColor = Color.Chartreuse, MetallicFactor = 0.2f, RoughnessFactor = 0.2f }));
+
+            materials.Add(new Tuple<bool, MaterialCore>(true, new DiffuseMaterialCore() { DiffuseColor = new Color4(1, 0, 1, 0.6f), DiffuseMap = diffuse }));
+            materials.Add(new Tuple<bool, MaterialCore>(true, new DiffuseMaterialCore() { DiffuseColor = new Color4(0, 1, 1, 0.4f), DiffuseMap = diffuse }));
+            materials.Add(new Tuple<bool, MaterialCore>(true, new DiffuseMaterialCore() { DiffuseColor = new Color4(1, 0, 1, 0.3f), DiffuseMap = diffuse }));
+            materials.Add(new Tuple<bool, MaterialCore>(true, new PhongMaterialCore() { DiffuseColor = new Color4(1, 1, 0, 0.6f), ReflectiveColor = Color.DarkGray, 
+                SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal }));
+            materials.Add(new Tuple<bool, MaterialCore>(true, new PhongMaterialCore() { DiffuseColor = new Color4(0, 1, 1, 0.4f), ReflectiveColor = Color.DarkGray,
+                SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal }));
+            materials.Add(new Tuple<bool, MaterialCore>(true, new PhongMaterialCore() { DiffuseColor = new Color4(1, 0, 1, 0.3f), ReflectiveColor = Color.DarkGray,
+                SpecularShininess = 10, SpecularColor = Color.Red, DiffuseMap = diffuse, NormalMap = normal }));
+            materials.Add(new Tuple<bool, MaterialCore>(true, new PBRMaterialCore() { AlbedoColor = new Color4(1, 1, 0, 0.6f), MetallicFactor = 0.8f, RoughnessFactor = 0.6f }));
+            materials.Add(new Tuple<bool, MaterialCore>(true, new PBRMaterialCore() { AlbedoColor = new Color4(0, 1, 1, 0.4f), MetallicFactor = 0.4f, RoughnessFactor = 0.9f }));
+            materials.Add(new Tuple<bool, MaterialCore>(true, new PBRMaterialCore() { AlbedoColor = new Color4(1, 0, 1, 0.6f), MetallicFactor = 0.2f, RoughnessFactor = 0.2f }));
         }
 
         private void Viewport_OnErrorOccurred(object sender, Exception e)

--- a/Source/Examples/WPF.SharpDX/OrderIndependantTransparentRendering/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/OrderIndependantTransparentRendering/MainViewModel.cs
@@ -68,6 +68,8 @@ namespace OrderIndependentTransparentRendering
 
         public OITWeightMode[] OITWeights { get; } = new OITWeightMode[] { OITWeightMode.Linear0, OITWeightMode.Linear1, OITWeightMode.Linear2, OITWeightMode.NonLinear };
 
+        public OITRenderType[] OITRenderTypes { get; } = new OITRenderType[] { OITRenderType.None, OITRenderType.DepthPeeling, OITRenderType.SinglePassWeighted };
+
         public ICommand ResetCameraCommand
         {
             set; get;
@@ -208,11 +210,15 @@ namespace OrderIndependentTransparentRendering
                         diffuse.Blue = (float)rnd.NextDouble();
                         diffuse.Alpha = 0.8f;//(float)(Math.Min(0.8, Math.Max(0.2, rnd.NextDouble())));
                         p.DiffuseColor = diffuse;
-                        if (p.DiffuseColor.Alpha < 0.9)
+                        if (diffuse.Alpha < 0.9)
                         {
                             s.IsTransparent = true;
                         }
-                        s.Material = p;
+                        s.Material = new HelixToolkit.Wpf.SharpDX.Model.PBRMaterialCore()
+                        {
+                            AlbedoColor = diffuse,
+                            MetallicFactor = 0.3f, RoughnessFactor = 0.8f,
+                        };
                     }
 
                     if (ob.Transform != null && ob.Transform.Count > 0)

--- a/Source/Examples/WPF.SharpDX/OrderIndependantTransparentRendering/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/OrderIndependantTransparentRendering/MainWindow.xaml
@@ -31,6 +31,7 @@
             CameraRotationMode="Turnball"
             CoordinateSystemLabelForeground="White"
             EffectsManager="{Binding EffectsManager}"
+            OITRenderMode="{Binding OITRenderType}"
             FXAALevel="Medium" EnableSwapChainRendering="True" EnableD2DRendering="False"
             ShowCoordinateSystem="True">
             <hx:Viewport3DX.InputBindings>
@@ -45,7 +46,6 @@
                 <MouseBinding Command="hx:ViewportCommands.Zoom" Gesture="MiddleClick" />
                 <MouseBinding Command="hx:ViewportCommands.Pan" Gesture="LeftClick" />
             </hx:Viewport3DX.InputBindings>
-            <hx:AmbientLight3D />
             <hx:DirectionalLight3D Direction="{Binding Camera.LookDirection}" Color="White" />
             <hx:LineGeometryModel3D
                 Geometry="{Binding GridModel}"
@@ -73,22 +73,33 @@
                 Reset Camera
             </Button>
             <CheckBox Foreground="White" IsChecked="{Binding ShowWireframe}">Show Wireframe</CheckBox>
-            <ComboBox ItemsSource="{Binding OITRenderTypes}" SelectedItem="{Binding ElementName=view, Path=OITRenderMode}"></ComboBox>
-            <ComboBox ItemsSource="{Binding OITWeights}" SelectedItem="{Binding ElementName=view, Path=OITWeightMode}" />
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Foreground="White">OIT Weight Power:</TextBlock>
-                <TextBlock Foreground="#FFF400" Text="{Binding ElementName=view, Path=OITWeightPower, StringFormat={}{0:#,0.0}}" />
+            <ComboBox ItemsSource="{Binding MaterialTypes}" SelectedItem="{Binding MaterialType}"/>
+            <ComboBox ItemsSource="{Binding OITRenderTypes}" SelectedItem="{Binding OITRenderType}"></ComboBox>
+            <StackPanel Orientation="Vertical" IsEnabled="{Binding OITDepthPeelModeEnabled}" Margin="2, 4">
+                <Label Foreground="White">Depth Peeling Iteration:</Label>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Foreground="White" Width="14" Text="{Binding ElementName=view, Path=OITDepthPeelingIteration}"></TextBlock>
+                    <Slider Minimum="1" Maximum="16" Value="{Binding ElementName=view, Path=OITDepthPeelingIteration}" Width="100"/>
+                </StackPanel>
             </StackPanel>
-            <Slider
-                LargeChange="1"
-                Maximum="5"
-                Minimum="0.5"
-                SmallChange="0.1"
-                Value="{Binding ElementName=view, Path=OITWeightPower}" />
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Foreground="White">OIT Weight Slope:</TextBlock>
-                <TextBlock Foreground="#FFF400" Text="{Binding ElementName=view, Path=OITWeightDepthSlope, StringFormat={}{0:#,0.0}}" />
+            <StackPanel Orientation="Vertical" IsEnabled="{Binding OITWeightedModeEnabled}">
+                <ComboBox ItemsSource="{Binding OITWeights}" SelectedItem="{Binding ElementName=view, Path=OITWeightMode}" />
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Foreground="White">OIT Weight Power:</TextBlock>
+                    <TextBlock Foreground="#FFF400" Text="{Binding ElementName=view, Path=OITWeightPower, StringFormat={}{0:#,0.0}}" />
+                </StackPanel>
+                <Slider
+                    LargeChange="1"
+                    Maximum="5"
+                    Minimum="0.5"
+                    SmallChange="0.1"
+                    Value="{Binding ElementName=view, Path=OITWeightPower}" />
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Foreground="White">OIT Weight Slope:</TextBlock>
+                    <TextBlock Foreground="#FFF400" Text="{Binding ElementName=view, Path=OITWeightDepthSlope, StringFormat={}{0:#,0.0}}" />
+                </StackPanel>                
             </StackPanel>
+
             <Slider
                 LargeChange="1"
                 Maximum="5"

--- a/Source/Examples/WPF.SharpDX/OrderIndependantTransparentRendering/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/OrderIndependantTransparentRendering/MainWindow.xaml
@@ -31,7 +31,7 @@
             CameraRotationMode="Turnball"
             CoordinateSystemLabelForeground="White"
             EffectsManager="{Binding EffectsManager}"
-            FXAALevel="Medium"
+            FXAALevel="Medium" EnableSwapChainRendering="True" EnableD2DRendering="False"
             ShowCoordinateSystem="True">
             <hx:Viewport3DX.InputBindings>
                 <KeyBinding Key="B" Command="hx:ViewportCommands.BackView" />
@@ -73,7 +73,7 @@
                 Reset Camera
             </Button>
             <CheckBox Foreground="White" IsChecked="{Binding ShowWireframe}">Show Wireframe</CheckBox>
-            <CheckBox Foreground="White" IsChecked="{Binding ElementName=view, Path=EnableOITRendering}">Enable OIT</CheckBox>
+            <ComboBox ItemsSource="{Binding OITRenderTypes}" SelectedItem="{Binding ElementName=view, Path=OITRenderMode}"></ComboBox>
             <ComboBox ItemsSource="{Binding OITWeights}" SelectedItem="{Binding ElementName=view, Path=OITWeightMode}" />
             <StackPanel Orientation="Horizontal">
                 <TextBlock Foreground="White">OIT Weight Power:</TextBlock>

--- a/Source/Examples/WinUI/App1/App1 (Package)/App1 (Package).wapproj
+++ b/Source/Examples/WinUI/App1/App1 (Package)/App1 (Package).wapproj
@@ -64,9 +64,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0">
-          <IncludeAssets>build</IncludeAssets>
-      </PackageReference>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.3">
+      <IncludeAssets>build</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
 </Project>

--- a/Source/Examples/WinUI/App1/App1/App1.csproj
+++ b/Source/Examples/WinUI/App1/App1/App1.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.3" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.csproj
+++ b/Source/HelixToolkit.Native.ShaderBuilder/HelixToolkit.Native.ShaderBuilder.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-
+      <None Remove="PS\psBillboardTextOITDP.hlsl" />
     </ItemGroup>
 
     <ItemGroup>
@@ -51,7 +51,15 @@
         <HLSLShader Include="PS\psBillboardText.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
         </HLSLShader>
+        <HLSLShader Include="PS\psBillboardTextOITDP.hlsl">
+          <EntryPointName>billboardTextOIT</EntryPointName>
+          <ShaderProfile>ps_4_0</ShaderProfile>
+        </HLSLShader>
         <HLSLShader Include="PS\psBillboardTextOIT.hlsl">
+            <ShaderProfile>ps_4_0</ShaderProfile>
+            <EntryPointName>billboardTextOIT</EntryPointName>
+        </HLSLShader>
+        <HLSLShader Include="PS\psBillboardTextOITDP.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
             <EntryPointName>billboardTextOIT</EntryPointName>
         </HLSLShader>
@@ -127,6 +135,20 @@
             <ShaderProfile>ps_4_0</ShaderProfile>
             <EntryPointName>meshBlinnPhongOIT</EntryPointName>
         </HLSLShader>
+        <HLSLShader Include="PS\psOITDepthPeelingCommon.hlsl">
+            <ShaderProfile>ps_5_0</ShaderProfile>
+            <EntryPointName>firstPassPS</EntryPointName>
+            <ObjectFileOutput>$(OutDir)\PS\psMeshOITDPFirst.cso</ObjectFileOutput>
+        </HLSLShader>
+        <HLSLShader Include="PS\psMeshBlinnPhongOITDP.hlsl">
+            <ShaderProfile>ps_5_0</ShaderProfile>
+            <EntryPointName>blinnPhongOITDP</EntryPointName>
+        </HLSLShader>
+        <HLSLShader Include="PS\psOITDepthPeelingCommon.hlsl">
+            <ShaderProfile>ps_5_0</ShaderProfile>
+            <EntryPointName>finalPS</EntryPointName>
+            <ObjectFileOutput>$(OutDir)\PS\psMeshOITDPFinal.cso</ObjectFileOutput>
+        </HLSLShader>
         <HLSLShader Include="PS\psMeshBlinnPhongOITQuad.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
         </HLSLShader>
@@ -144,12 +166,20 @@
             <ShaderProfile>ps_4_0</ShaderProfile>
             <EntryPointName>meshDiffuseOIT</EntryPointName>
         </HLSLShader>
+        <HLSLShader Include="PS\psMeshDiffuseMapOITDP.hlsl">
+            <ShaderProfile>ps_5_0</ShaderProfile>
+            <EntryPointName>diffuseOITDP</EntryPointName>
+        </HLSLShader>
         <HLSLShader Include="PS\psMeshPBR.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
         </HLSLShader>
         <HLSLShader Include="PS\psMeshPBROIT.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
             <EntryPointName>meshPBROIT</EntryPointName>
+        </HLSLShader>
+        <HLSLShader Include="PS\psMeshPBROITDP.hlsl">
+            <ShaderProfile>ps_4_0</ShaderProfile>
+            <EntryPointName>pbrOITDP</EntryPointName>
         </HLSLShader>
         <HLSLShader Include="PS\psMeshXRay.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
@@ -163,6 +193,10 @@
         <HLSLShader Include="PS\psParticleOIT.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
             <EntryPointName>particleOIT</EntryPointName>
+        </HLSLShader>
+        <HLSLShader Include="PS\psParticleOITDP.hlsl">
+            <ShaderProfile>ps_4_0</ShaderProfile>
+            <EntryPointName>particleOITDP</EntryPointName>
         </HLSLShader>
         <HLSLShader Include="PS\psPlaneGrid.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
@@ -212,6 +246,10 @@
         <HLSLShader Include="PS\psWireframeOIT.hlsl">
             <ShaderProfile>ps_4_0</ShaderProfile>
             <EntryPointName>wireframeOIT</EntryPointName>
+        </HLSLShader>
+        <HLSLShader Include="PS\psWireframeOITDP.hlsl">
+            <ShaderProfile>ps_4_0</ShaderProfile>
+            <EntryPointName>wireframeOITDP</EntryPointName>
         </HLSLShader>
         <HLSLShader Include="VS\vsBillboard.hlsl">
             <ShaderProfile>vs_4_0</ShaderProfile>
@@ -314,7 +352,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JeremyAnsel.HLSL.Targets" Version="1.0.10" />
+        <PackageReference Include="JeremyAnsel.HLSL.Targets" Version="1.0.13" />
     </ItemGroup>
 
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psBillboardTextOIT.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psBillboardTextOIT.hlsl
@@ -1,5 +1,5 @@
-#ifndef PSBILLBOARDTEXTOIT_HLSL
-#define PSBILLBOARDTEXTOIT_HLSL
+#ifndef PSBILLBOARDTEXTOITDP_HLSL
+#define PSBILLBOARDTEXTOITDP_HLSL
 #define POINTLINE
 #include"..\Common\DataStructs.hlsl"
 #include"..\Common\Common.hlsl"

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psBillboardTextOITDP.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psBillboardTextOITDP.hlsl
@@ -1,0 +1,11 @@
+#ifndef PSBILLBOARDTEXTOIT_HLSL
+#define PSBILLBOARDTEXTOIT_HLSL
+#define POINTLINE
+#include "psOITDepthPeelingCommon.hlsl"
+#include "psBillboardText.hlsl"
+
+DDPOutputMRT billboardTextOIT(PSInputBT input)
+{
+    return depthPeelPS(input.p, main(input));
+}
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshBlinnPhongOIT.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshBlinnPhongOIT.hlsl
@@ -18,4 +18,41 @@ PSOITOutput meshBlinnPhongOIT(PSInput input)
     float4 color = main(input);
     return calculateOIT(color, input.vEye.w, input.p.z);
 }
+
+//--------------------------------------------------------------------------------------
+// PER PIXEL LIGHTING - BLINN-PHONG for Order Independant Transparent from Microsoft DX11 SDK
+//--------------------------------------------------------------------------------------
+RWTexture2D<uint> fragmentCount : register(u1);
+RWBuffer<float> deepBufferDepth : register(u2);
+RWBuffer<uint4> deepBufferColor : register(u3);
+RWBuffer<uint> prefixSum : register(u4);
+
+void FragmentCountPS(PSInput input)
+{
+    // Increments need to be done atomically
+    InterlockedAdd(fragmentCount[input.p.xy], 1);
+}
+
+void meshBlinnPhongOITSort(PSInput input)
+{
+    float4 color = main(input);
+    
+    uint x = input.p.x;
+    uint y = input.p.y;
+
+    // Atomically allocate space in the deep buffer
+    uint fc;
+    InterlockedAdd(fragmentCount[input.p.xy], 1, fc);
+
+    uint nPrefixSumPos = y * vViewport.x + x;
+    uint nDeepBufferPos;
+    if (nPrefixSumPos == 0)
+        nDeepBufferPos = fc;
+    else
+        nDeepBufferPos = prefixSum[nPrefixSumPos - 1] + fc;
+
+    // Store fragment data into the allocated space
+    deepBufferDepth[nDeepBufferPos] = input.p.z;
+    deepBufferColor[nDeepBufferPos] = clamp(color, 0, 1) * 255;
+}
 #endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshBlinnPhongOITDP.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshBlinnPhongOITDP.hlsl
@@ -1,0 +1,12 @@
+﻿#ifndef PSMESHBLINNPHONGOITDEPTHPEEL_HLSL
+#define PSMESHBLINNPHONGOITDEPTHPEEL_HLSL
+#define CLIPPLANE
+#define MESH
+
+#include "psOITDepthPeelingCommon.hlsl"
+#include "psMeshBlinnPhong.hlsl"
+DDPOutputMRT blinnPhongOITDP(PSInput input)
+{
+    return depthPeelPS(input.p, main(input));
+}
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshDiffuseMapOITDP.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshDiffuseMapOITDP.hlsl
@@ -1,0 +1,15 @@
+﻿#ifndef PSMESHDIFFUSEMAPOITDP_HLSL
+#define PSMESHDIFFUSEMAPOITDP_HLSL
+
+#define CLIPPLANE
+#define MESH
+
+
+#include "psOITDepthPeelingCommon.hlsl"
+#include"psDiffuseMap.hlsl"
+
+DDPOutputMRT diffuseOITDP(PSInput input)
+{
+    return depthPeelPS(input.p, main(input));
+}
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshPBROITDP.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psMeshPBROITDP.hlsl
@@ -1,0 +1,14 @@
+﻿#ifndef PSMESHPBROITDP_HLSL
+#define PSMESHPBROITDP_HLSL
+
+#define MESH
+#define PBR
+
+#include "psOITDepthPeelingCommon.hlsl"
+#include"psMeshPBR.hlsl"
+
+DDPOutputMRT pbrOITDP(PSInput input)
+{
+    return depthPeelPS(input.p, main(input));
+}
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psOITDepthPeelingCommon.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psOITDepthPeelingCommon.hlsl
@@ -1,0 +1,85 @@
+﻿/**
+Classic depth peeling implementation for order independent transparency rendering.
+Ref: Nvidia Direct3D SDK 11 Samples: https://developer.download.nvidia.com/gameworks/samples/NVIDIA_SDK11_Direct3D_11.00.0328.2105.exe
+*/
+#ifndef PSOITDEPTHPEELINGCOMMON_HLSL
+#define PSOITDEPTHPEELINGCOMMON_HLSL
+#include"..\Common\Common.hlsl"
+#include"..\Common\DataStructs.hlsl"
+#include"psCommon.hlsl"
+#define MAX_DEPTH_FLOAT 1.0f
+
+Texture2DMS<float4> tLayerColor : register(t100);
+Texture2D<float2> tDepthBlender : register(t100);
+Texture2D<float4> tFrontBlender : register(t101);
+Texture2D<float4> tBackBlender : register(t102);
+
+struct DDPOutputMRT
+{
+    float2 Depths : SV_Target0;
+    float4 FrontColor : SV_Target1;
+    float4 BackColor : SV_Target2;
+};
+
+float4 firstPassPS(float4 p : SV_POSITION) : SV_TARGET
+{
+    float z = p.z;
+    return float4(-z, z, 0, 0);
+}
+
+DDPOutputMRT depthPeelPS(in float4 pos, in float4 color)
+{
+    DDPOutputMRT OUT = (DDPOutputMRT) 0;
+
+    // Window-space depth interpolated linearly in screen space
+    float fragDepth = pos.z;
+
+    OUT.Depths.xy = tDepthBlender.Load(int3(pos.xy, 0)).xy;
+    float nearestDepth = -OUT.Depths.x;
+    float farthestDepth = OUT.Depths.y;
+
+    if (fragDepth < nearestDepth || fragDepth > farthestDepth)
+    {
+        // Skip this depth in the peeling algorithm
+        OUT.Depths.xy = -MAX_DEPTH_FLOAT;
+        return OUT;
+    }
+    
+    if (fragDepth > nearestDepth && fragDepth < farthestDepth)
+    {
+        // This fragment needs to be peeled again
+        OUT.Depths.xy = float2(-fragDepth, fragDepth);
+        return OUT;
+    }
+    
+    // If we made it here, this fragment is on the peeled layer from last pass
+    // therefore, we need to shade it, and make sure it is not peeled any farther
+    OUT.Depths.xy = -MAX_DEPTH_FLOAT;
+    
+    if (fragDepth == nearestDepth)
+    {
+        color.rgb *= color.a;
+        OUT.FrontColor = color;
+    }
+    else
+    {
+        OUT.BackColor = color;
+    }
+    return OUT;
+}
+
+float4 blendingPS(ScreenDupVS_INPUT IN) : SV_TARGET
+{
+    return tLayerColor.Load(int2(IN.Pos.xy), 0);
+}
+
+float4 finalPS(ScreenDupVS_INPUT IN) : SV_TARGET
+{
+    float4 frontColor = tFrontBlender.Load(int3(IN.Pos.xy, 0));
+    float3 backColor = tBackBlender.Load(int3(IN.Pos.xy, 0)).xyz;
+    float3 final = frontColor.xyz + backColor * frontColor.w;
+    float alpha = frontColor.w;
+    return float4(final, alpha);
+}
+
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psParticleOITDP.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psParticleOITDP.hlsl
@@ -1,0 +1,11 @@
+﻿#ifndef PSPARTICLEOITDP_HLSL
+#define PSPARTICLEOITDP_HLSL
+#define PARTICLE
+#include "psOITDepthPeelingCommon.hlsl"
+#include"psParticle.hlsl"
+
+DDPOutputMRT particleOITDP(ParticlePS_INPUT input)
+{
+    return depthPeelPS(input.position, main(input));
+}
+#endif

--- a/Source/HelixToolkit.Native.ShaderBuilder/PS/psWireframeOITDP.hlsl
+++ b/Source/HelixToolkit.Native.ShaderBuilder/PS/psWireframeOITDP.hlsl
@@ -1,0 +1,12 @@
+﻿#ifndef PSWIREFRAMEOITDP_HLSL
+#define PSWIREFRAMEOITDP_HLSL
+
+#define MESH
+#include "psOITDepthPeelingCommon.hlsl"
+#include "psWireframe.hlsl"
+
+DDPOutputMRT wireframeOITDP(PSWireframeInput input)
+{
+    return depthPeelPS(input.p, main(input.p));
+}
+#endif

--- a/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
+++ b/Source/HelixToolkit.SharpDX.Core/HelixToolkit.SharpDX.Core.csproj
@@ -1,8 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        
-
-    </ItemGroup>
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <Copyright>Copyright (C) Helix Toolkit 2019.</Copyright>
@@ -53,6 +49,7 @@
     <None Remove="Resources\hsMeshTriTessellation.cso" />
     <None Remove="Resources\psBillboardText.cso" />
     <None Remove="Resources\psBillboardTextOIT.cso" />
+    <None Remove="Resources\psBillboardTextOITDP.cso" />
     <None Remove="Resources\psColor.cso" />
     <None Remove="Resources\psDepthStencilOnly.cso" />
     <None Remove="Resources\psDiffuseMap.cso" />
@@ -76,17 +73,23 @@
     <None Remove="Resources\psLuma.cso" />
     <None Remove="Resources\psMeshBlinnPhong.cso" />
     <None Remove="Resources\psMeshBlinnPhongOIT.cso" />
+    <None Remove="Resources\psMeshBlinnPhongOITDP.cso" />
     <None Remove="Resources\psMeshBlinnPhongOITQuad.cso" />
     <None Remove="Resources\psMeshClipPlaneBackface.cso" />
     <None Remove="Resources\psMeshClipPlaneQuad.cso" />
     <None Remove="Resources\psMeshColorStripe.cso" />
     <None Remove="Resources\psMeshDiffuseMapOIT.cso" />
+    <None Remove="Resources\psMeshDiffuseMapOITDP.cso" />
+    <None Remove="Resources\psMeshOITDPFinal.cso" />
+    <None Remove="Resources\psMeshOITDPFirst.cso" />
     <None Remove="Resources\psMeshPBR.cso" />
     <None Remove="Resources\psMeshPBROIT.cso" />
+    <None Remove="Resources\psMeshPBROITDP.cso" />
     <None Remove="Resources\psMeshXRay.cso" />
     <None Remove="Resources\psNormals.cso" />
     <None Remove="Resources\psParticle.cso" />
     <None Remove="Resources\psParticleOIT.cso" />
+    <None Remove="Resources\psParticleOITDP.cso" />
     <None Remove="Resources\psPlaneGrid.cso" />
     <None Remove="Resources\psPoint.cso" />
     <None Remove="Resources\psPositions.cso" />
@@ -103,6 +106,7 @@
     <None Remove="Resources\psVolumeDiffuse.cso" />
     <None Remove="Resources\psWireframe.cso" />
     <None Remove="Resources\psWireframeOIT.cso" />
+    <None Remove="Resources\psWireframeOITDP.cso" />
     <None Remove="Resources\vsBillboard.cso" />
     <None Remove="Resources\vsBillboardInstancing.cso" />
     <None Remove="Resources\vsBoneSkinningBasic.cso" />
@@ -143,7 +147,12 @@
     <EmbeddedResource Include="Resources\arial.dds" />
     <EmbeddedResource Include="Resources\gsLineArrowHead.cso" />
     <EmbeddedResource Include="Resources\gsLineArrowHeadTail.cso" />
+    <EmbeddedResource Include="Resources\psBillboardTextOITDP.cso" />
     <EmbeddedResource Include="Resources\psEffectOutlineSmooth.cso" />
+    <EmbeddedResource Include="Resources\psMeshBlinnPhongOITDP.cso" />
+    <EmbeddedResource Include="Resources\psMeshDiffuseMapOITDP.cso" />
+    <EmbeddedResource Include="Resources\psMeshOITDPFinal.cso" />
+    <EmbeddedResource Include="Resources\psMeshOITDPFirst.cso" />
     <EmbeddedResource Include="Resources\psMeshPBROIT.cso" />
   </ItemGroup>
   <ItemGroup>
@@ -188,10 +197,12 @@
     <EmbeddedResource Include="Resources\psMeshColorStripe.cso" />
     <EmbeddedResource Include="Resources\psMeshDiffuseMapOIT.cso" />
     <EmbeddedResource Include="Resources\psMeshPBR.cso" />
+    <EmbeddedResource Include="Resources\psMeshPBROITDP.cso" />
     <EmbeddedResource Include="Resources\psMeshXRay.cso" />
     <EmbeddedResource Include="Resources\psNormals.cso" />
     <EmbeddedResource Include="Resources\psParticle.cso" />
     <EmbeddedResource Include="Resources\psParticleOIT.cso" />
+    <EmbeddedResource Include="Resources\psParticleOITDP.cso" />
     <EmbeddedResource Include="Resources\psPlaneGrid.cso" />
     <EmbeddedResource Include="Resources\psPoint.cso" />
     <EmbeddedResource Include="Resources\psPositions.cso" />
@@ -208,6 +219,7 @@
     <EmbeddedResource Include="Resources\psVolumeDiffuse.cso" />
     <EmbeddedResource Include="Resources\psWireframe.cso" />
     <EmbeddedResource Include="Resources\psWireframeOIT.cso" />
+    <EmbeddedResource Include="Resources\psWireframeOITDP.cso" />
     <EmbeddedResource Include="Resources\vsBillboard.cso" />
     <EmbeddedResource Include="Resources\vsBillboardInstancing.cso" />
     <EmbeddedResource Include="Resources\vsBoneSkinningBasic.cso" />

--- a/Source/HelixToolkit.SharpDX.Shared/Core/OITDepthPeeling.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/OITDepthPeeling.cs
@@ -1,0 +1,180 @@
+﻿/*
+The MIT License (MIT)
+Copyright (c) 2018 Helix Toolkit contributors
+*/
+#define MSAASEPARATE
+using System;
+using SharpDX;
+using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using SharpDX.Direct3D;
+using System.Runtime.InteropServices;
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    namespace Core
+    {
+        using Render;
+        using Shaders;
+        using System.Diagnostics;
+        using Utilities;
+        using Components;
+
+        public sealed class OITDepthPeeling : RenderCore
+        {
+            private int currWidth = 0, currHeight = 0;
+            private ShaderResourceViewProxy minMaxZTarget0, minMaxZTarget1, frontBlendingTarget, backBlendingTarget;
+            private readonly ShaderResourceViewProxy[] minMaxZTargets = new ShaderResourceViewProxy[2];
+            private readonly RenderTargetView[] targets = new RenderTargetView[3];
+            private readonly ShaderResourceView[] finalSRVs = new ShaderResourceView[3];
+            private ShaderPass finalPass = ShaderPass.NullPass;
+            public RenderParameter ExternRenderParameter
+            {
+                set; get;
+            }
+            public int RenderCount { private set; get; }
+
+            public int PeelingIteration { set; get; } = 4;
+
+            public OITDepthPeeling() : base(RenderType.Transparent) { }
+
+            private bool CreateRenderTargets(int width, int height)
+            {
+                if (currWidth == width || currHeight == height)
+                {
+                    return false;
+                }
+                DisposeAllTargets();
+                currWidth = width;
+                currHeight = height;
+                var tex2DDesc = new Texture2DDescription()
+                {
+                    Width = width,
+                    Height = height,
+                    ArraySize = 1,
+                    MipLevels = 1,
+                    SampleDescription = new SampleDescription(1, 0),
+                    BindFlags = BindFlags.RenderTarget | BindFlags.ShaderResource,
+                    Usage = ResourceUsage.Default,
+                    CpuAccessFlags = CpuAccessFlags.None,
+                };
+                tex2DDesc.Format = Format.R32G32_Float;
+                minMaxZTarget0 = new ShaderResourceViewProxy(Device, tex2DDesc);
+                minMaxZTarget0.CreateRenderTargetView();
+                minMaxZTarget0.CreateTextureView();
+                minMaxZTarget1 = new ShaderResourceViewProxy(Device, tex2DDesc);
+                minMaxZTarget1.CreateRenderTargetView();
+                minMaxZTarget1.CreateTextureView();
+                minMaxZTargets[0] = minMaxZTarget0;
+                minMaxZTargets[1] = minMaxZTarget1;
+                tex2DDesc.Format = Format.R8G8B8A8_UNorm;
+                frontBlendingTarget = new ShaderResourceViewProxy(Device, tex2DDesc);
+                frontBlendingTarget.CreateRenderTargetView();
+                frontBlendingTarget.CreateTextureView();
+                backBlendingTarget = new ShaderResourceViewProxy(Device, tex2DDesc);
+                backBlendingTarget.CreateRenderTargetView();
+                backBlendingTarget.CreateTextureView();
+                return true;
+            }
+
+            private void DisposeAllTargets()
+            {
+                RemoveAndDispose(ref minMaxZTarget0);
+                RemoveAndDispose(ref minMaxZTarget1);
+                RemoveAndDispose(ref frontBlendingTarget);
+                RemoveAndDispose(ref backBlendingTarget);
+            }
+
+            private void InitializeMinMaxRenderTarget(DeviceContextProxy deviceContext)
+            {
+                var color = new Color4(0, 0, 0, 1);
+                deviceContext.ClearRenderTargetView(frontBlendingTarget, color);
+                color = new Color4(0, 0, 0, 0);
+                deviceContext.ClearRenderTargetView(backBlendingTarget, color);
+                color = new Color4(-1, -1, 0, 0);
+                deviceContext.ClearRenderTargetView(minMaxZTargets[0], color);
+            }
+
+            private void DrawMesh(RenderContext context, DeviceContextProxy deviceContext)
+            {
+                var parameter = ExternRenderParameter;
+                if (!parameter.ScissorRegion.IsEmpty)
+                {
+                    RenderCount = context.RenderHost.Renderer.
+                        RenderOpaque(context, context.RenderHost.PerFrameTransparentNodes, ref parameter, context.EnableBoundingFrustum);
+                }
+                else
+                {
+                    var count = context.RenderHost.PerFrameTransparentNodes.Count;
+                    for (var i = 0; i < count; ++i)
+                    {
+                        var renderable = context.RenderHost.PerFrameTransparentNodes[i];
+                        renderable.RenderCore.Render(context, deviceContext);
+                        ++RenderCount;
+                    }
+                }
+            }
+
+            public override void Render(RenderContext context, DeviceContextProxy deviceContext)
+            {
+                if (CreateRenderTargets((int)context.ActualWidth, (int)context.ActualHeight))
+                {
+                    RaiseInvalidateRender();
+                    return;
+                }
+                RenderCount = 0;
+                InitializeMinMaxRenderTarget(deviceContext);
+                context.OITRenderStage = OITRenderStage.DepthPeelingInitMinMaxZ;
+                deviceContext.SetRenderTarget(ExternRenderParameter.DepthStencilView, minMaxZTargets[0]);
+                DrawMesh(context, deviceContext);
+
+                context.OITRenderStage = OITRenderStage.DepthPeeling;
+                var currId = 0;
+                for(var layer = 1; layer < PeelingIteration; ++layer)
+                {
+                    currId = layer % 2;
+                    var prevId = 1 - currId;
+                    var color = new Color4(-1, -1, 0, 0);
+                    deviceContext.ClearRenderTargetView(minMaxZTargets[currId], color);
+                    targets[0] = minMaxZTargets[currId];
+                    targets[1] = frontBlendingTarget;
+                    targets[2] = backBlendingTarget;
+                    deviceContext.SetRenderTargets(ExternRenderParameter.DepthStencilView, targets);
+                    deviceContext.SetShaderResource(new PixelShaderType(), 100, minMaxZTargets[prevId]);
+                    DrawMesh(context, deviceContext);
+                    deviceContext.SetShaderResource(new PixelShaderType(), 100, null);
+                }
+                context.OITRenderStage = OITRenderStage.None;
+                finalSRVs[0] = minMaxZTargets[currId];
+                finalSRVs[1] = frontBlendingTarget;
+                finalSRVs[2] = backBlendingTarget;
+                finalPass.BindShader(deviceContext);
+                finalPass.BindStates(deviceContext, StateType.All);
+                deviceContext.SetRenderTargets(null, ExternRenderParameter.RenderTargetView);
+                deviceContext.SetShaderResources(new PixelShaderType(), 100, finalSRVs);
+                deviceContext.Draw(4, 0);
+            }
+
+            protected override bool OnAttach(IRenderTechnique technique)
+            {
+                finalPass = technique[DefaultPassNames.OITDepthPeelingFinal];
+                Debug.Assert(!finalPass.IsNULL);
+                return true;
+            }
+
+            protected override void OnDetach()
+            {
+                DisposeAllTargets();
+                currWidth = currHeight = 0;
+                finalPass = ShaderPass.NullPass;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX.Shared/Core/OrderIndependantTransparentRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/OrderIndependantTransparentRenderCore.cs
@@ -201,7 +201,7 @@ namespace HelixToolkit.UWP
                 }
                 Bind(context, deviceContext);
 
-                context.IsOITPass = true;
+                context.OITRenderStage = OITRenderStage.SinglePassWeighted;
                 var parameter = ExternRenderParameter;
                 if (!parameter.ScissorRegion.IsEmpty)
                 {
@@ -220,7 +220,7 @@ namespace HelixToolkit.UWP
                         ++RenderCount;
                     }
                 }
-                context.IsOITPass = false;
+                context.OITRenderStage = OITRenderStage.None;
                 UnBind(context, deviceContext);
                 screenQuadPass.BindShader(deviceContext);
                 screenQuadPass.BindStates(deviceContext, StateType.BlendState | StateType.DepthStencilState | StateType.RasterState);

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultBuffers.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultBuffers.cs
@@ -62,6 +62,7 @@ namespace HelixToolkit.UWP
             //----------Order Independent Transparent-----------
             public const string OITColorTB = "texOITColor";
             public const string OITAlphaTB = "texOITAlpha";
+            public const string OITSortCB = "cbOITSortRender";
             //----------Bone Skin--------------
             public const string BoneSkinSB = "skinMatrices"; // Structured Buffer
 

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultPixelShaders.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultPixelShaders.cs
@@ -38,6 +38,7 @@ namespace HelixToolkit.UWP
             {
                 get;
             } = "psMeshBlinnPhongOIT";
+
             /// <summary>
             /// Gets the ps mesh binn phong oit quad.
             /// </summary>
@@ -48,6 +49,26 @@ namespace HelixToolkit.UWP
             {
                 get;
             } = "psMeshBlinnPhongOITQuad";
+
+            public static string PSMeshOITDPFirst
+            {
+                get;
+            } = "psMeshOITDPFirst";
+
+            public static string PSMeshBlinnPhongOITDP
+            {
+                get;
+            } = "psMeshBlinnPhongOITDP";
+
+            public static string PSMeshOITDPBlending
+            {
+                get;
+            } = "psMeshOITDPBlending";
+
+            public static string PSMeshOITDPFinal
+            {
+                get;
+            } = "psMeshOITDPFinal";
             /// <summary>
             /// Gets the ps mesh diffuse map oit.
             /// </summary>
@@ -58,6 +79,11 @@ namespace HelixToolkit.UWP
             {
                 get;
             } = "psMeshDiffuseMapOIT";
+
+            public static string PSMeshDiffuseMapOITDP
+            {
+                get;
+            } = "psMeshDiffuseMapOITDP";
             /// <summary>
             /// 
             /// </summary>
@@ -141,6 +167,11 @@ namespace HelixToolkit.UWP
             {
                 get;
             } = "psBillboardTextOIT";
+
+            public static string PSBillboardTextOITDP
+            {
+                get;
+            } = "psBillboardTextOITDP";
             /// <summary>
             /// 
             /// </summary>
@@ -177,6 +208,11 @@ namespace HelixToolkit.UWP
             {
                 get;
             } = "psParticleOIT";
+
+            public static string PSParticleOITDP
+            {
+                get;
+            } = "psParticleOITDP";
             /// <summary>
             /// 
             /// </summary>
@@ -202,6 +238,11 @@ namespace HelixToolkit.UWP
             {
                 get;
             } = "psWireframeOIT";
+
+            public static string PSMeshWireframeOITDP
+            {
+                get;
+            } = "psWireframeOITDP";
             /// <summary>
             /// 
             /// </summary>
@@ -405,7 +446,10 @@ namespace HelixToolkit.UWP
             {
                 get;
             } = "psMeshPBROIT";
-
+            public static string PSMeshPBROITDP
+            {
+                get;
+            } = "psMeshPBROITDP";
             /// <summary>
             /// Gets the ps sprite.
             /// </summary>
@@ -478,6 +522,18 @@ namespace HelixToolkit.UWP
             /// </summary>
             public static readonly ShaderDescription PSMeshBlinnPhongOITQuad = new ShaderDescription(nameof(PSMeshBlinnPhongOITQuad), ShaderStage.Pixel, new ShaderReflector(),
                 DefaultPSShaderByteCodes.PSMeshBinnPhongOITQuad);
+
+            public static readonly ShaderDescription PSMeshOITDPInit = new ShaderDescription(nameof(PSMeshOITDPInit), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSMeshOITDPFirst);
+
+            public static readonly ShaderDescription PSMeshBlinnPhongOITDP = new ShaderDescription(nameof(PSMeshBlinnPhongOITDP), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSMeshBlinnPhongOITDP);
+
+            public static readonly ShaderDescription PSMeshOITDPBlending = new ShaderDescription(nameof(PSMeshOITDPBlending), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSMeshOITDPBlending);
+
+            public static readonly ShaderDescription PSMeshOITDPFinal = new ShaderDescription(nameof(PSMeshOITDPFinal), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSMeshOITDPFinal);
             /// <summary>
             /// 
             /// </summary>
@@ -503,6 +559,9 @@ namespace HelixToolkit.UWP
             /// </summary>
             public static readonly ShaderDescription PSMeshDiffuseMapOIT = new ShaderDescription(nameof(PSMeshDiffuseMapOIT), ShaderStage.Pixel, new ShaderReflector(),
                 DefaultPSShaderByteCodes.PSMeshDiffuseMapOIT);
+
+            public static readonly ShaderDescription PSMeshDiffuseMapOITDP = new ShaderDescription(nameof(PSMeshDiffuseMapOITDP), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSMeshDiffuseMapOITDP);
             /// <summary>
             /// 
             /// </summary>
@@ -538,6 +597,9 @@ namespace HelixToolkit.UWP
             /// </summary>
             public static readonly ShaderDescription PSBillboardTextOIT = new ShaderDescription(nameof(PSBillboardTextOIT), ShaderStage.Pixel, new ShaderReflector(),
                 DefaultPSShaderByteCodes.PSBillboardTextOIT);
+
+            public static readonly ShaderDescription PSBillboardTextOITDP = new ShaderDescription(nameof(PSBillboardTextOITDP), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSBillboardTextOITDP);
             /// <summary>
             /// 
             /// </summary>
@@ -571,6 +633,9 @@ namespace HelixToolkit.UWP
             /// </summary>
             public static readonly ShaderDescription PSParticleOIT = new ShaderDescription(nameof(PSParticleOIT), ShaderStage.Pixel, new ShaderReflector(),
                 DefaultPSShaderByteCodes.PSParticleOIT);
+
+            public static readonly ShaderDescription PSParticleOITDP = new ShaderDescription(nameof(PSParticleOITDP), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSParticleOITDP);
             /// <summary>
             /// 
             /// </summary>
@@ -587,6 +652,9 @@ namespace HelixToolkit.UWP
             /// </summary>
             public static readonly ShaderDescription PSMeshWireframeOIT = new ShaderDescription(nameof(PSMeshWireframeOIT), ShaderStage.Pixel, new ShaderReflector(),
                 DefaultPSShaderByteCodes.PSMeshWireframeOIT);
+
+            public static readonly ShaderDescription PSMeshWireframeOITDP = new ShaderDescription(nameof(PSMeshWireframeOITDP), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSMeshWireframeOITDP);
             /// <summary>
             /// The ps depth stencil only
             /// </summary>
@@ -696,7 +764,8 @@ namespace HelixToolkit.UWP
             /// </summary>
             public static readonly ShaderDescription PSMeshPBROIT = new ShaderDescription(nameof(PSMeshPBROIT), ShaderStage.Pixel, new ShaderReflector(),
                 DefaultPSShaderByteCodes.PSMeshPBROIT);
-
+            public static readonly ShaderDescription PSMeshPBROITDP = new ShaderDescription(nameof(PSMeshPBROITDP), ShaderStage.Pixel, new ShaderReflector(),
+                DefaultPSShaderByteCodes.PSMeshPBROITDP);
             /// <summary>
             /// The ps sprite
             /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultStates.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/DefaultShaders/DefaultStates.cs
@@ -29,9 +29,13 @@ namespace HelixToolkit.UWP
             public readonly static BlendStateDescription AdditiveBlend;
             public readonly static BlendStateDescription BSScreenDupCursorBlend;
             public readonly static BlendStateDescription BSOITBlend = new BlendStateDescription() { IndependentBlendEnable = true };
+            public readonly static BlendStateDescription BSOTISortingBlend;
             public readonly static BlendStateDescription BSMeshOITBlendQuad;
             public readonly static BlendStateDescription VolumeBlending;
             public readonly static BlendStateDescription BSGlowBlending;
+            public readonly static BlendStateDescription BSOITDP;
+            public readonly static BlendStateDescription BSOITDPMaxBlending;
+            public readonly static BlendStateDescription BSOITDPFinal;
 
             static DefaultBlendStateDescriptions()
             {
@@ -156,6 +160,73 @@ namespace HelixToolkit.UWP
                     AlphaBlendOperation = BlendOperation.Add,
                     IsBlendEnabled = true,
                     RenderTargetWriteMask = ColorWriteMaskFlags.All
+                };
+
+                BSOITDP.IndependentBlendEnable = true;
+                // Max blending
+                BSOITDP.RenderTarget[0] = new RenderTargetBlendDescription()
+                {
+                    IsBlendEnabled = true,
+                    RenderTargetWriteMask = ColorWriteMaskFlags.All,
+                    SourceBlend = BlendOption.One,
+                    DestinationBlend = BlendOption.One,
+                    BlendOperation = BlendOperation.Maximum,
+                    SourceAlphaBlend = BlendOption.One,
+                    DestinationAlphaBlend = BlendOption.One,
+                    AlphaBlendOperation = BlendOperation.Maximum
+                };
+                // Front to back blending
+                BSOITDP.RenderTarget[1] = new RenderTargetBlendDescription()
+                {
+                    IsBlendEnabled = true,
+                    RenderTargetWriteMask = ColorWriteMaskFlags.All,
+                    SourceBlend = BlendOption.DestinationAlpha,
+                    DestinationBlend = BlendOption.One,
+                    BlendOperation = BlendOperation.Add,
+                    SourceAlphaBlend = BlendOption.Zero,
+                    DestinationAlphaBlend = BlendOption.InverseSourceAlpha,
+                    AlphaBlendOperation = BlendOperation.Add
+                };
+                // Back to front blending
+                BSOITDP.RenderTarget[2] = new RenderTargetBlendDescription()
+                {
+                    IsBlendEnabled = true,
+                    RenderTargetWriteMask = ColorWriteMaskFlags.All,
+                    SourceBlend = BlendOption.SourceAlpha,
+                    DestinationBlend = BlendOption.InverseSourceAlpha,
+                    BlendOperation = BlendOperation.Add,
+                    SourceAlphaBlend = BlendOption.Zero,
+                    DestinationAlphaBlend = BlendOption.One,
+                    AlphaBlendOperation = BlendOperation.Add
+                };
+
+                // Max blending
+                for (int i = 0; i < 3; ++i)
+                {
+                    BSOITDPMaxBlending.IndependentBlendEnable = true;
+                    BSOITDPMaxBlending.RenderTarget[i] = new RenderTargetBlendDescription()
+                    {
+                        IsBlendEnabled = true,
+                        RenderTargetWriteMask = ColorWriteMaskFlags.All,
+                        SourceBlend = BlendOption.One,
+                        DestinationBlend = BlendOption.One,
+                        BlendOperation = BlendOperation.Maximum,
+                        SourceAlphaBlend = BlendOption.One,
+                        DestinationAlphaBlend = BlendOption.One,
+                        AlphaBlendOperation = BlendOperation.Maximum
+                    };
+                }
+
+                BSOITDPFinal.RenderTarget[0] = new RenderTargetBlendDescription()
+                {
+                    IsBlendEnabled = true,
+                    RenderTargetWriteMask = ColorWriteMaskFlags.All,
+                    SourceBlend = BlendOption.One,
+                    DestinationBlend = BlendOption.SourceAlpha,
+                    BlendOperation = BlendOperation.Add,
+                    SourceAlphaBlend = BlendOption.One,
+                    DestinationAlphaBlend = BlendOption.One,
+                    AlphaBlendOperation = BlendOperation.Maximum
                 };
             }
         }

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -48,6 +48,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core\DynamicCubeMapCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\EmptyRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\AxisPlaneGridCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core\OITDepthPeeling.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\TopMostMeshRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\InstancingBillboardRenderCore.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core\InstancingMeshRenderCore.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/BillboardMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/BillboardMaterialVariable.cs
@@ -35,7 +35,17 @@ namespace HelixToolkit.UWP
                 get;
             }
 
-            public ShaderPass BillboardOITPass
+            public ShaderPass OITPass
+            {
+                get;
+            }
+
+            public ShaderPass OITDepthPeelingInit
+            {
+                get;
+            }
+
+            public ShaderPass OITDepthPeeling
             {
                 get;
             }
@@ -52,14 +62,13 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The core.</param>
-            /// <param name="billboardPassName">Name of the billboard pass.</param>
-            /// <param name="billboardOITPassName">Name of the billboard oit pass.</param>
-            public BillboardMaterialVariable(IEffectsManager manager, IRenderTechnique technique, BillboardMaterialCore materialCore,
-                string billboardPassName = DefaultPassNames.Default, string billboardOITPassName = DefaultPassNames.OITPass)
+            public BillboardMaterialVariable(IEffectsManager manager, IRenderTechnique technique, BillboardMaterialCore materialCore)
                 : base(manager, technique, DefaultPointLineConstantBufferDesc, materialCore)
             {
-                BillboardPass = technique[billboardPassName];
-                BillboardOITPass = technique[billboardOITPassName];
+                BillboardPass = technique[DefaultPassNames.Default];
+                OITPass = technique[DefaultPassNames.OITPass];
+                OITDepthPeelingInit = technique[DefaultPassNames.OITDepthPeelingInit];
+                OITDepthPeeling = technique[DefaultPassNames.OITDepthPeeling];
                 this.materialCore = materialCore;
                 shaderTextureSlot = BillboardPass.PixelShader.ShaderResourceViewMapping.TryGetBindSlot(ShaderTextureName);
                 textureSamplerSlot = BillboardPass.PixelShader.SamplerMapping.TryGetBindSlot(ShaderTextureSamplerName);
@@ -87,7 +96,21 @@ namespace HelixToolkit.UWP
 
             public override ShaderPass GetPass(RenderType renderType, RenderContext context)
             {
-                return renderType == RenderType.Transparent && context.IsOITPass ? BillboardOITPass : BillboardPass;
+                if (renderType == RenderType.Transparent)
+                {
+                    switch (context.OITRenderStage)
+                    {
+                        case OITRenderStage.SinglePassWeighted:
+                            return OITPass;
+                        case OITRenderStage.DepthPeelingInitMinMaxZ:
+                            return OITDepthPeelingInit;
+                        case OITRenderStage.DepthPeeling:
+                            return OITDepthPeeling;
+                        default:
+                            break;
+                    }
+                }
+                return BillboardPass;
             }
 
             public override ShaderPass GetShadowPass(RenderType renderType, RenderContext context)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/DiffuseMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/DiffuseMaterialVariable.cs
@@ -52,7 +52,16 @@ namespace HelixToolkit.UWP
             {
                 get;
             }
-            public ShaderPass TransparentPass
+            public ShaderPass OITPass
+            {
+                get;
+            }
+            public ShaderPass OITDepthPeelingInit
+            {
+                get;
+            }
+
+            public ShaderPass OITDepthPeeling
             {
                 get;
             }
@@ -67,6 +76,10 @@ namespace HelixToolkit.UWP
             public ShaderPass WireframeOITPass
             {
                 get;
+            }
+            public ShaderPass WireframeOITDPPass 
+            {
+                get; 
             }
             public ShaderPass DepthPass
             {
@@ -93,17 +106,7 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            /// <param name="materialPassName">Name of the material pass.</param>
-            /// <param name="wireframePassName">Name of the wireframe pass.</param>
-            /// <param name="materialOITPassName">Name of the material oit pass.</param>
-            /// <param name="wireframeOITPassName">Name of the wireframe oit pass.</param>
-            /// <param name="shadowPassName">Name of the shadow pass.</param>
-            /// <param name="depthPassName">Name of the depth pass</param>
-            private DiffuseMaterialVariables(IEffectsManager manager, IRenderTechnique technique, DiffuseMaterialCore materialCore,
-                string materialPassName = DefaultPassNames.Default, string wireframePassName = DefaultPassNames.Wireframe,
-                string materialOITPassName = DefaultPassNames.DiffuseOIT, string wireframeOITPassName = DefaultPassNames.WireframeOITPass,
-                string shadowPassName = DefaultPassNames.ShadowPass,
-                string depthPassName = DefaultPassNames.DepthPrepass)
+            private DiffuseMaterialVariables(IEffectsManager manager, IRenderTechnique technique, DiffuseMaterialCore materialCore)
                 : base(manager, technique, DefaultMeshConstantBufferDesc, materialCore)
             {
                 this.material = materialCore;
@@ -111,12 +114,15 @@ namespace HelixToolkit.UWP
                 samplerDiffuseSlot = samplerShadowSlot = -1;
                 textureManager = manager.MaterialTextureManager;
                 statePoolManager = manager.StateManager;
-                MaterialPass = technique[materialPassName];
-                TransparentPass = technique[materialOITPassName];
-                ShadowPass = technique[shadowPassName];
-                WireframePass = technique[wireframePassName];
-                WireframeOITPass = technique[wireframeOITPassName];
-                DepthPass = technique[depthPassName];
+                MaterialPass = technique[DefaultPassNames.Default];
+                OITPass = technique[DefaultPassNames.DiffuseOIT];
+                OITDepthPeelingInit = technique[DefaultPassNames.OITDepthPeelingInit];
+                OITDepthPeeling = technique[DefaultPassNames.DiffuseOITDP];
+                ShadowPass = technique[DefaultPassNames.ShadowPass];
+                WireframePass = technique[DefaultPassNames.Wireframe];
+                WireframeOITPass = technique[DefaultPassNames.WireframeOITPass];
+                WireframeOITDPPass = technique[DefaultPassNames.WireframeOITDPPass];
+                DepthPass = technique[DefaultPassNames.DepthPrepass];
                 UpdateMappings(MaterialPass);
                 CreateTextureViews();
                 CreateSamplers();
@@ -255,7 +261,21 @@ namespace HelixToolkit.UWP
 
             public override ShaderPass GetPass(RenderType renderType, RenderContext context)
             {
-                return renderType == RenderType.Transparent && context.IsOITPass ? TransparentPass : MaterialPass;
+                if (renderType == RenderType.Transparent)
+                {
+                    switch (context.OITRenderStage)
+                    {
+                        case OITRenderStage.SinglePassWeighted:
+                            return OITPass;
+                        case OITRenderStage.DepthPeelingInitMinMaxZ:
+                            return OITDepthPeelingInit;
+                        case OITRenderStage.DepthPeeling:
+                            return OITDepthPeeling;
+                        default:
+                            break;
+                    }
+                }
+                return MaterialPass;
             }
 
             public override ShaderPass GetShadowPass(RenderType renderType, RenderContext context)
@@ -270,7 +290,21 @@ namespace HelixToolkit.UWP
 
             public override ShaderPass GetWireframePass(RenderType renderType, RenderContext context)
             {
-                return renderType == RenderType.Transparent && context.IsOITPass ? WireframeOITPass : WireframePass;
+                if (renderType == RenderType.Transparent)
+                {
+                    switch (context.OITRenderStage)
+                    {
+                        case OITRenderStage.SinglePassWeighted:
+                            return WireframeOITPass;
+                        case OITRenderStage.DepthPeelingInitMinMaxZ:
+                            return OITDepthPeelingInit;
+                        case OITRenderStage.DepthPeeling:
+                            return WireframeOITDPPass;
+                        default:
+                            break;
+                    }
+                }
+                return WireframePass;
             }
 
             public override void Draw(DeviceContextProxy deviceContext, IAttachableBufferModel bufferModel, int instanceCount)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineArrowMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineArrowMaterialVariable.cs
@@ -25,13 +25,8 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            /// <param name="linePassName">Name of the line pass.</param>
-            /// <param name="shadowPassName">Name of the shadow pass.</param>
-            /// <param name="depthPassName">Name of the depth pass</param>
-            public LineArrowMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineArrowHeadMaterialCore materialCore,
-                string linePassName = DefaultPassNames.Default, string shadowPassName = DefaultPassNames.ShadowPass,
-                string depthPassName = DefaultPassNames.DepthPrepass)
-                : base(manager, technique, materialCore, linePassName, shadowPassName, depthPassName)
+            public LineArrowMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineArrowHeadMaterialCore materialCore)
+                : base(manager, technique, materialCore)
             {
                 this.material = materialCore;
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineMaterialVariable.cs
@@ -58,18 +58,13 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            /// <param name="linePassName">Name of the line pass.</param>
-            /// <param name="shadowPassName">Name of the shadow pass.</param>
-            /// <param name="depthPassName">Name of the depth pass</param>
-            public LineMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineMaterialCore materialCore,
-                string linePassName = DefaultPassNames.Default, string shadowPassName = DefaultPassNames.ShadowPass,
-                string depthPassName = DefaultPassNames.DepthPrepass)
+            public LineMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineMaterialCore materialCore)
                 : base(manager, technique, DefaultPointLineConstantBufferDesc, materialCore)
             {
                 textureManager = manager.MaterialTextureManager;
-                LinePass = technique[linePassName];
-                ShadowPass = technique[shadowPassName];
-                DepthPass = technique[depthPassName];
+                LinePass = technique[DefaultPassNames.Default];
+                ShadowPass = technique[DefaultPassNames.ShadowPass];
+                DepthPass = technique[DefaultPassNames.DepthPrepass];
                 this.material = materialCore;
                 shaderTextureSlot = LinePass.PixelShader.ShaderResourceViewMapping.TryGetBindSlot(ShaderTextureName);
                 textureSamplerSlot = LinePass.PixelShader.SamplerMapping.TryGetBindSlot(ShaderTextureSamplerName);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PhongMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PhongMaterialVariable.cs
@@ -57,10 +57,21 @@ namespace HelixToolkit.UWP
             {
                 get;
             }
-            public ShaderPass MaterialOITPass
+            public ShaderPass OITPass
             {
                 get;
             }
+
+            public ShaderPass OITDepthPeelingInit
+            { 
+                get;
+            }
+
+            public ShaderPass OITDepthPeeling
+            {
+                get;
+            }
+
             public ShaderPass ShadowPass
             {
                 get;
@@ -73,11 +84,19 @@ namespace HelixToolkit.UWP
             {
                 get;
             }
+            public ShaderPass WireframeOITDPPass 
+            { 
+                get;
+            }
             public ShaderPass TessellationPass
             {
                 get;
             }
             public ShaderPass TessellationOITPass
+            {
+                get;
+            }
+            public ShaderPass TessellationOITDPPass
             {
                 get;
             }
@@ -142,9 +161,7 @@ namespace HelixToolkit.UWP
                 {
                     if (Set(ref enableTessellation, value))
                     {
-                        currentMaterialPass = value ? TessellationPass : MaterialPass;
                         UpdateMappings(currentMaterialPass);
-                        currentOITPass = value ? TessellationOITPass : MaterialOITPass;
                         InvalidateRenderer();
                     }
                 }
@@ -155,8 +172,7 @@ namespace HelixToolkit.UWP
             }
 
             private readonly PhongMaterialCore material;
-            private ShaderPass currentMaterialPass = ShaderPass.NullPass;
-            private ShaderPass currentOITPass = ShaderPass.NullPass;
+            private ShaderPass currentMaterialPass => EnableTessellation ? TessellationPass : MaterialPass;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="PhongMaterialVariables"/> class.
@@ -164,21 +180,7 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            /// <param name="materialPassName">Name of the material pass.</param>
-            /// <param name="wireframePassName">Name of the wireframe pass.</param>
-            /// <param name="materialOITPassName">Name of the material oit pass.</param>
-            /// <param name="wireframeOITPassName">Name of the wireframe oit pass.</param>
-            /// <param name="shadowPassName">Name of the shadow pass.</param>
-            /// <param name="tessellationPassName">Name of the tessellation pass.</param>
-            /// <param name="tessellationOITPassName">Name of the tessellation oit pass.</param>
-            /// <param name="depthPassName">Name of the depth pass</param>
-            public PhongMaterialVariables(IEffectsManager manager, IRenderTechnique technique, PhongMaterialCore materialCore,
-                string materialPassName = DefaultPassNames.Default, string wireframePassName = DefaultPassNames.Wireframe,
-                string materialOITPassName = DefaultPassNames.OITPass, string wireframeOITPassName = DefaultPassNames.WireframeOITPass,
-                string shadowPassName = DefaultPassNames.ShadowPass,
-                string tessellationPassName = DefaultPassNames.MeshTriTessellation,
-                string tessellationOITPassName = DefaultPassNames.MeshTriTessellationOIT,
-                string depthPassName = DefaultPassNames.DepthPrepass)
+            public PhongMaterialVariables(IEffectsManager manager, IRenderTechnique technique, PhongMaterialCore materialCore)
                 : base(manager, technique, DefaultMeshConstantBufferDesc, materialCore)
             {
                 this.material = materialCore;
@@ -187,30 +189,20 @@ namespace HelixToolkit.UWP
                 textureManager = manager.MaterialTextureManager;
                 statePoolManager = manager.StateManager;
 
-                MaterialPass = technique[materialPassName];
-                MaterialOITPass = technique[materialOITPassName];
-                ShadowPass = technique[shadowPassName];
-                WireframePass = technique[wireframePassName];
-                WireframeOITPass = technique[wireframeOITPassName];
-                TessellationPass = technique[tessellationPassName];
-                TessellationOITPass = technique[tessellationOITPassName];
-                DepthPass = technique[depthPassName];
+                MaterialPass = technique[DefaultPassNames.Default];
+                OITPass = technique[DefaultPassNames.OITPass];
+                OITDepthPeelingInit = technique[DefaultPassNames.OITDepthPeelingInit];
+                OITDepthPeeling = technique[DefaultPassNames.OITDepthPeeling];
+                ShadowPass = technique[DefaultPassNames.ShadowPass];
+                WireframePass = technique[DefaultPassNames.Wireframe];
+                WireframeOITPass = technique[DefaultPassNames.WireframeOITPass];
+                WireframeOITDPPass = technique[DefaultPassNames.WireframeOITDPPass];
+                TessellationPass = technique[DefaultPassNames.MeshTriTessellation];
+                TessellationOITPass = technique[DefaultPassNames.MeshTriTessellationOIT];
+                TessellationOITDPPass = technique[DefaultPassNames.MeshPBRTriTessellationOITDP];
+                DepthPass = technique[DefaultPassNames.DepthPrepass];
                 UpdateMappings(MaterialPass);
                 EnableTessellation = materialCore.EnableTessellation;
-                currentMaterialPass = EnableTessellation ? TessellationPass : MaterialPass;
-                currentOITPass = EnableTessellation ? TessellationOITPass : MaterialOITPass;
-            }
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="PhongMaterialVariables"/> class. This construct will be using the PassName pass into constructor only.
-            /// </summary>
-            /// <param name="passName">Name of the pass.</param>
-            /// <param name="manager">The manager.</param>
-            /// <param name="technique"></param>
-            /// <param name="material">The material.</param>
-            public PhongMaterialVariables(string passName, IEffectsManager manager, IRenderTechnique technique, PhongMaterialCore material)
-                : this(manager, technique, material, passName)
-            {
             }
 
             protected override void OnInitialPropertyBindings()
@@ -419,7 +411,21 @@ namespace HelixToolkit.UWP
 
             public override ShaderPass GetPass(RenderType renderType, RenderContext context)
             {
-                return renderType == RenderType.Transparent && context.IsOITPass ? currentOITPass : currentMaterialPass;
+                if (renderType == RenderType.Transparent)
+                {
+                    switch (context.OITRenderStage)
+                    {
+                        case OITRenderStage.SinglePassWeighted:
+                            return EnableTessellation ? TessellationOITPass : OITPass;
+                        case OITRenderStage.DepthPeelingInitMinMaxZ:
+                            return OITDepthPeelingInit;
+                        case OITRenderStage.DepthPeeling:
+                            return EnableTessellation ? TessellationOITDPPass : OITDepthPeeling;
+                        default:
+                            break;
+                    }
+                }
+                return currentMaterialPass;
             }
 
             public override ShaderPass GetShadowPass(RenderType renderType, RenderContext context)
@@ -429,7 +435,21 @@ namespace HelixToolkit.UWP
 
             public override ShaderPass GetWireframePass(RenderType renderType, RenderContext context)
             {
-                return renderType == RenderType.Transparent && context.IsOITPass ? WireframeOITPass : WireframePass;
+                if (renderType == RenderType.Transparent)
+                {
+                    switch (context.OITRenderStage)
+                    {
+                        case OITRenderStage.SinglePassWeighted:
+                            return WireframeOITPass;
+                        case OITRenderStage.DepthPeelingInitMinMaxZ:
+                            return OITDepthPeelingInit;
+                        case OITRenderStage.DepthPeeling:
+                            return WireframeOITDPPass;
+                        default:
+                            break;
+                    }
+                }
+                return WireframePass;
             }
 
             public override ShaderPass GetDepthPass(RenderType renderType, RenderContext context)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PointMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PointMaterialVariable.cs
@@ -45,14 +45,12 @@ namespace HelixToolkit.UWP
             /// <param name="pointPassName">Name of the point pass.</param>
             /// <param name="shadowPassName">Name of the shadow pass.</param>
             /// <param name="depthPassName">Name of the depth pass</param>
-            public PointMaterialVariable(IEffectsManager manager, IRenderTechnique technique, PointMaterialCore materialCore,
-                string pointPassName = DefaultPassNames.Default, string shadowPassName = DefaultPassNames.ShadowPass,
-                string depthPassName = DefaultPassNames.DepthPrepass)
+            public PointMaterialVariable(IEffectsManager manager, IRenderTechnique technique, PointMaterialCore materialCore)
                 : base(manager, technique, DefaultPointLineConstantBufferDesc, materialCore)
             {
-                PointPass = technique[pointPassName];
-                ShadowPass = technique[shadowPassName];
-                DepthPass = technique[depthPassName];
+                PointPass = technique[DefaultPassNames.Default];
+                ShadowPass = technique[DefaultPassNames.ShadowPass];
+                DepthPass = technique[DefaultPassNames.DepthPrepass];
                 this.material = materialCore;
             }
 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PointMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PointMaterialVariable.cs
@@ -42,9 +42,6 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            /// <param name="pointPassName">Name of the point pass.</param>
-            /// <param name="shadowPassName">Name of the shadow pass.</param>
-            /// <param name="depthPassName">Name of the depth pass</param>
             public PointMaterialVariable(IEffectsManager manager, IRenderTechnique technique, PointMaterialCore materialCore)
                 : base(manager, technique, DefaultPointLineConstantBufferDesc, materialCore)
             {

--- a/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy/DeviceContextProxy_Targets.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/DeviceContextProxy/DeviceContextProxy_Targets.cs
@@ -295,7 +295,53 @@ namespace HelixToolkit.UWP
             {
                 deviceContext.ClearUnorderedAccessView(unorderedAccessViewRef, values);
             }
+
+            /// <summary>
+            /// Clears an unordered access resource with bit-precise values.
+            /// </summary>
+            /// <param name="unorderedAccessViewRef">The unordered access view reference.</param>
+            /// <param name="values">The values.</param>
+            /// <remarks>
+            ///     This API copies the lower ni bits from each array element i to the corresponding
+            ///     channel, where ni is the number of bits in the ith channel of the resource format
+            ///     (for example, R8G8B8_FLOAT has 8 bits for the first 3 channels). This works on
+            ///     any UAV with no format conversion. For a raw or structured buffer view, only
+            ///     the first array element value is used.
+            /// </remarks>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ClearUnorderedAccessView(UnorderedAccessView unorderedAccessViewRef, ref Int4 values)
+            {
+                deviceContext.ClearUnorderedAccessView(unorderedAccessViewRef, values);
+            }
+
+            /// <summary>
+            /// Clears an unordered access resource with a float value.
+            /// </summary>
+            /// <param name="unorderedAccessViewRef">The unordered access view reference.</param>
+            /// <param name="values">The values.</param>
+            /// <remarks>
+            ///     This API works on FLOAT, UNORM, and SNORM unordered access views (UAVs), with
+            ///     format conversion from FLOAT to *NORM where appropriate. On other UAVs, the operation
+            ///     is invalid and the call will not reach the driver.
+            /// </remarks>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ClearUnorderedAccessView(UnorderedAccessView unorderedAccessViewRef, ref Vector4 values)
+            {
+                deviceContext.ClearUnorderedAccessView(unorderedAccessViewRef, values);
+            }
             #endregion Clear Targets
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void SetOutputUAV(int slot, UnorderedAccessView uav)
+            {
+                deviceContext.OutputMerger.SetUnorderedAccessView(slot, uav);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void SetOutputUAVs(int startSlot, UnorderedAccessView[] uavs)
+            {
+                deviceContext.OutputMerger.SetUnorderedAccessViews(startSlot, uavs);
+            }
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderContext.cs
@@ -30,6 +30,27 @@ namespace HelixToolkit.UWP
     using Utilities;
     using Render;
 
+    public enum OITRenderType
+    {
+        None,
+        /// <summary>
+        /// Use weighted order independent transparent rendering. This OIT is the fastest but not color accurate in many cases.
+        /// </summary>
+        SinglePassWeighted,
+        /// <summary>
+        /// Use classic depth peeling method for independent transparent rendering.
+        /// </summary>
+        DepthPeeling
+    }
+
+    public enum OITRenderStage
+    {
+        None,
+        SinglePassWeighted,
+        DepthPeelingInitMinMaxZ,
+        DepthPeeling,
+    }
+
     /// <summary>
     /// The render-context is currently generated per frame
     /// Optimizations might be possible
@@ -221,12 +242,12 @@ namespace HelixToolkit.UWP
         public bool IsDeferredPass;
 
         /// <summary>
-        /// Gets or sets a value indicating whether is order independent transparent pass.
+        /// Gets or sets a value indicating order independent transparent pass stage.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if this instance is oit pass; otherwise, <c>false</c>.
+        ///   <c>None</c> It is not using oit pass <c>false</c>.
         /// </value>
-        public bool IsOITPass = false;
+        public OITRenderStage OITRenderStage = OITRenderStage.None;
 
         /// <summary>
         /// Gets or sets the name of the custom pass.
@@ -351,6 +372,14 @@ namespace HelixToolkit.UWP
                 return (OITWeightMode)globalTransform.OITWeightMode;
             }
         }
+        /// <summary>
+        /// Depth peeling iteration. Default is 4. 
+        /// Iteration depends on estimating number of overlapping semi-transparent layers to be accurately rendered.
+        /// </summary>
+        public int OITDepthPeelingIteration
+        {
+            set; get;
+        } = 4;
         /// <summary>
         /// Gets or sets a value indicating whether [ssao enabled].
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DX11RenderHostConfiguration.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DX11RenderHostConfiguration.cs
@@ -43,13 +43,6 @@ namespace HelixToolkit.UWP
             /// </summary>
             public bool AutoUpdateOctree = false;
             /// <summary>
-            /// Gets or sets a value indicating whether [enable oit rendering].
-            /// </summary>
-            /// <value>
-            ///   <c>true</c> if [enable oit rendering]; otherwise, <c>false</c>.
-            /// </value>
-            public bool EnableOITRendering = true;
-            /// <summary>
             /// Gets or sets the OIT weight power used for color weight calculation. Default = 3.
             /// </summary>
             /// <value>
@@ -74,6 +67,17 @@ namespace HelixToolkit.UWP
             /// The oit weight mode.
             /// </value>
             public OITWeightMode OITWeightMode = OITWeightMode.Linear1;
+
+            /// <summary>
+            /// Gets or sets the oit render mode
+            /// </summary>
+            public OITRenderType OITRenderType = OITRenderType.DepthPeeling;
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public int OITDepthPeelingIteration = 4;
+
             /// <summary>
             /// Enable FXAA. If MSAA used, FXAA will be disabled automatically
             /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -608,8 +608,8 @@ namespace HelixToolkit.UWP
             public DX11RenderHostConfiguration RenderConfiguration
             {
                 set; get;
-            }
-                = new DX11RenderHostConfiguration() { UpdatePerFrameData = true, RenderD2D = true, RenderLights = true, ClearEachFrame = true, EnableOITRendering = true };
+            } = new DX11RenderHostConfiguration() { UpdatePerFrameData = true, RenderD2D = true, 
+                RenderLights = true, ClearEachFrame = true, OITRenderType = OITRenderType.DepthPeeling };
             /// <summary>
             /// Gets the feature level.
             /// </summary>
@@ -775,6 +775,7 @@ namespace HelixToolkit.UWP
                         renderContext.SSAOEnabled = RenderConfiguration.EnableSSAO;
                         renderContext.SSAOBias = RenderConfiguration.SSAOBias;
                         renderContext.SSAOIntensity = RenderConfiguration.SSAOIntensity;
+                        RenderContext.OITDepthPeelingIteration = RenderConfiguration.OITDepthPeelingIteration;
                     }
                     renderBuffer.VSyncInterval = RenderConfiguration.EnableVSync ? 1 : 0;
                     var updateSceneGraph = UpdateSceneGraphRequested;

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -33,7 +33,8 @@ namespace HelixToolkit.UWP
         {
             private readonly Stack<KeyValuePair<int, IList<SceneNode>>> stackCache1 = new Stack<KeyValuePair<int, IList<SceneNode>>>(20);
             private readonly Stack<KeyValuePair<int, IList<SceneNode2D>>> stack2DCache1 = new Stack<KeyValuePair<int, IList<SceneNode2D>>>(20);
-            private OrderIndependentTransparentRenderCore transparentRenderCore;
+            private OrderIndependentTransparentRenderCore oitWeightedCore;
+            private OITDepthPeeling oitDepthPeelingCore;
             private PostEffectFXAA postFXAACore;
             private SSAOCore preSSAOCore;
             private DeviceContextProxy immediateContext;
@@ -56,7 +57,8 @@ namespace HelixToolkit.UWP
 #else
                 immediateContext = new DeviceContextProxy(deviceResource.Device.ImmediateContext, deviceResource.Device);
 #endif
-                transparentRenderCore = new OrderIndependentTransparentRenderCore();
+                oitWeightedCore = new OrderIndependentTransparentRenderCore();
+                oitDepthPeelingCore = new OITDepthPeeling();
                 postFXAACore = new PostEffectFXAA();
                 preSSAOCore = new SSAOCore();
             }
@@ -161,25 +163,30 @@ namespace HelixToolkit.UWP
             /// <returns></returns>
             public virtual int RenderTransparent(RenderContext context, FastList<SceneNode> renderables, ref RenderParameter parameter)
             {
-                if (context.RenderHost.RenderConfiguration.EnableOITRendering
+                if (context.RenderHost.RenderConfiguration.OITRenderType != OITRenderType.None
                     && context.RenderHost.FeatureLevel >= global::SharpDX.Direct3D.FeatureLevel.Level_11_0)
                 {
-                    transparentRenderCore.ExternRenderParameter = parameter;
-                    transparentRenderCore.Render(context, ImmediateContext);
-                    return transparentRenderCore.RenderCount;
-                }
-                else
-                {
-                    var renderedCount = 0;
-                    var frustum = context.BoundingFrustum;
-                    var count = renderables.Count;
-                    for (var i = 0; i < count; ++i)
+                    switch (context.RenderHost.RenderConfiguration.OITRenderType)
                     {
-                        renderables[i].Render(context, ImmediateContext);
-                        ++renderedCount;
-                    }
-                    return renderedCount;
+                        case OITRenderType.SinglePassWeighted:
+                            oitWeightedCore.ExternRenderParameter = parameter;
+                            oitWeightedCore.Render(context, ImmediateContext);
+                            return oitWeightedCore.RenderCount;
+                        case OITRenderType.DepthPeeling:
+                            oitDepthPeelingCore.ExternRenderParameter = parameter;
+                            oitDepthPeelingCore.PeelingIteration = context.OITDepthPeelingIteration;
+                            oitDepthPeelingCore.Render(context, ImmediateContext);
+                            return oitDepthPeelingCore.RenderCount;
+                    }                    
                 }
+                var renderedCount = 0;
+                var count = renderables.Count;
+                for (var i = 0; i < count; ++i)
+                {
+                    renderables[i].Render(context, ImmediateContext);
+                    ++renderedCount;
+                }
+                return renderedCount;
             }
             /// <summary>
             /// Updates the no render parallel. <see cref="IRenderer.UpdateNotRenderParallel(RenderContext, FastList{KeyValuePair{int, SceneNode}})"/>
@@ -367,7 +374,8 @@ namespace HelixToolkit.UWP
             {
                 Detach();
                 RemoveAndDispose(ref immediateContext);
-                RemoveAndDispose(ref transparentRenderCore);
+                RemoveAndDispose(ref oitWeightedCore);
+                RemoveAndDispose(ref oitDepthPeelingCore);
                 RemoveAndDispose(ref postFXAACore);
                 RemoveAndDispose(ref preSSAOCore);
                 base.OnDispose(disposeManagedResources);
@@ -377,7 +385,8 @@ namespace HelixToolkit.UWP
             {
                 if (host.FeatureLevel >= global::SharpDX.Direct3D.FeatureLevel.Level_11_0)
                 {
-                    transparentRenderCore.Attach(host.EffectsManager.GetTechnique(DefaultRenderTechniqueNames.MeshOITQuad));
+                    oitWeightedCore.Attach(host.EffectsManager.GetTechnique(DefaultRenderTechniqueNames.MeshOITQuad));
+                    oitDepthPeelingCore.Attach(host.EffectsManager.GetTechnique(DefaultRenderTechniqueNames.MeshOITDepthPeeling));
                     postFXAACore.Attach(host.EffectsManager.GetTechnique(DefaultRenderTechniqueNames.PostEffectFXAA));
                     preSSAOCore.Attach(host.EffectsManager.GetTechnique(DefaultRenderTechniqueNames.SSAO));
                 }
@@ -387,9 +396,10 @@ namespace HelixToolkit.UWP
             {
                 stackCache1.Clear();
                 stack2DCache1.Clear();
-                transparentRenderCore.Detach();
+                oitWeightedCore.Detach();
+                oitDepthPeelingCore.Detach();
                 postFXAACore.Detach();
-                preSSAOCore.Detach();
+                preSSAOCore.Detach();               
             }
         }
     }

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
@@ -185,6 +185,26 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeelingInit)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshDefault,
+                            DefaultPSShaderDescriptions.PSMeshOITDPInit
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDPMaxBlending,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeeling)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshDefault,
+                            DefaultPSShaderDescriptions.PSMeshBlinnPhongOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
                     new ShaderPassDescription(DefaultPassNames.PBROITPass)
                     {
                         ShaderList = new[]
@@ -195,6 +215,16 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
+                    new ShaderPassDescription(DefaultPassNames.PBROITDPPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshDefault,
+                            DefaultPSShaderDescriptions.PSMeshPBROITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
                     new ShaderPassDescription(DefaultPassNames.DiffuseOIT)
                     {
                         ShaderList = new[]
@@ -203,6 +233,16 @@ namespace HelixToolkit.UWP
                             DefaultPSShaderDescriptions.PSMeshDiffuseMapOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },                    
+                    new ShaderPassDescription(DefaultPassNames.DiffuseOITDP)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshDefault,
+                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
                     new ShaderPassDescription(DefaultPassNames.PreComputeMeshBoneSkinned)
@@ -263,6 +303,19 @@ namespace HelixToolkit.UWP
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
                         Topology = PrimitiveTopology.PatchListWith3ControlPoints
                     },
+                    new ShaderPassDescription(DefaultPassNames.MeshTriTessellationOITDP)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshTessellation,
+                            DefaultHullShaderDescriptions.HSMeshTessellation,
+                            DefaultDomainShaderDescriptions.DSMeshTessellation,
+                            DefaultPSShaderDescriptions.PSMeshBlinnPhongOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
+                        Topology = PrimitiveTopology.PatchListWith3ControlPoints
+                    },
                     new ShaderPassDescription(DefaultPassNames.MeshPBRTriTessellation)
                     {
                         ShaderList = new[]
@@ -286,6 +339,19 @@ namespace HelixToolkit.UWP
                             DefaultPSShaderDescriptions.PSMeshPBROIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
+                        Topology = PrimitiveTopology.PatchListWith3ControlPoints
+                    },                   
+                    new ShaderPassDescription(DefaultPassNames.MeshPBRTriTessellationOITDP)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshTessellation,
+                            DefaultHullShaderDescriptions.HSMeshTessellation,
+                            DefaultDomainShaderDescriptions.DSMeshTessellation,
+                            DefaultPSShaderDescriptions.PSMeshPBROITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
                         Topology = PrimitiveTopology.PatchListWith3ControlPoints
                     },
@@ -328,6 +394,17 @@ namespace HelixToolkit.UWP
                             DefaultPSShaderDescriptions.PSMeshWireframeOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
+                        Topology = PrimitiveTopology.TriangleList
+                    },                    
+                    new ShaderPassDescription(DefaultPassNames.WireframeOITDPPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshWireframe,
+                            DefaultPSShaderDescriptions.PSMeshWireframeOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
                         Topology = PrimitiveTopology.TriangleList
                     },
@@ -516,6 +593,16 @@ namespace HelixToolkit.UWP
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },                   
+                    new ShaderPassDescription(DefaultPassNames.PBROITDPPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshBatched,
+                            DefaultPSShaderDescriptions.PSMeshPBROITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
                     new ShaderPassDescription(DefaultPassNames.PreComputeMeshBoneSkinned)
                     {
@@ -537,6 +624,16 @@ namespace HelixToolkit.UWP
                             DefaultPSShaderDescriptions.PSMeshDiffuseMapOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.DiffuseOITDP)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshBatched,
+                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
                     new ShaderPassDescription(DefaultPassNames.DepthPrepass)
@@ -598,6 +695,17 @@ namespace HelixToolkit.UWP
                             DefaultPSShaderDescriptions.PSMeshWireframeOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
+                        Topology = PrimitiveTopology.TriangleList
+                    },
+                    new ShaderPassDescription(DefaultPassNames.WireframeOITDPPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshBatchedWireframe,
+                            DefaultPSShaderDescriptions.PSMeshWireframeOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
                         Topology = PrimitiveTopology.TriangleList
                     },
@@ -808,6 +916,46 @@ namespace HelixToolkit.UWP
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },                    
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeelingInit)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshInstancing,
+                            DefaultPSShaderDescriptions.PSMeshOITDPInit
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDPMaxBlending,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeeling)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshInstancing,
+                            DefaultPSShaderDescriptions.PSMeshBlinnPhongOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.PBROITDPPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshInstancing,
+                            DefaultPSShaderDescriptions.PSMeshPBROITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.DiffuseOITDP)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshInstancing,
+                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
                     new ShaderPassDescription(DefaultPassNames.DepthPrepass)
                     {
@@ -855,6 +1003,19 @@ namespace HelixToolkit.UWP
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
                         Topology = PrimitiveTopology.PatchListWith3ControlPoints
                     },
+                    new ShaderPassDescription(DefaultPassNames.MeshTriTessellationOITDP)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshInstancingTessellation,
+                            DefaultHullShaderDescriptions.HSMeshTessellation,
+                            DefaultDomainShaderDescriptions.DSMeshTessellation,
+                            DefaultPSShaderDescriptions.PSMeshBlinnPhongOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
+                        Topology = PrimitiveTopology.PatchListWith3ControlPoints
+                    },
                     new ShaderPassDescription(DefaultPassNames.ShadowPass)
                     {
                         ShaderList = new[]
@@ -884,6 +1045,17 @@ namespace HelixToolkit.UWP
                             DefaultPSShaderDescriptions.PSMeshWireframeOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
+                        Topology = PrimitiveTopology.TriangleList
+                    },
+                    new ShaderPassDescription(DefaultPassNames.WireframeOITDPPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshWireframe,
+                            DefaultPSShaderDescriptions.PSMeshWireframeOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
                         Topology = PrimitiveTopology.TriangleList
                     },
@@ -1382,6 +1554,28 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeelingInit)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSBillboardText,
+                            DefaultGSShaderDescriptions.GSBillboard,
+                            DefaultPSShaderDescriptions.PSMeshOITDPInit
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDPMaxBlending,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeeling)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSBillboardText,
+                            DefaultGSShaderDescriptions.GSBillboard,
+                            DefaultPSShaderDescriptions.PSBillboardTextOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    }
                 }
             };
 
@@ -1410,6 +1604,28 @@ namespace HelixToolkit.UWP
                             DefaultPSShaderDescriptions.PSBillboardTextOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeelingInit)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSBillboardInstancing,
+                            DefaultGSShaderDescriptions.GSBillboard,
+                            DefaultPSShaderDescriptions.PSMeshOITDPInit
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDPMaxBlending,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeeling)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSBillboardInstancing,
+                            DefaultGSShaderDescriptions.GSBillboard,
+                            DefaultPSShaderDescriptions.PSBillboardTextOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
                 }
@@ -1532,6 +1748,46 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
                     },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeelingInit)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshClipPlane,
+                            DefaultPSShaderDescriptions.PSMeshOITDPInit
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDPMaxBlending,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeeling)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshClipPlane,
+                            DefaultPSShaderDescriptions.PSMeshBlinnPhongOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.PBROITDPPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshClipPlane,
+                            DefaultPSShaderDescriptions.PSMeshPBROITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.DiffuseOITDP)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshClipPlane,
+                            DefaultPSShaderDescriptions.PSMeshDiffuseMapOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
                     new ShaderPassDescription(DefaultPassNames.DepthPrepass)
                     {
                         ShaderList = new[]
@@ -1583,6 +1839,16 @@ namespace HelixToolkit.UWP
                             DefaultPSShaderDescriptions.PSMeshWireframeOIT
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
+                    },
+                    new ShaderPassDescription(DefaultPassNames.WireframeOITDPPass)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshClipPlane,
+                            DefaultPSShaderDescriptions.PSMeshWireframeOITDP
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessEqualNoWrite,
                     },
                     new ShaderPassDescription(DefaultPassNames.EffectOutlineP1)
@@ -1684,6 +1950,29 @@ namespace HelixToolkit.UWP
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
                         BlendStateDescription = DefaultBlendStateDescriptions.BSOITBlend,
                         RasterStateDescription = DefaultRasterDescriptions.RSSolidNoMSAA
+                    },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeelingInit)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSParticle,
+                            DefaultGSShaderDescriptions.GSParticle,
+                            DefaultPSShaderDescriptions.PSMeshOITDPInit
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDPMaxBlending,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite
+                    },
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeeling)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSParticle,
+                            DefaultGSShaderDescriptions.GSParticle,
+                            DefaultPSShaderDescriptions.PSParticleOITDP
+                        },
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSLessNoWrite,
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDP,
+                        RasterStateDescription = DefaultRasterDescriptions.RSSolidNoMSAA
                     }
                 }
             };
@@ -1722,6 +2011,27 @@ namespace HelixToolkit.UWP
                         BlendStateDescription = DefaultBlendStateDescriptions.BSMeshOITBlendQuad,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSNoDepthNoStencil,
                         RasterStateDescription = DefaultRasterDescriptions.RSOutline,
+                        Topology = PrimitiveTopology.TriangleStrip
+                    }
+                }
+            };
+
+            var meshOITDepthPeeling = new TechniqueDescription(DefaultRenderTechniqueNames.MeshOITDepthPeeling)
+            {
+                InputLayoutDescription = InputLayoutDescription.EmptyInputLayout,
+                PassDescriptions = new[]
+                {
+                    new ShaderPassDescription(DefaultPassNames.OITDepthPeelingFinal)
+                    {
+                        ShaderList = new[]
+                        {
+                            DefaultVSShaderDescriptions.VSMeshOutlineScreenQuad,
+                            DefaultPSShaderDescriptions.PSMeshOITDPFinal,
+                        },
+                        BlendStateDescription = DefaultBlendStateDescriptions.BSOITDPFinal,
+                        DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSNoDepthNoStencil,
+                        RasterStateDescription = DefaultRasterDescriptions.RSSkybox,
+                        StencilRef = 0,
                         Topology = PrimitiveTopology.TriangleStrip
                     }
                 }
@@ -2146,6 +2456,7 @@ namespace HelixToolkit.UWP
             yield return sprite2D;
             yield return volume3D;
             yield return ssao;
+            yield return meshOITDepthPeeling;
 #if !NETFX_CORE
             yield return renderScreenDup;
 #endif

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/RenderTechniqueNames.cs
@@ -98,6 +98,12 @@ namespace HelixToolkit.UWP
         /// </summary>
         public const string MeshOITQuad = "MeshOITQuad";
         /// <summary>
+        /// 
+        /// </summary>
+        public const string MeshOITSortRender = "MeshOITSortRender";
+
+        public const string MeshOITDepthPeeling = "MeshOITDeepPeeling";
+        /// <summary>
         /// The post effect fxaa
         /// </summary>
         public const string PostEffectFXAA = "PostEffectFXAA";
@@ -148,6 +154,7 @@ namespace HelixToolkit.UWP
         /// The diffuse oit
         /// </summary>
         public const string DiffuseOIT = "RenderDiffuseOIT";
+        public const string DiffuseOITDP = "RenderDiffuseOITDepthPeeling";
         /// <summary>
         /// 
         /// </summary>
@@ -189,27 +196,41 @@ namespace HelixToolkit.UWP
         /// </summary>
         public const string OITPass = "MeshOITPass";
 
+        #region Deep peeling
+        public const string OITDepthPeelingInit = "OITDepthPeelingFirst";
+
+        public const string OITDepthPeeling = "OITDepthPeeling";
+
+        public const string OITDepthPeelingBlending = "OITDepthPeelingBlending";
+
+        public const string OITDepthPeelingFinal = "OITDepthPeelingFinal";
+        #endregion
         /// <summary>
         /// The oit pass PBR
         /// </summary>
         public const string PBROITPass = "MeshPhysicsBasedOITPass";
-
+        public const string PBROITDPPass = "MeshPhysicsBasedOITDepthPeelingPass";
         /// <summary>
         /// 
         /// </summary>
         public const string WireframeOITPass = "WireframeOIT";
+        public const string WireframeOITDPPass = "WireframeOITDP";
         /// <summary>
         /// 
         /// </summary>
         public const string MeshTriTessellation = "MeshTriTessellation";
 
         public const string MeshTriTessellationOIT = "MeshTriTessellationOIT";
+
+        public const string MeshTriTessellationOITDP = "MeshTriTessellationOITDP";
         /// <summary>
         /// 
         /// </summary>
         public const string MeshPBRTriTessellation = "MeshPBRTriTessellation";
 
         public const string MeshPBRTriTessellationOIT = "MeshPBRTriTessellationOIT";
+
+        public const string MeshPBRTriTessellationOITDP = "MeshPBRTriTessellationOITDP";
         /// <summary>
         /// 
         /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
@@ -132,7 +132,36 @@ namespace HelixToolkit.UWP
                 resource = new Texture3D(device, textureDesc);
                 TextureFormat = textureDesc.Format;
             }
-
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ShaderResourceViewProxy"/> class.
+            /// </summary>
+            /// <param name="device">The device.</param>
+            /// <param name="textureDesc">The texture desc.</param>
+            public ShaderResourceViewProxy(Device device, ref Texture1DDescription textureDesc) : this(device)
+            {
+                resource = new Texture1D(device, textureDesc);
+                TextureFormat = textureDesc.Format;
+            }
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ShaderResourceViewProxy"/> class.
+            /// </summary>
+            /// <param name="device">The device.</param>
+            /// <param name="textureDesc">The texture desc.</param>
+            public ShaderResourceViewProxy(Device device, ref Texture2DDescription textureDesc) : this(device)
+            {
+                resource = new Texture2D(device, textureDesc);
+                TextureFormat = textureDesc.Format;
+            }
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ShaderResourceViewProxy"/> class.
+            /// </summary>
+            /// <param name="device">The device.</param>
+            /// <param name="textureDesc">The texture desc.</param>
+            public ShaderResourceViewProxy(Device device, ref Texture3DDescription textureDesc) : this(device)
+            {
+                resource = new Texture3D(device, textureDesc);
+                TextureFormat = textureDesc.Format;
+            }
             /// <summary>
             /// 
             /// </summary>
@@ -317,6 +346,19 @@ namespace HelixToolkit.UWP
                     return;
                 }
                 textureView = new ShaderResourceView(device, resource);
+            }
+
+            /// <summary>
+            /// Creates the view.
+            /// </summary>
+            public void CreateTextureView(ref ShaderResourceViewDescription desc)
+            {
+                RemoveAndDispose(ref textureView);
+                if (resource == null)
+                {
+                    return;
+                }
+                textureView = new ShaderResourceView(device, resource, desc);
             }
             /// <summary>
             /// Creates the render target.

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/UAVBufferViewProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/UAVBufferViewProxy.cs
@@ -24,51 +24,61 @@ namespace HelixToolkit.UWP
         /// </summary>
         public sealed class UAVBufferViewProxy : IDisposable
         {
-            private SDX11.Buffer buffer;
-            /// <summary>
-            /// The uav
-            /// </summary>
-            public UnorderedAccessView uav;
-            /// <summary>
-            /// The SRV
-            /// </summary>
-            public ShaderResourceViewProxy srv;
-
+            private SDX11.Resource resource;
+            public Resource Resource => resource;
+ 
+            private UnorderedAccessView uav;
             /// <summary>
             /// Get UnorderedAccessView
             /// </summary>
-            public UnorderedAccessView UAV
-            {
-                get
-                {
-                    return uav;
-                }
-            }
-
+            public UnorderedAccessView UAV => uav;
+            private ShaderResourceViewProxy srv;
             /// <summary>
             /// Get ShaderResourceView
             /// </summary>
-            public ShaderResourceViewProxy SRV
-            {
-                get
-                {
-                    return srv;
-                }
-            }
+            public ShaderResourceViewProxy SRV => srv;
+
             /// <summary>
-            /// Initializes a new instance of the <see cref="UAVBufferViewProxy"/> class.
+            /// Create a raw buffer based UAV
             /// </summary>
             /// <param name="device">The device.</param>
             /// <param name="bufferDesc">The buffer desc.</param>
             /// <param name="uavDesc">The uav desc.</param>
             /// <param name="srvDesc">The SRV desc.</param>
-            public UAVBufferViewProxy(Device device, ref BufferDescription bufferDesc, ref UnorderedAccessViewDescription uavDesc, ref ShaderResourceViewDescription srvDesc)
+            public UAVBufferViewProxy(Device device, ref BufferDescription bufferDesc, 
+                ref UnorderedAccessViewDescription uavDesc, ref ShaderResourceViewDescription srvDesc)
+                : this(device, ref bufferDesc, ref uavDesc)
             {
-                buffer = new SDX11.Buffer(device, bufferDesc);
-                srv = new ShaderResourceViewProxy(device, buffer);
+                srv = new ShaderResourceViewProxy(device, resource);
                 srv.CreateTextureView();
-                uav = new UnorderedAccessView(device, buffer, uavDesc);
             }
+            /// <summary>
+            /// Create a raw buffer based UAV
+            /// </summary>
+            /// <param name="device"></param>
+            /// <param name="bufferDesc"></param>
+            /// <param name="uavDesc"></param>
+            public UAVBufferViewProxy(Device device, ref BufferDescription bufferDesc, ref UnorderedAccessViewDescription uavDesc)
+            {
+                resource = new SDX11.Buffer(device, bufferDesc);
+                uav = new UnorderedAccessView(device, resource, uavDesc);
+            }
+            /// <summary>
+            /// Create a texture2D based UAV
+            /// </summary>
+            /// <param name="device"></param>
+            /// <param name="texture2DDesc"></param>
+            /// <param name="uavDesc"></param>
+            /// <param name="srvDesc"></param>
+            public UAVBufferViewProxy(Device device, ref Texture2DDescription texture2DDesc, 
+                ref UnorderedAccessViewDescription uavDesc, ref ShaderResourceViewDescription srvDesc)
+            {
+                resource = new SDX11.Texture2D(device, texture2DDesc);
+                srv = new ShaderResourceViewProxy(device, resource);
+                srv.CreateTextureView(ref srvDesc);
+                uav = new UnorderedAccessView(device, resource, uavDesc);
+            }
+
             /// <summary>
             /// Copies the count.
             /// </summary>
@@ -102,7 +112,7 @@ namespace HelixToolkit.UWP
                     {
                         Disposer.RemoveAndDispose(ref uav);
                         Disposer.RemoveAndDispose(ref srv);
-                        Disposer.RemoveAndDispose(ref buffer);
+                        Disposer.RemoveAndDispose(ref resource);
                     }
 
                     // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.

--- a/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DX.cs
@@ -392,7 +392,8 @@ namespace HelixToolkit.UWP
                     renderHostInternal.MSAA = this.MSAA;
 #endif
                     renderHostInternal.RenderConfiguration.AutoUpdateOctree = this.EnableAutoOctreeUpdate;
-                    renderHostInternal.RenderConfiguration.EnableOITRendering = EnableOITRendering;
+                    renderHostInternal.RenderConfiguration.OITRenderType = OITRenderMode;
+                    renderHostInternal.RenderConfiguration.OITDepthPeelingIteration = OITDepthPeelingIteration;
                     renderHostInternal.RenderConfiguration.OITWeightPower = (float)OITWeightPower;
                     renderHostInternal.RenderConfiguration.OITWeightDepthSlope = (float)OITWeightDepthSlope;
                     renderHostInternal.RenderConfiguration.OITWeightMode = OITWeightMode;

--- a/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DXProperties.cs
+++ b/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DXProperties.cs
@@ -1913,38 +1913,58 @@ namespace HelixToolkit.UWP
             DependencyProperty.Register("FrameRate", typeof(double), typeof(Viewport3DX), new PropertyMetadata(0));
 
         /// <summary>
-        /// Gets or sets a value indicating whether [enable order independent transparent rendering] for Transparent objects.
+        /// Gets or sets order independent transparency render mode
         /// <see cref="MaterialGeometryModel3D.IsTransparent"/>, <see cref="BillboardTextModel3D.IsTransparent"/>
         /// </summary>
         /// <value>
         ///   <c>true</c> if [enable oit rendering]; otherwise, <c>false</c>.
         /// </value>
-        public bool EnableOITRendering
+        public OITRenderType OITRenderMode
         {
-            get { return (bool)GetValue(EnableOITRenderingProperty); }
-            set { SetValue(EnableOITRenderingProperty, value); }
+            get { return (OITRenderType)GetValue(OITRenderModeProperty); }
+            set { SetValue(OITRenderModeProperty, value); }
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether [enable order independent transparent rendering] for Transparent objects.
-        /// <see cref="MaterialGeometryModel3D.IsTransparent"/>, <see cref="BillboardTextModel3D.IsTransparent"/>
+        /// 
         /// </summary>
-        /// <value>
-        ///   <c>true</c> if [enable oit rendering]; otherwise, <c>false</c>.
-        /// </value>
-        public static readonly DependencyProperty EnableOITRenderingProperty =
-            DependencyProperty.Register("EnableOITRendering", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) =>
+        public static readonly DependencyProperty OITRenderModeProperty =
+            DependencyProperty.Register("OITRenderMode", typeof(OITRenderType), typeof(Viewport3DX), new PropertyMetadata(OITRenderType.DepthPeeling, (d, e) =>
             {
                 var viewport = d as Viewport3DX;
                 if (viewport.renderHostInternal != null)
                 {
-                    viewport.renderHostInternal.RenderConfiguration.EnableOITRendering = (bool)e.NewValue;
+                    viewport.renderHostInternal.RenderConfiguration.OITRenderType = (OITRenderType)e.NewValue;
                     viewport.InvalidateRender();
                 }
             }));
-
         /// <summary>
-        /// Gets or sets the Order independent transparent rendering color weight power. 
+        /// Sets or gets Order independent transparency depth peeling mode iteration.
+        /// </summary>
+        public int OITDepthPeelingIteration
+        {
+            get
+            {
+                return (int)GetValue(OITDepthPeelingIterationProperty);
+            }
+            set
+            {
+                SetValue(OITDepthPeelingIterationProperty, value);
+            }
+        }
+
+        public static readonly DependencyProperty OITDepthPeelingIterationProperty =
+            DependencyProperty.Register("OITDepthPeelingIteration", typeof(int), typeof(Viewport3DX), new PropertyMetadata(4, (d, e) =>
+            {
+                var viewport = d as Viewport3DX;
+                if (viewport.renderHostInternal != null)
+                {
+                    viewport.renderHostInternal.RenderConfiguration.OITDepthPeelingIteration = (int)e.NewValue;
+                    viewport.InvalidateRender();
+                }
+            }));
+        /// <summary>
+        /// Gets or sets the Order independent transparency rendering color weight power. 
         /// Used for color weight calculation. 
         /// <para>Different near field/far field settings may need different power value for z value based weight calculation.</para>
         /// </summary>

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -122,10 +122,8 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <PropertyGroup>
-    
   </PropertyGroup>
   <PropertyGroup>
-    
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
@@ -141,7 +139,6 @@
     <Compile Include="CommonDX\SwapChainCompositionRenderHost.cs" />
     <Compile Include="CommonDX\SwapChainRenderHost.cs" />
     <Compile Include="Properties\AssemblyDescription.cs" />
-
     <EmbeddedResource Include="Properties\HelixToolkit.UWP.rd.xml" />
   </ItemGroup>
   <ItemGroup>
@@ -225,6 +222,7 @@
     <None Include="HelixToolkit.UWP\Resources\psBillboardText.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="HelixToolkit.UWP\Resources\psBillboardTextOITDP.cso" />
     <None Include="HelixToolkit.UWP\Resources\psColor.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -276,12 +274,17 @@
     <None Include="HelixToolkit.UWP\Resources\psMeshBlinnPhong.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="HelixToolkit.UWP\Resources\psMeshBlinnPhongOITDP.cso" />
     <None Include="HelixToolkit.UWP\Resources\psMeshClipPlaneBackface.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="HelixToolkit.UWP\Resources\psMeshClipPlaneQuad.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="HelixToolkit.UWP\Resources\psMeshDiffuseMapOITDP.cso" />
+    <None Include="HelixToolkit.UWP\Resources\psMeshOITDPFinal.cso" />
+    <None Include="HelixToolkit.UWP\Resources\psMeshOITDPFirst.cso" />
+    <None Include="HelixToolkit.UWP\Resources\psMeshPBROITDP.cso" />
     <None Include="HelixToolkit.UWP\Resources\psMeshXRay.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -291,6 +294,7 @@
     <None Include="HelixToolkit.UWP\Resources\psParticle.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="HelixToolkit.UWP\Resources\psParticleOITDP.cso" />
     <None Include="HelixToolkit.UWP\Resources\psPoint.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -312,6 +316,7 @@
     <None Include="HelixToolkit.UWP\Resources\psWireframe.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="HelixToolkit.UWP\Resources\psWireframeOITDP.cso" />
     <None Include="HelixToolkit.UWP\Resources\vsBillboard.cso">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Source/HelixToolkit.WinUI.nuspec
+++ b/Source/HelixToolkit.WinUI.nuspec
@@ -30,7 +30,7 @@
 		<dependency id="System.Runtime.Serialization.Primitives" version="4.3.0"/>
 		<dependency id="System.Runtime.Serialization.Xml" version="4.3.0"/>
 		<dependency id="System.Threading.Tasks.Parallel" version="4.3.0"/>		
-		<dependency id="Microsoft.WindowsAppSDK" version="1.0.0"/>
+		<dependency id="Microsoft.WindowsAppSDK" version="1.0.3"/>
 	   </group>
     </dependencies>
   </metadata>

--- a/Source/HelixToolkit.WinUI/HelixToolkit.WinUI.csproj
+++ b/Source/HelixToolkit.WinUI/HelixToolkit.WinUI.csproj
@@ -38,7 +38,7 @@
 
     <ItemGroup>
         <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="2.0.0" />
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.3" />
         <PackageReference Include="SharpDX" Version="4.2.0" />
         <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
         <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
@@ -1127,19 +1127,16 @@ namespace HelixToolkit.Wpf.SharpDX
             }));
 
         /// <summary>
-        /// Gets or sets a value indicating whether [enable order independent transparent rendering] for Transparent objects.
+        /// Gets or sets a value indicating for Transparent objects render mode.
         /// <see cref="MaterialGeometryModel3D.IsTransparent"/>, <see cref="BillboardTextModel3D.IsTransparent"/>
         /// </summary>
-        /// <value>
-        ///   <c>true</c> if [enable oit rendering]; otherwise, <c>false</c>.
-        /// </value>
-        public static readonly DependencyProperty EnableOITRenderingProperty =
-            DependencyProperty.Register("EnableOITRendering", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) =>
+        public static readonly DependencyProperty OITRenderModeProperty =
+            DependencyProperty.Register("OITRenderMode", typeof(OITRenderType), typeof(Viewport3DX), new PropertyMetadata(OITRenderType.DepthPeeling, (d, e) =>
             {
                 var viewport = d as Viewport3DX;
                 if (viewport.renderHostInternal != null)
                 {
-                    viewport.renderHostInternal.RenderConfiguration.EnableOITRendering = (bool)e.NewValue;
+                    viewport.renderHostInternal.RenderConfiguration.OITRenderType = (OITRenderType)e.NewValue;
                     viewport.InvalidateRender();
                 }
             }));
@@ -1189,7 +1186,16 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
             }));
 
-
+        public static readonly DependencyProperty OITDepthPeelingIterationProperty =
+            DependencyProperty.Register("OITDepthPeelingIteration", typeof(int), typeof(Viewport3DX), new PropertyMetadata(4, (d, e) => 
+            {
+                var viewport = d as Viewport3DX;
+                if (viewport.renderHostInternal != null)
+                {
+                    viewport.renderHostInternal.RenderConfiguration.OITDepthPeelingIteration = (int)e.NewValue;
+                    viewport.InvalidateRender();
+                }
+            }));
 
         /// <summary>
         /// The fxaa level property
@@ -3210,21 +3216,18 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether [enable order independent transparent rendering] for Transparent objects.
+        /// Gets or sets a value indicating the render mode for Transparent objects.
         /// <see cref="MaterialGeometryModel3D.IsTransparent"/>, <see cref="BillboardTextModel3D.IsTransparent"/>
         /// </summary>
-        /// <value>
-        ///   <c>true</c> if [enable oit rendering]; otherwise, <c>false</c>.
-        /// </value>
-        public bool EnableOITRendering
+        public OITRenderType OITRenderMode
         {
             get
             {
-                return (bool)GetValue(EnableOITRenderingProperty);
+                return (OITRenderType)GetValue(OITRenderModeProperty);
             }
             set
             {
-                SetValue(EnableOITRenderingProperty, value);
+                SetValue(OITRenderModeProperty, value);
             }
         }
 
@@ -3284,6 +3287,18 @@ namespace HelixToolkit.Wpf.SharpDX
             set
             {
                 SetValue(OITWeightModeProperty, value);
+            }
+        }
+
+        public int OITDepthPeelingIteration
+        {
+            get
+            {
+                return (int)GetValue(OITDepthPeelingIterationProperty);
+            }
+            set
+            {
+                SetValue(OITDepthPeelingIterationProperty, value);
             }
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
@@ -705,10 +705,11 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.renderHostInternal.IsRendering = this.Visibility == System.Windows.Visibility.Visible;
                 this.renderHostInternal.RenderConfiguration.RenderD2D = EnableD2DRendering;
                 this.renderHostInternal.RenderConfiguration.AutoUpdateOctree = EnableAutoOctreeUpdate;
-                this.renderHostInternal.RenderConfiguration.EnableOITRendering = EnableOITRendering;
+                this.renderHostInternal.RenderConfiguration.OITRenderType = this.OITRenderMode;
                 this.renderHostInternal.RenderConfiguration.OITWeightPower = (float)OITWeightPower;
                 this.renderHostInternal.RenderConfiguration.OITWeightDepthSlope = (float)OITWeightDepthSlope;
                 this.renderHostInternal.RenderConfiguration.OITWeightMode = OITWeightMode;
+                this.renderHostInternal.RenderConfiguration.OITDepthPeelingIteration = OITDepthPeelingIteration;
                 this.renderHostInternal.RenderConfiguration.FXAALevel = FXAALevel;
                 this.renderHostInternal.RenderConfiguration.EnableRenderOrder = EnableRenderOrder;
                 this.renderHostInternal.RenderConfiguration.EnableSSAO = EnableSSAO;

--- a/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
+++ b/Source/HelixToolkit.Wpf.SharpDX/HelixToolkit.Wpf.SharpDX.csproj
@@ -35,7 +35,6 @@
     <DefineConstants>TRACE;DX11; MSAA; SHARPDX;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    
     <DocumentationFile>bin\Release\HelixToolkit.Wpf.SharpDX.XML</DocumentationFile>
     <RegisterForComInterop>false</RegisterForComInterop>
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
@@ -44,10 +43,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup>
-    
   </PropertyGroup>
   <PropertyGroup>
-    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -107,7 +104,6 @@
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
-
     <Compile Include="Properties\AssemblyDescription.cs" />
     <Compile Include="Properties\Resources.Designer.cs" />
   </ItemGroup>
@@ -143,6 +139,7 @@
     <None Include="Resources\hsMeshTriTessellation.cso" />
     <None Include="Resources\psBillboardText.cso" />
     <None Include="Resources\psBillboardTextOIT.cso" />
+    <None Include="Resources\psBillboardTextOITDP.cso" />
     <None Include="Resources\psColor.cso" />
     <None Include="Resources\psDepthStencilOnly.cso" />
     <None Include="Resources\psDiffuseMap.cso" />
@@ -166,17 +163,23 @@
     <None Include="Resources\psLuma.cso" />
     <None Include="Resources\psMeshBlinnPhong.cso" />
     <None Include="Resources\psMeshBlinnPhongOIT.cso" />
+    <None Include="Resources\psMeshBlinnPhongOITDP.cso" />
     <None Include="Resources\psMeshBlinnPhongOITQuad.cso" />
     <None Include="Resources\psMeshClipPlaneBackface.cso" />
     <None Include="Resources\psMeshClipPlaneQuad.cso" />
     <None Include="Resources\psMeshColorStripe.cso" />
     <None Include="Resources\psMeshDiffuseMapOIT.cso" />
+    <None Include="Resources\psMeshDiffuseMapOITDP.cso" />
+    <None Include="Resources\psMeshOITDPFinal.cso" />
+    <None Include="Resources\psMeshOITDPFirst.cso" />
     <None Include="Resources\psMeshPBR.cso" />
     <None Include="Resources\psMeshPBROIT.cso" />
+    <None Include="Resources\psMeshPBROITDP.cso" />
     <None Include="Resources\psMeshXRay.cso" />
     <None Include="Resources\psNormals.cso" />
     <None Include="Resources\psParticle.cso" />
     <None Include="Resources\psParticleOIT.cso" />
+    <None Include="Resources\psParticleOITDP.cso" />
     <None Include="Resources\psPlaneGrid.cso" />
     <None Include="Resources\psPoint.cso" />
     <None Include="Resources\psPositions.cso" />
@@ -193,6 +196,7 @@
     <None Include="Resources\psVolumeDiffuse.cso" />
     <None Include="Resources\psWireframe.cso" />
     <None Include="Resources\psWireframeOIT.cso" />
+    <None Include="Resources\psWireframeOITDP.cso" />
     <None Include="Resources\vsBillboard.cso" />
     <None Include="Resources\vsBillboardInstancing.cso" />
     <None Include="Resources\vsBoneSkinningBasic.cso" />
@@ -257,7 +261,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    
   </ItemGroup>
   <Import Project="..\HelixToolkit.SharpDX.Shared\HelixToolkit.SharpDX.Shared.projitems" Label="Shared" />
   <Import Project="..\HelixToolkit.Shared\HelixToolkit.Shared.projitems" Label="Shared" />

--- a/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.resx
+++ b/Source/HelixToolkit.Wpf.SharpDX/Properties/Resources.resx
@@ -118,161 +118,59 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="psMeshBlinnPhong" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psmeshblinnphong.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsMeshDefault" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshdefault.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsMeshInstancing" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshinstancing.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psColor" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pscolor.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psNormals" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psnormals.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psPositions" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pspositions.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psMeshXRay" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psmeshxray.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsCubeMap" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vscubemap.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="gsPoint" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\gspoint.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psPoint" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pspoint.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsPoint" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vspoint.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="gsLine" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\gsline.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psLine" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psline.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psBillboardText" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psbillboardtext.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsBillboard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsbillboard.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="gsBillboard" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\gsbillboard.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psMeshClipPlaneBackface" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psmeshclipplanebackface.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psMeshClipPlaneQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psmeshclipplanequad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsMeshClipPlaneQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshclipplanequad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="dsMeshTriTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\dsmeshtritessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="hsMeshTriTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\hsmeshtritessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsMeshTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshtessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsMeshInstancingTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshinstancingtessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsBillboardInstancing" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsbillboardinstancing.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="csParticleInsert" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\csparticleinsert.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="csParticleUpdate" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\csparticleupdate.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="dsMeshTriTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\dsmeshtritessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="gsBillboard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gsbillboard.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="gsLine" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gsline.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="gsLineArrowHead" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gslinearrowhead.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="gsLineArrowHeadTail" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gslinearrowheadtail.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="gsMeshNormalVector" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gsmeshnormalvector.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="gsMeshSkinnedOut" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gsmeshskinnedout.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="gsParticle" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\gsparticle.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psParticle" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psparticle.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="gsPoint" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\gspoint.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsParticle" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsparticle.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="hsMeshTriTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\hsmeshtritessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psDiffuseMap" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psdiffusemap.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psBillboardText" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psbillboardtext.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psViewCube" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psviewcube.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psBillboardTextOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psbillboardtextoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psLineColor" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pslinecolor.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psBillboardTextOITDP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psbillboardtextoitdp.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsMeshShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsPointShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vspointshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psSkybox" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psskybox.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsSkybox" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsskybox.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psScreenDup" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psscreendup.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsScreenDup" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsscreendup.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psWireframe" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pswireframe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsMeshWireframe" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshwireframe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psColor" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pscolor.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="psDepthStencilOnly" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psdepthstencilonly.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsMeshOutlinePass1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshoutlinepass1.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsMeshOutlineScreenQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshoutlinescreenquad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectMeshXRay" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectmeshxray.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectOutlineQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectoutlinequad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectOutlineQuadStencil" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectoutlinequadstencil.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectOutlineQualFinal" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectoutlinequalfinal.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectMeshBorderHighlight" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectmeshborderhighlight.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectGaussianBlurHorizontal" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectgaussianblurhorizontal.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectGaussianBlurVertical" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectgaussianblurvertical.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectBloomExtract" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectbloomextract.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psDiffuseMap" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psdiffusemap.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="psEffectBloomBlurHorizontal" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\pseffectbloomblurhorizontal.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -283,68 +181,83 @@
   <data name="psEffectBloomCombine" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\pseffectbloomcombine.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsScreenDupCursor" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsscreendupcursor.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psEffectBloomExtract" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectbloomextract.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsMeshClipPlane" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshclipplane.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psEffectGaussianBlurHorizontal" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectgaussianblurhorizontal.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psMeshBlinnPhongOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psmeshblinnphongoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psEffectGaussianBlurVertical" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectgaussianblurvertical.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psMeshBlinnPhongOITQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psmeshblinnphongoitquad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psBillboardTextOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psbillboardtextoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psParticleOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psparticleoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psFXAA" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psfxaa.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psWireframeOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pswireframeoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psLuma" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psluma.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psEffectMeshXRayGrid" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectmeshxraygrid.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="gsMeshNormalVector" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\gsmeshnormalvector.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psMeshColorStripe" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psmeshcolorstripe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psEffectMeshBorderHighlight" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectmeshborderhighlight.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="psEffectMeshDiffuseXRayGrid" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\pseffectmeshdiffusexraygrid.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="psEffectMeshXRay" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectmeshxray.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psEffectMeshXRayGrid" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectmeshxraygrid.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psEffectOutlineQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectoutlinequad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psEffectOutlineQuadStencil" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectoutlinequadstencil.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psEffectOutlineQualFinal" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectoutlinequalfinal.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psEffectOutlineSmooth" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pseffectoutlinesmooth.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psFXAA" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psfxaa.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psLine" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psline.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psLineColor" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pslinecolor.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psLuma" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psluma.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psMeshBlinnPhong" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshblinnphong.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psMeshBlinnPhongOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshblinnphongoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psMeshBlinnPhongOITDP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshblinnphongoitdp.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psMeshBlinnPhongOITQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshblinnphongoitquad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psMeshClipPlaneBackface" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshclipplanebackface.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psMeshClipPlaneQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshclipplanequad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psMeshColorStripe" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshcolorstripe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="psMeshDiffuseMapOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psmeshdiffusemapoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsMeshBatched" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshbatched.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psMeshDiffuseMapOITDP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshdiffusemapoitdp.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsMeshBatchedWireframe" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshbatchedwireframe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psMeshOITDPFinal" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshoitdpfinal.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsMeshBatchedShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshbatchedshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="gsMeshSkinnedOut" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\gsmeshskinnedout.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsBoneSkinningBasic" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsboneskinningbasic.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="psPlaneGrid" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psplanegrid.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsPlaneGrid" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsplanegrid.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psMeshOITDPFirst" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshoitdpfirst.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="psMeshPBR" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psmeshpbr.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -352,20 +265,59 @@
   <data name="psMeshPBROIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psmeshpbroit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsScreenQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsscreenquad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psMeshPBROITDP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshpbroitdp.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psMeshXRay" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psmeshxray.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psNormals" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psnormals.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psParticle" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psparticle.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psParticleOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psparticleoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psParticleOITDP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psparticleoitdp.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psPlaneGrid" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psplanegrid.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psPoint" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pspoint.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psPositions" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pspositions.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psScreenDup" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psscreendup.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psSkybox" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psskybox.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="psSprite" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\pssprite.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsSprite" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vssprite.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psSSAO" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psssao.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psSSAOBlur" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psssaoblur.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psSSAOP1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psssaop1.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="psViewCube" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\psviewcube.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="psVolume" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psvolume.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="vsVolume" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsvolume.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="psVolumeCube" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psvolumecube.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -373,34 +325,106 @@
   <data name="psVolumeDiffuse" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\psvolumediffuse.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsMeshDepth" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshdepth.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psWireframe" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pswireframe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psSSAO" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psssao.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psWireframeOIT" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pswireframeoit.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psSSAOP1" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psssaop1.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="psWireframeOITDP" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\pswireframeoitdp.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsMeshSSAO" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsmeshssao.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="vsBillboard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsbillboard.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="vsSSAO" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\vsssao.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="vsBillboardInstancing" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsbillboardinstancing.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psSSAOBlur" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\psssaoblur.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="vsBoneSkinningBasic" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsboneskinningbasic.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsCubeMap" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vscubemap.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshBatched" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshbatched.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshBatchedShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshbatchedshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="vsMeshBatchedSSAO" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\vsmeshbatchedssao.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="psEffectOutlineSmooth" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\pseffectoutlinesmooth.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="vsMeshBatchedWireframe" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshbatchedwireframe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="gsLineArrowHead" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\gslinearrowhead.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="vsMeshClipPlane" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshclipplane.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="gsLineArrowHeadTail" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\resources\gslinearrowheadtail.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="vsMeshClipPlaneQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshclipplanequad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshDefault" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshdefault.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshDepth" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshdepth.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshInstancing" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshinstancing.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshInstancingTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshinstancingtessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshOutlinePass1" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshoutlinepass1.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshOutlineScreenQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshoutlinescreenquad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshSSAO" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshssao.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshTessellation" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshtessellation.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsMeshWireframe" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsmeshwireframe.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsParticle" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsparticle.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsPlaneGrid" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsplanegrid.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsPoint" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vspoint.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsPointShadow" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vspointshadow.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsScreenDup" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsscreendup.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsScreenDupCursor" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsscreendupcursor.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsScreenQuad" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsscreenquad.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsSkybox" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsskybox.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsSprite" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vssprite.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsSSAO" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsssao.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="vsVolume" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\resources\vsvolume.cso;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
Implemented classic depth peeling order independent transparency rendering.
Better color accurate than weighed method in current helix toolkit implementation, but with performance penalties.