### PR TITLE
Improve depth buffer handling when MSAA is enabled.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRayGrid.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/PostEffects/PostEffectMeshXRayGrid.cs
@@ -55,7 +55,6 @@ namespace HelixToolkit.UWP
         {
             #region Variables
             private readonly List<KeyValuePair<SceneNode, IEffectAttributes>> currentCores = new List<KeyValuePair<SceneNode, IEffectAttributes>>();
-            private DepthPrepassCore depthPrepassCore;
             private readonly ConstantBufferComponent modelCB;
             private BorderEffectStruct modelStruct;
             #endregion
@@ -176,15 +175,11 @@ namespace HelixToolkit.UWP
 
             protected override bool OnAttach(IRenderTechnique technique)
             {
-                depthPrepassCore = new DepthPrepassCore();
-                depthPrepassCore.Attach(technique);
                 return true;
             }
 
             protected override void OnDetach()
             {
-                depthPrepassCore.Detach();
-                RemoveAndDispose(ref depthPrepassCore);
             }
 
             protected override bool OnUpdateCanRenderFlag()
@@ -199,18 +194,11 @@ namespace HelixToolkit.UWP
             public override void Render(RenderContext context, DeviceContextProxy deviceContext)
             {
                 var buffer = context.RenderHost.RenderBuffer;
-                var hasMSAA = buffer.ColorBufferSampleDesc.Count > 1;
-                var depthStencilBuffer = hasMSAA ? context.GetOffScreenDS(OffScreenTextureSize.Full, Format.D32_Float_S8X24_UInt) : buffer.DepthStencilBuffer;
+                var depthStencilBuffer = buffer.DepthStencilBufferNoMSAA;
                 deviceContext.SetRenderTarget(depthStencilBuffer, buffer.FullResPPBuffer.CurrentRTV);
                 var viewport = context.Viewport;
                 deviceContext.SetViewport(ref viewport);
                 deviceContext.SetScissorRectangle(ref viewport);
-                if (hasMSAA)
-                {
-                    //Needs to do a depth pass for existing meshes.Because the msaa depth buffer is not resolvable.
-                    deviceContext.ClearDepthStencilView(depthStencilBuffer, DepthStencilClearFlags.Depth, 1, 0);
-                    depthPrepassCore.Render(context, deviceContext);
-                }
                 //First pass, draw onto stencil buffer
                 for (var i = 0; i < context.RenderHost.PerFrameNodesWithPostEffect.Count; ++i)
                 {
@@ -273,11 +261,6 @@ namespace HelixToolkit.UWP
                         material.MaterialVariables.BindMaterialResources(context, deviceContext, pass);
                     }
                     mesh.RenderCustom(context, deviceContext);
-                }
-                if (hasMSAA)
-                {
-                    deviceContext.ClearRenderTagetBindings();
-                    depthStencilBuffer.Dispose();
                 }
                 currentCores.Clear();
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SSAOCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SSAOCore.cs
@@ -76,7 +76,7 @@ namespace HelixToolkit.UWP
             private readonly ConstantBufferComponent ssaoCB;
             private const int KernalSize = 32;
             private readonly Vector4[] kernels = new Vector4[KernalSize];
-            private const global::SharpDX.DXGI.Format DEPTHFORMAT = global::SharpDX.DXGI.Format.R32_Typeless;
+            private const global::SharpDX.DXGI.Format DEPTHFORMAT = global::SharpDX.DXGI.Format.D32_Float;
             private const global::SharpDX.DXGI.Format RENDERTARGETFORMAT = global::SharpDX.DXGI.Format.R16G16B16A16_Float;
             private const global::SharpDX.DXGI.Format SSAOTARGETFORMAT = global::SharpDX.DXGI.Format.R16_Float;
 

--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -200,6 +200,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Model\Scene\VolumeTextureNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Render\RenderHost\DefaultRenderHostPartial_Properties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Render\RenderHost\DX11RenderHostConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\DepthStencilFormatHelper.cs" />
     <Compile Include="..\HelixToolkit.SharpDX.Shared\ShaderManager\StructArrayPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShaderManager\MaterialVariablePool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShaderManager\TextureResourceManager.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/BillboardMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/BillboardMaterialVariable.cs
@@ -62,10 +62,12 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The core.</param>
-            public BillboardMaterialVariable(IEffectsManager manager, IRenderTechnique technique, BillboardMaterialCore materialCore)
+            /// <param name="defaultPassName">Default pass name</param>
+            public BillboardMaterialVariable(IEffectsManager manager, IRenderTechnique technique, BillboardMaterialCore materialCore,
+                string defaultPassName = DefaultPassNames.Default)
                 : base(manager, technique, DefaultPointLineConstantBufferDesc, materialCore)
             {
-                BillboardPass = technique[DefaultPassNames.Default];
+                BillboardPass = technique[defaultPassName];
                 OITPass = technique[DefaultPassNames.OITPass];
                 OITDepthPeelingInit = technique[DefaultPassNames.OITDepthPeelingInit];
                 OITDepthPeeling = technique[DefaultPassNames.OITDepthPeeling];

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/DiffuseMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/DiffuseMaterialVariable.cs
@@ -106,7 +106,8 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            private DiffuseMaterialVariables(IEffectsManager manager, IRenderTechnique technique, DiffuseMaterialCore materialCore)
+            private DiffuseMaterialVariables(IEffectsManager manager, IRenderTechnique technique, DiffuseMaterialCore materialCore,
+                string defaultPassName = DefaultPassNames.Default)
                 : base(manager, technique, DefaultMeshConstantBufferDesc, materialCore)
             {
                 this.material = materialCore;
@@ -114,7 +115,7 @@ namespace HelixToolkit.UWP
                 samplerDiffuseSlot = samplerShadowSlot = -1;
                 textureManager = manager.MaterialTextureManager;
                 statePoolManager = manager.StateManager;
-                MaterialPass = technique[DefaultPassNames.Default];
+                MaterialPass = technique[defaultPassName];
                 OITPass = technique[DefaultPassNames.DiffuseOIT];
                 OITDepthPeelingInit = technique[DefaultPassNames.OITDepthPeelingInit];
                 OITDepthPeeling = technique[DefaultPassNames.DiffuseOITDP];

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineArrowMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineArrowMaterialVariable.cs
@@ -25,8 +25,10 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            public LineArrowMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineArrowHeadMaterialCore materialCore)
-                : base(manager, technique, materialCore)
+            /// <param name="defaultPassName">Default pass name</param>
+            public LineArrowMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineArrowHeadMaterialCore materialCore,
+                string defaultPassName = DefaultPassNames.Default)
+                : base(manager, technique, materialCore, defaultPassName)
             {
                 this.material = materialCore;
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/LineMaterialVariable.cs
@@ -58,11 +58,13 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            public LineMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineMaterialCore materialCore)
+            /// <param name="defaultPassName">Default pass name</param>
+            public LineMaterialVariable(IEffectsManager manager, IRenderTechnique technique, LineMaterialCore materialCore,
+                string defaultPassName = DefaultPassNames.Default)
                 : base(manager, technique, DefaultPointLineConstantBufferDesc, materialCore)
             {
                 textureManager = manager.MaterialTextureManager;
-                LinePass = technique[DefaultPassNames.Default];
+                LinePass = technique[defaultPassName];
                 ShadowPass = technique[DefaultPassNames.ShadowPass];
                 DepthPass = technique[DefaultPassNames.DepthPrepass];
                 this.material = materialCore;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PBRMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PBRMaterialVariable.cs
@@ -118,13 +118,14 @@ namespace HelixToolkit.UWP
             }
             private ShaderPass currentMaterialPass => EnableTessellation ? TessellationPass : MaterialPass;
 
-            public PBRMaterialVariable(IEffectsManager manager, IRenderTechnique technique, PBRMaterialCore core)
+            public PBRMaterialVariable(IEffectsManager manager, IRenderTechnique technique, PBRMaterialCore core,
+                string defaultPassName = DefaultPassNames.PBR)
                 : base(manager, technique, DefaultMeshConstantBufferDesc, core)
             {
                 textureManager = manager.MaterialTextureManager;
                 statePoolManager = manager.StateManager;
                 material = core;
-                MaterialPass = technique[DefaultPassNames.PBR];
+                MaterialPass = technique[defaultPassName];
                 OITPass = technique[DefaultPassNames.PBROITPass];
                 OITDepthPeelingInit = technique[DefaultPassNames.OITDepthPeelingInit];
                 OITDepthPeeling = technique[DefaultPassNames.PBROITDPPass];

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PhongMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PhongMaterialVariable.cs
@@ -180,7 +180,9 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            public PhongMaterialVariables(IEffectsManager manager, IRenderTechnique technique, PhongMaterialCore materialCore)
+            /// <param name="defaultPassName">Default pass name</param>
+            public PhongMaterialVariables(IEffectsManager manager, IRenderTechnique technique, PhongMaterialCore materialCore, 
+                string defaultPassName = DefaultPassNames.Default)
                 : base(manager, technique, DefaultMeshConstantBufferDesc, materialCore)
             {
                 this.material = materialCore;
@@ -189,7 +191,7 @@ namespace HelixToolkit.UWP
                 textureManager = manager.MaterialTextureManager;
                 statePoolManager = manager.StateManager;
 
-                MaterialPass = technique[DefaultPassNames.Default];
+                MaterialPass = technique[defaultPassName];
                 OITPass = technique[DefaultPassNames.OITPass];
                 OITDepthPeelingInit = technique[DefaultPassNames.OITDepthPeelingInit];
                 OITDepthPeeling = technique[DefaultPassNames.OITDepthPeeling];

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PointMaterialVariable.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Material/Variables/PointMaterialVariable.cs
@@ -42,10 +42,12 @@ namespace HelixToolkit.UWP
             /// <param name="manager">The manager.</param>
             /// <param name="technique">The technique.</param>
             /// <param name="materialCore">The material core.</param>
-            public PointMaterialVariable(IEffectsManager manager, IRenderTechnique technique, PointMaterialCore materialCore)
+            /// <param name="defaultPassName">Default pass name</param>
+            public PointMaterialVariable(IEffectsManager manager, IRenderTechnique technique, PointMaterialCore materialCore, 
+                string defaultPassName = DefaultPassNames.Default)
                 : base(manager, technique, DefaultPointLineConstantBufferDesc, materialCore)
             {
-                PointPass = technique[DefaultPassNames.Default];
+                PointPass = technique[defaultPassName];
                 ShadowPass = technique[DefaultPassNames.ShadowPass];
                 DepthPass = technique[DefaultPassNames.DepthPrepass];
                 this.material = materialCore;

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderBuffers/ColorBufferPool.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderBuffers/ColorBufferPool.cs
@@ -249,24 +249,22 @@ namespace HelixToolkit.UWP
                     }
                     else if ((desc.BindFlags & BindFlags.DepthStencil) != 0)
                     {
-                        if (format == Format.R32_Typeless)// Special handle for depth buffer used as both depth stencil and shader resource
+                        desc.Format = DepthStencilFormatHelper.ComputeTextureFormat(format, out var canUseAsShaderResource);
+                        if (canUseAsShaderResource)
                         {
                             desc.BindFlags |= BindFlags.ShaderResource;
                         }
                         texture = new PooledShaderResourceViewProxy(deviceResourse.Device, desc, bag);
-                        if (format == Format.R32_Typeless)// Special handle for depth buffer used as both depth stencil and shader resource
+                        texture.CreateView(new DepthStencilViewDescription() { Format = DepthStencilFormatHelper.ComputeDSVFormat(format),
+                            Dimension = DepthStencilViewDimension.Texture2D });
+                        if (canUseAsShaderResource)
                         {
-                            texture.CreateView(new DepthStencilViewDescription() { Format = Format.D32_Float, Dimension = DepthStencilViewDimension.Texture2D });
                             texture.CreateView(new ShaderResourceViewDescription()
                             {
-                                Format = Format.R32_Float,
+                                Format = DepthStencilFormatHelper.ComputeSRVFormat(format),
                                 Dimension = global::SharpDX.Direct3D.ShaderResourceViewDimension.Texture2D,
                                 Texture2D = new ShaderResourceViewDescription.Texture2DResource() { MipLevels = desc.MipLevels }
                             });
-                        }
-                        else
-                        {
-                            texture.CreateDepthStencilView();
                         }
                     }
                     Debug.WriteLine("Create New Full Screen Texture");

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -349,7 +349,7 @@ namespace HelixToolkit.UWP
                     renderer.RenderToPingPongBuffer(RenderContext, ref renderParameter);
                     renderParameter.IsMSAATexture = false;
                     renderParameter.CurrentTargetTexture = RenderBuffer.FullResPPBuffer.CurrentTexture;
-                    renderParameter.RenderTargetView[0] = RenderBuffer.FullResPPBuffer.CurrentRTV;
+                    renderParameter.RenderTargetView[0] = RenderBuffer.FullResPPBuffer.CurrentRTV;                                 
                 }
                 if (postEffectNodes.Count > 0)
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -332,18 +332,13 @@ namespace HelixToolkit.UWP
             {
                 if (count > 0)
                 {
-                    var hasMSAA = context.RenderHost.RenderBuffer.ColorBufferSampleDesc.Count == 1;
                     var buffer = context.RenderHost.RenderBuffer;
-                    var depthStencilBuffer = hasMSAA ? buffer.DepthStencilBuffer : context.GetOffScreenDS(OffScreenTextureSize.Full, Format.D32_Float_S8X24_UInt);
+                    var depthStencilBuffer = buffer.DepthStencilBufferNoMSAA;
                     ImmediateContext.SetRenderTargets(depthStencilBuffer, parameter.RenderTargetView);
 
                     for (var i = start; i < start + count; ++i)
                     {
                         renderables[i].Render(context, ImmediateContext);
-                    }
-                    if (!hasMSAA)
-                    {
-                        depthStencilBuffer.Dispose();
                     }
                 }
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/Renderer/ImmediateContextRenderer.cs
@@ -163,6 +163,8 @@ namespace HelixToolkit.UWP
             /// <returns></returns>
             public virtual int RenderTransparent(RenderContext context, FastList<SceneNode> renderables, ref RenderParameter parameter)
             {
+                if (renderables.Count == 0)
+                { return 0; }
                 if (context.RenderHost.RenderConfiguration.OITRenderType != OITRenderType.None
                     && context.RenderHost.FeatureLevel >= global::SharpDX.Direct3D.FeatureLevel.Level_11_0)
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/ShaderManager/DefaultEffectsManager.cs
@@ -1213,7 +1213,7 @@ namespace HelixToolkit.UWP
                         {
                             DefaultVSShaderDescriptions.VSPoint,
                             DefaultGSShaderDescriptions.GSLine,
-                            DefaultPSShaderDescriptions.PSShadow
+                            DefaultPSShaderDescriptions.PSDepthStencilOnly
                         },
                         BlendStateDescription = DefaultBlendStateDescriptions.NoBlend,
                         DepthStencilStateDescription = DefaultDepthStencilDescriptions.DSSDepthLess

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/Buffers/ShaderResourceViewProxy.cs
@@ -347,7 +347,14 @@ namespace HelixToolkit.UWP
                 }
                 textureView = new ShaderResourceView(device, resource);
             }
-
+            /// <summary>
+            /// Creates the view.
+            /// </summary>
+            /// <param name="desc"></param>
+            public void CreateTextureView(ShaderResourceViewDescription desc)
+            {
+                CreateTextureView(ref desc);
+            }
             /// <summary>
             /// Creates the view.
             /// </summary>
@@ -383,6 +390,20 @@ namespace HelixToolkit.UWP
                 depthStencilView = new DepthStencilView(device, resource);
             }
 
+            public void CreateDepthStencilView(DepthStencilViewDescription desc)
+            {
+                CreateDepthStencilView(ref desc);
+            }
+
+            public void CreateDepthStencilView(ref DepthStencilViewDescription desc)
+            {
+                RemoveAndDispose(ref depthStencilView);
+                if (resource == null)
+                {
+                    return;
+                }
+                depthStencilView = new DepthStencilView(device, resource, desc);
+            }
             /// <summary>
             /// Creates the 1D texture view from data array.
             /// </summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/DepthStencilFormatHelper.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/DepthStencilFormatHelper.cs
@@ -1,0 +1,97 @@
+﻿using SharpDX;
+using SharpDX.DXGI;
+using System;
+using System.Threading;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
+{
+    using Model;
+    namespace Utilities
+    {
+        public static class DepthStencilFormatHelper
+        {
+            public static Format ComputeDSVFormat(this Format format)
+            {
+                switch (format)
+                {
+                    case Format.D32_Float:
+                    case Format.R32_Typeless:
+                        return Format.D32_Float;
+                    case Format.D24_UNorm_S8_UInt:
+                    case Format.R24G8_Typeless:
+                        return Format.D24_UNorm_S8_UInt;
+                    case Format.D32_Float_S8X24_UInt:
+                    case Format.R32G8X24_Typeless:
+                        return Format.D32_Float_S8X24_UInt;
+                }
+                throw new InvalidOperationException(string.Format("Unsupported DXGI.FORMAT [{0}] for depth buffer", format));
+            }
+
+            public static Format ComputeTextureFormat(this Format format, out bool canUseAsShaderResource)
+            {
+                Format viewFormat;
+                canUseAsShaderResource = false;
+
+                // Determine TypeLess Format and ShaderResourceView Format
+                switch (format)
+                {
+                    case Format.D32_Float:
+                    case Format.R32_Typeless:
+                        viewFormat = Format.R32_Typeless;
+                        canUseAsShaderResource = true;
+                        break;
+                    case Format.D24_UNorm_S8_UInt:
+                    case Format.R24G8_Typeless:
+                        viewFormat = Format.R24G8_Typeless;
+                        canUseAsShaderResource = true;
+                        break;
+                    case Format.D32_Float_S8X24_UInt:
+                    case Format.R32G8X24_Typeless:
+                        viewFormat = Format.R32G8X24_Typeless;
+                        canUseAsShaderResource = true;
+                        break;
+                    default:
+                        viewFormat = (Format)format;
+                        break;
+                }
+
+                return viewFormat;
+            }
+
+            public static Format ComputeSRVFormat(this Format format)
+            {
+                switch (format)
+                {
+                    case Format.D32_Float:
+                    case Format.R32_Typeless:
+                        return Format.R32_Float;
+                    case Format.D24_UNorm_S8_UInt:
+                    case Format.R24G8_Typeless:
+                        return Format.R24_UNorm_X8_Typeless;
+                    case Format.D32_Float_S8X24_UInt:
+                    case Format.R32G8X24_Typeless:
+                        return Format.R32_Float_X8X24_Typeless;
+                }
+
+                throw new InvalidOperationException(string.Format("Unsupported DXGI.FORMAT [{0}] for creating shaderResourceView", format));
+            }
+
+            public static bool CanUseAsShaderResource(this Format format)
+            {
+                ComputeTextureFormat(format, out var canUse);
+                return canUse;
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Do depth prepass if MASS is enabled to avoid redundant depth prepass in different render cores.
2. Adds depth stencil format helper to compute the corresponding formats for depth stencil view and shader resource view.
3. Adds back default pass name as parameter for material variables.