### PR TITLE
Allow environment map to skip rendering but still available for other object to do reflection. #1767

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Core/SkyBoxRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SkyBoxRenderCore.cs
@@ -150,6 +150,10 @@ namespace HelixToolkit.UWP
             /// The name of the shader cube texture sampler.
             /// </value>
             public string ShaderCubeTextureSamplerName { set; get; } = DefaultSamplerStateNames.CubeMapSampler;
+            /// <summary>
+            /// Skip environment map rendering, but still keep it available for other object to use.
+            /// </summary>
+            public bool SkipRendering { set; get; }
             #endregion
 
             /// <summary>
@@ -237,6 +241,10 @@ namespace HelixToolkit.UWP
                 }
                 context.SharedResource.EnvironementMap = cubeTextureRes;
                 context.SharedResource.EnvironmentMapMipLevels = MipMapLevels;
+                if (SkipRendering)
+                {
+                    return;
+                }
                 DefaultShaderPass.BindShader(deviceContext);
                 DefaultShaderPass.BindStates(deviceContext, StateType.BlendState | StateType.DepthStencilState);
                 DefaultShaderPass.PixelShader.BindTexture(deviceContext, cubeTextureSlot, cubeTextureRes);

--- a/Source/HelixToolkit.SharpDX.Shared/Core/SkyDomeRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/SkyDomeRenderCore.cs
@@ -114,6 +114,11 @@ namespace HelixToolkit.UWP
             /// The name of the shader cube texture sampler.
             /// </value>
             public string ShaderCubeTextureSamplerName { set; get; } = DefaultSamplerStateNames.CubeMapSampler;
+            /// <summary>
+            /// Skip environment map rendering, but still keep it available for other object to use.
+            /// </summary>
+            public bool SkipRendering { set; get; }
+
             #endregion
 
             /// <summary>
@@ -187,6 +192,11 @@ namespace HelixToolkit.UWP
             protected override void OnRender(RenderContext context, DeviceContextProxy deviceContext)
             {
                 context.SharedResource.EnvironementMap = cubeTextureRes;
+                context.SharedResource.EnvironmentMapMipLevels = MipMapLevels;
+                if (SkipRendering)
+                {
+                    return;
+                }
                 DefaultShaderPass.BindShader(deviceContext);
                 DefaultShaderPass.BindStates(deviceContext, StateType.BlendState | StateType.DepthStencilState);
                 DefaultShaderPass.PixelShader.BindTexture(deviceContext, cubeTextureSlot, cubeTextureRes);

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderCoreParams.cs
@@ -495,6 +495,13 @@ namespace HelixToolkit.UWP
             {
                 set; get;
             }
+            /// <summary>
+            /// Skip environment map rendering, but still keep it available for other object to use.
+            /// </summary>
+            bool SkipRendering
+            {
+                set; get;
+            }
         }
         /// <summary>
         /// 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/EnvironmentMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/EnvironmentMapNode.cs
@@ -41,6 +41,20 @@ namespace HelixToolkit.UWP
                     return (RenderCore as ISkyboxRenderParams).CubeTexture;
                 }
             }
+            /// <summary>
+            /// Skip environment map rendering, but still keep it available for other object to use.
+            /// </summary>
+            public bool SkipRendering
+            {
+                set
+                {
+                    (RenderCore as ISkyboxRenderParams).SkipRendering = value;
+                }
+                get
+                {
+                    return (RenderCore as ISkyboxRenderParams).SkipRendering;
+                }
+            }
 
             private readonly bool UseSkyDome = false;
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/EnvironmentMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/EnvironmentMap3D.cs
@@ -51,6 +51,25 @@ namespace HelixToolkit.Wpf.SharpDX
                 return (TextureModel)GetValue(TextureProperty);
             }
         }
+
+        public static readonly DependencyProperty SkipRenderingProperty = DependencyProperty.Register("SkipRendering", typeof(bool), typeof(EnvironmentMap3D),
+            new PropertyMetadata(false, (d, e) => {
+                ((d as Element3DCore).SceneNode as EnvironmentMapNode).SkipRendering = (bool)e.NewValue; 
+            }));
+        /// <summary>
+        /// Skip environment map rendering, but still keep it available for other object to use.
+        /// </summary>
+        public bool SkipRendering
+        {
+            set
+            {
+                SetValue(SkipRenderingProperty, value);
+            }
+            get
+            {
+                return (bool)GetValue(SkipRenderingProperty);
+            }
+        }
         /// <summary>
         /// Called when [create scene node].
         /// </summary>


### PR DESCRIPTION
Allow environment map to skip rendering but still available for other object to do reflection. #1767