### PR TITLE
Supports multithreading scene node pre-attachment.

### DIFF
--- a/Source/Examples/SharpDX.Core/CoreTest/App.config
+++ b/Source/Examples/SharpDX.Core/CoreTest/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/Source/Examples/SharpDX.Core/CoreTest/CoreTest.csproj
+++ b/Source/Examples/SharpDX.Core/CoreTest/CoreTest.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>CoreTest</RootNamespace>
     <AssemblyName>CoreTest</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Source/Examples/SharpDX.Core/CoreTest/Form1.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/Form1.cs
@@ -24,10 +24,11 @@ namespace CoreTest
                 TopLevel = false, 
                 Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right
             };
+            var context = WindowsFormsSynchronizationContext.Current;
             renderForm.Dock = DockStyle.Fill;
             renderForm.FormBorderStyle = FormBorderStyle.None;
             renderForm.ShowIcon = false;
-            app = new CoreTestApp(renderForm);
+            app = new CoreTestApp(renderForm, context);
             splitContainer1.Panel2.Controls.Add(renderForm);
             Shown += Form1_Shown;
             FormClosing += Form1_FormClosing;

--- a/Source/Examples/SharpDX.Core/CoreTest/ImGuiNode.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/ImGuiNode.cs
@@ -80,9 +80,9 @@ namespace HelixToolkit.SharpDX.Core.Model
             base.OnDetach();
         }
 
-        protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+        protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
         {
-            return host.EffectsManager[ImGuiRenderTechnique];
+            return effectsManager[ImGuiRenderTechnique];
         }
 
         public override void Update(RenderContext context)

--- a/Source/Examples/SharpDX.Core/CoreTest/Properties/Resources.Designer.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CoreTest.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Source/Examples/SharpDX.Core/CoreTest/Properties/Settings.Designer.cs
+++ b/Source/Examples/SharpDX.Core/CoreTest/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CoreTest.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomMeshNode.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomMeshNode.cs
@@ -28,9 +28,9 @@ namespace CustomShaderDemo
             return new CustomMeshCore();
         }
 
-        protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+        protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
         {
-            return host.EffectsManager[CustomShaderNames.DataSampling];
+            return effectsManager[CustomShaderNames.DataSampling];
         }
     }
 }

--- a/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomNoiseMeshModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/CustomShaderDemo/CustomNoiseMeshModel3D.cs
@@ -13,7 +13,7 @@ namespace CustomShaderDemo
         protected override SceneNode OnCreateSceneNode()
         {
             var node = base.OnCreateSceneNode();
-            node.OnSetRenderTechnique = (host) => { return host.EffectsManager[CustomShaderNames.NoiseMesh]; };
+            node.OnSetRenderTechnique = (host) => { return node.EffectsManager[CustomShaderNames.NoiseMesh]; };
             return node;
         }
     }

--- a/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/App.config
+++ b/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
     </startup>
 </configuration>

--- a/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/CustomViewCubeDemo.csproj
+++ b/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/CustomViewCubeDemo.csproj
@@ -8,12 +8,13 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>CustomViewCubeDemo</RootNamespace>
     <AssemblyName>CustomViewCubeDemo</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -76,7 +77,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainWindowViewModel.cs" />
-
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -110,11 +110,11 @@
       <Name>DemoCore</Name>
     </ProjectReference>
   </ItemGroup>
-    <ItemGroup>
-        <Content Include="..\..\..\..\Models\obj\bunny\bunny.obj">
-            <Link>bunny.obj</Link>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </Content>
-    </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\..\Models\obj\bunny\bunny.obj">
+      <Link>bunny.obj</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/Properties/Resources.Designer.cs
+++ b/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace CustomViewCubeDemo.Properties
-{
-
-
+namespace CustomViewCubeDemo.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace CustomViewCubeDemo.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("CustomViewCubeDemo.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/Properties/Settings.Designer.cs
+++ b/Source/Examples/WPF.SharpDX/CustomViewCubeDemo/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace CustomViewCubeDemo.Properties
-{
-
-
+namespace CustomViewCubeDemo.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10048/MyLineGeometryModel3D.cs
+++ b/Source/Examples/WPF.SharpDX/ExampleBrowser/Workitems/Workitem10048/MyLineGeometryModel3D.cs
@@ -41,42 +41,6 @@ namespace Workitem10048
             return result;
         }
 
-        protected override SceneNode OnCreateSceneNode()
-        {
-            var sn = base.OnCreateSceneNode();
-            sn.Attached += this.OnSceneNodeOnAttached;
-            return sn;
-        }
-
-        private void OnSceneNodeOnAttached(object sender, EventArgs e)
-        {
-            var sn = this.SceneNode;
-            if (sn?.RenderHost?.Viewport is Viewport3DX vp)
-            {
-                vp.OnRendered += this.OnViewportOnRendered;
-                vp.CameraChanged += this.OnViewportCameraChanged;
-            }
-        }
-
-        private void OnViewportCameraChanged(object sender, RoutedEventArgs e)
-        {
-            Debug.WriteLine("Viewport3DX.CameraChanged works!");
-            var sn = this.SceneNode;
-            if (sn?.RenderHost?.Viewport is Viewport3DX vp)
-            {
-                vp.CameraChanged -= this.OnViewportCameraChanged;
-            }                        
-        }
-
-        private void OnViewportOnRendered(object sender, EventArgs e)
-        {
-            Debug.WriteLine("Viewport3DX.OnRendered works!");
-            var sn = this.SceneNode;
-            if (sn?.RenderHost?.Viewport is Viewport3DX vp)
-            {
-                vp.OnRendered -= this.OnViewportOnRendered;
-            }            
-        }
 
         //// alternative way, 3.36 times faster, but wrong PointHit
         //protected bool HitTest2D(IRenderContext context, Ray rayWS, ref List<HitTestResult> hits)

--- a/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
+++ b/Source/HelixToolkit.SharpDX.Core/Controls/ViewportCore.cs
@@ -73,18 +73,30 @@ namespace HelixToolkit.SharpDX.Core.Controls
         /// <param name="host">The host.</param>
         public void Attach(IRenderHost host)
         {
-            Items.Attach(host);
-            ViewCube.Attach(host);
-            CoordinateSystem.Attach(host);
+            Items.Attach(host.EffectsManager);
+            Items.Invalidated += Items_Invalidated;
+            ViewCube.Attach(host.EffectsManager);
+            ViewCube.Invalidated += Items_Invalidated;
+            CoordinateSystem.Attach(host.EffectsManager);
+            CoordinateSystem.Invalidated += Items_Invalidated;
             Items2D.Attach(host);
         }
+
+        private void Items_Invalidated(object sender, InvalidateTypes e)
+        {
+            RenderHost?.Invalidate(e);
+        }
+
         /// <summary>
         /// Detaches this instance.
         /// </summary>
         public void Detach()
         {
+            Items.Invalidated -= Items_Invalidated;
             Items.Detach();
+            ViewCube.Invalidated -= Items_Invalidated;
             ViewCube.Detach();
+            CoordinateSystem.Invalidated -= Items_Invalidated;
             CoordinateSystem.Detach();
             Items2D.Detach();
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -420,6 +420,11 @@ namespace HelixToolkit.UWP
         /// </summary>
         void InvalidatePerFrameRenderables();
         /// <summary>
+        /// Invalidate by InvalidateTypes
+        /// </summary>
+        /// <param name="type"></param>
+        void Invalidate(InvalidateTypes type);
+        /// <summary>
         /// Resizes
         /// </summary>
         /// <param name="width">The width.</param>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/Geometry3D.cs
@@ -19,6 +19,7 @@ namespace HelixToolkit.UWP
 
     using Core;
     using Model;
+    using System.ComponentModel;
 
 
 #if !NETFX_CORE
@@ -29,6 +30,12 @@ namespace HelixToolkit.UWP
     {
         public const string VertexBuffer = "VertexBuffer";
         public const string TriangleBuffer = "TriangleBuffer";
+        private static readonly PropertyChangedEventArgs vertexBufferPropChanged = new PropertyChangedEventArgs(VertexBuffer);
+        private static readonly PropertyChangedEventArgs triangleBufferPropChanged = new PropertyChangedEventArgs(TriangleBuffer);
+        private static readonly PropertyChangedEventArgs colorsPropChanged = new PropertyChangedEventArgs(nameof(Colors));
+        private static readonly PropertyChangedEventArgs positionPropChanged = new PropertyChangedEventArgs(nameof(Positions));
+        private static readonly PropertyChangedEventArgs indicesPropChanged = new PropertyChangedEventArgs(nameof(Indices));
+
         [DataMember]
         public Guid GUID { set; get; } = Guid.NewGuid();
 
@@ -46,9 +53,10 @@ namespace HelixToolkit.UWP
             }
             set
             {
-                if (Set(ref indices, value))
+                if (Set(ref indices, value, false))
                 {
                     ClearOctree();
+                    RaisePropertyChanged(indicesPropChanged);
                 }
             }
         }
@@ -67,14 +75,12 @@ namespace HelixToolkit.UWP
             }
             set
             {
-                if (position == value)
+                if (Set(ref position, value, false))
                 {
-                    return;
+                    ClearOctree();
+                    RaisePropertyChanged(positionPropChanged);
+                    UpdateBounds();
                 }
-                position = value;
-                ClearOctree();
-                RaisePropertyChanged();
-                UpdateBounds();
             }
         }
 
@@ -131,7 +137,10 @@ namespace HelixToolkit.UWP
             }
             set
             {
-                Set(ref colors, value);
+                if (Set(ref colors, value, false))
+                {
+                    RaisePropertyChanged(colorsPropChanged);
+                }
             }
         }
 
@@ -237,7 +246,7 @@ namespace HelixToolkit.UWP
         /// </summary>
         public void UpdateVertices()
         {
-            RaisePropertyChanged(VertexBuffer);
+            RaisePropertyChanged(vertexBufferPropChanged);
         }
         /// <summary>
         /// Call to manually update triangle buffer.
@@ -245,7 +254,7 @@ namespace HelixToolkit.UWP
         /// </summary>
         public void UpdateTriangles()
         {
-            RaisePropertyChanged(TriangleBuffer);
+            RaisePropertyChanged(triangleBufferPropChanged);
         }
 
         /// <summary>
@@ -255,7 +264,7 @@ namespace HelixToolkit.UWP
         /// </summary>
         public void UpdateColors()
         {
-            RaisePropertyChanged(nameof(Colors));
+            RaisePropertyChanged(colorsPropChanged);
         }
 
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Geometry/MeshGeometry3D.cs
@@ -18,6 +18,7 @@ namespace HelixToolkit.UWP
 #endif
 {
     using Core;
+    using System.ComponentModel;
     using Utilities;
 #if !NETFX_CORE
     [Serializable]
@@ -25,6 +26,8 @@ namespace HelixToolkit.UWP
     [DataContract]
     public class MeshGeometry3D : Geometry3D
     {
+        private static readonly PropertyChangedEventArgs textureCoordChangedArgs = new PropertyChangedEventArgs(nameof(TextureCoordinates));
+
         /// <summary>
         /// Used to scale up small triangle during hit test.
         /// </summary>
@@ -63,7 +66,10 @@ namespace HelixToolkit.UWP
             }
             set
             {
-                Set(ref textureCoordinates, value);
+                if (Set(ref textureCoordinates, value, false))
+                {
+                    RaisePropertyChanged(textureCoordChangedArgs);
+                }
             }
         }
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/ObservableObject.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/ObservableObject.cs
@@ -45,6 +45,12 @@ namespace HelixToolkit.UWP
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             }
 
+            protected void RaisePropertyChanged(PropertyChangedEventArgs args)
+            {
+                if (!DisablePropertyChangedEvent)
+                    PropertyChanged?.Invoke(this, args);
+            }
+
             protected bool Set<T>(ref T backingField, T value, [CallerMemberName] string propertyName = StringHelper.EmptyStr)
             {
                 if (EqualityComparer<T>.Default.Equals(backingField, value))

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GeometryNode.cs
@@ -512,13 +512,13 @@ namespace HelixToolkit.UWP
             /// <summary>
             /// This function initialize the Geometry Buffer and Instance Buffer
             /// </summary>
-            /// <param name="host"></param>
+            /// <param name="effectsManager"></param>
             /// <returns>
             /// Return true if attached
             /// </returns>
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                if (base.OnAttach(host))
+                if (base.OnAttach(effectsManager))
                 {
                     CreateGeometryBuffer();
                     BoundManager.Geometry = Geometry;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GroupNodeBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/GroupNodeBase.cs
@@ -107,7 +107,7 @@ namespace HelixToolkit.UWP
             /// <exception cref="System.ArgumentException">SceneNode already attach to a different node</exception>
             public bool AddChildNode(SceneNode node)
             {
-                if (node != null && !itemHashSet.ContainsKey(node.GUID) && !node.IsAttached)
+                if (node != null && !itemHashSet.ContainsKey(node.GUID))
                 {
                     itemHashSet.Add(node.GUID, node);
                     ItemsInternal.Add(node);
@@ -118,7 +118,7 @@ namespace HelixToolkit.UWP
                     node.Parent = this;
                     if (IsAttached)
                     {
-                        node.Attach(RenderHost);
+                        node.Attach(EffectsManager);
                         InvalidateSceneGraph();
                     }
                     ChildNodeAdded?.Invoke(this, new OnChildNodeChangedArgs(node, Operation.Add));
@@ -159,7 +159,7 @@ namespace HelixToolkit.UWP
                 node.Parent = this;
                 if (IsAttached)
                 {
-                    node.Attach(RenderHost);
+                    node.Attach(EffectsManager);
                     InvalidateSceneGraph();
                 }
                 ChildNodeAdded?.Invoke(this, new OnChildNodeChangedArgs(node, Operation.Add));
@@ -230,15 +230,15 @@ namespace HelixToolkit.UWP
             /// <summary>
             /// Called when [attach].
             /// </summary>
-            /// <param name="host">The host.</param>
+            /// <param name="effectsManager">The effectsManager.</param>
             /// <returns></returns>
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                if (base.OnAttach(host))
+                if (base.OnAttach(effectsManager))
                 {
                     for (var i = 0; i < ItemsInternal.Count; ++i)
                     {
-                        ItemsInternal[i].Attach(host);
+                        ItemsInternal[i].Attach(effectsManager);
                     }
                     return true;
                 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/MaterialGeometryNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/MaterialGeometryNode.cs
@@ -55,7 +55,7 @@ namespace HelixToolkit.UWP
                 {
                     if (Set(ref material, value))
                     {
-                        if (RenderHost != null)
+                        if (EffectsManager != null)
                         {
                             if (IsAttached)
                             {
@@ -65,7 +65,7 @@ namespace HelixToolkit.UWP
                             else
                             {
                                 Detach();
-                                Attach(RenderHost);
+                                Attach(EffectsManager);
                             }
                         }
                     }
@@ -94,9 +94,9 @@ namespace HelixToolkit.UWP
                 return base.CanRender(context) && materialVariable != null;
             }
 
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                if (base.OnAttach(host))
+                if (base.OnAttach(effectsManager))
                 {
                     AttachMaterial();
                     return true;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/ParametricSurface3DNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/ParametricSurface3DNode.cs
@@ -58,10 +58,10 @@ namespace HelixToolkit.UWP
                 get => isTessellating;
             }
 
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
                 cancelToken = new CancellationTokenSource();
-                return base.OnAttach(host);
+                return base.OnAttach(effectsManager);
             }
 
             protected override void OnDetach()

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Abstract/SceneNode.cs
@@ -26,13 +26,29 @@ namespace HelixToolkit.UWP
         using Core;
         using Render;
 
+        public enum InvalidateTypes
+        {
+            /// <summary>
+            /// Notify if scene needs re-rendered.
+            /// </summary>
+            Render,
+            /// <summary>
+            /// Notify if scene graph structure has changed.
+            /// </summary>
+            SceneGraph,
+            /// <summary>
+            /// Notify to rebuild per frame renderables.
+            /// </summary>
+            PerFrameRenderables
+        }
+
         /// <summary>
         ///
         /// </summary>
         public abstract partial class SceneNode : DisposeObject, IComparable<SceneNode>, Animations.IAnimationNode
         {
             #region Properties
-
+            private static readonly string NodeStr = "Node";
             /// <summary>
             ///
             /// </summary>
@@ -43,7 +59,7 @@ namespace HelixToolkit.UWP
                     return RenderCore.GUID;
                 }
             }
-            private string name = "Node";
+            private string name = NodeStr;
             /// <summary>
             /// Gets or sets the name.
             /// </summary>
@@ -221,25 +237,14 @@ namespace HelixToolkit.UWP
             }
 
             /// <summary>
-            ///
-            /// </summary>
-            public IRenderHost RenderHost
-            {
-                get; private set;
-            }
-
-            /// <summary>
             /// Gets the effects manager.
             /// </summary>
             /// <value>
             /// The effects manager.
             /// </value>
-            protected IEffectsManager EffectsManager
+            public IEffectsManager EffectsManager
             {
-                get
-                {
-                    return RenderHost.EffectsManager;
-                }
+                private set; get;
             }
 
             /// <summary>
@@ -398,7 +403,7 @@ namespace HelixToolkit.UWP
             /// </summary>
             /// <param name="host"></param>
             /// <returns></returns>
-            public delegate IRenderTechnique SetRenderTechniqueFunc(IRenderHost host);
+            public delegate IRenderTechnique SetRenderTechniqueFunc(IEffectsManager effectsManager);
 
             /// <summary>
             /// A delegate function to change render technique.
@@ -414,9 +419,9 @@ namespace HelixToolkit.UWP
             /// </summary>
             /// <param name="host"></param>
             /// <returns>Return RenderTechnique</returns>
-            protected virtual IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected virtual IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.RenderTechnique;
+                return effectsManager[DefaultRenderTechniqueNames.Mesh];
             }
 
             /// <summary>
@@ -504,6 +509,11 @@ namespace HelixToolkit.UWP
             /// Occurs when [mouse up].
             /// </summary>
             public event EventHandler<SceneNodeMouseUpArgs> MouseUp;
+            /// <summary>
+            /// Occurs when invalidation has happened.
+            /// This is a bubble up event.
+            /// </summary>
+            public event EventHandler<InvalidateTypes> Invalidated;
             #endregion Events
 
             private RenderCore core;
@@ -529,29 +539,33 @@ namespace HelixToolkit.UWP
                 Name = name;
             }
             /// <summary>
-            /// <para>Attaches the element to the specified host. To overide Attach, please override <see cref="OnAttach(IRenderHost)"/> function.</para>
+            /// <para>Attaches the element to the specified host. To overide Attach, please override <see cref="OnAttach(EffectsManager)"/> function.</para>
             /// <para>To set different render technique instead of using technique from host, override <see cref="OnCreateRenderTechnique"/></para>
-            /// <para>Attach Flow: <see cref="OnCreateRenderTechnique(IRenderHost)"/> -> Set RenderHost -> Get Effect -> <see cref="OnAttach(IRenderHost)"/> -> <see cref="InvalidateSceneGraph"/></para>
+            /// <para>Attach Flow: <see cref="OnCreateRenderTechnique(EffectsManager)"/> -> Set RenderHost -> Get Effect -> <see cref="OnAttach(EffectsManager)"/> -> <see cref="InvalidateSceneGraph"/></para>
             /// </summary>
             /// <param name="host">The host.</param>
-            public void Attach(IRenderHost host)
+            public void Attach(IEffectsManager effectsManager)
             {
-                if (IsAttached || host == null || host.EffectsManager == null)
+                if (IsAttached && effectsManager != EffectsManager)
+                {
+                    throw new InvalidOperationException("EffectsManager instances must be the same during attaching.");
+                }
+                if (IsAttached || effectsManager == null)
                 {
                     return;
                 }
-                RenderHost = host;
-                this.renderTechnique = OnSetRenderTechnique != null ? OnSetRenderTechnique(host) : OnCreateRenderTechnique(host);
+                EffectsManager = effectsManager;
+                this.renderTechnique = OnSetRenderTechnique != null ? OnSetRenderTechnique(effectsManager) : OnCreateRenderTechnique(effectsManager);
                 if (renderTechnique == null)
                 {
-                    var techniqueName = RenderHost.EffectsManager.RenderTechniques.FirstOrDefault();
+                    var techniqueName = EffectsManager.RenderTechniques.FirstOrDefault();
                     if (string.IsNullOrEmpty(techniqueName))
                     {
                         return;
                     }
-                    renderTechnique = RenderHost.EffectsManager[techniqueName];
+                    renderTechnique = EffectsManager[techniqueName];
                 }
-                IsAttached = OnAttach(host);
+                IsAttached = OnAttach(effectsManager);
                 if (IsAttached)
                 {
                     NeedMatrixUpdate = true;
@@ -566,7 +580,7 @@ namespace HelixToolkit.UWP
             /// </summary>
             /// <param name="host"></param>
             /// <returns>Return true if attached</returns>
-            protected virtual bool OnAttach(IRenderHost host)
+            protected virtual bool OnAttach(IEffectsManager host)
             {
                 RenderCore.Attach(renderTechnique);
                 AssignDefaultValuesToCore(RenderCore);
@@ -593,6 +607,7 @@ namespace HelixToolkit.UWP
                     OnDetach();
                     renderTechnique = null;
                     Detached?.Invoke(this, EventArgs.Empty);
+                    Invalidated = null;
                 }
             }
 
@@ -601,12 +616,12 @@ namespace HelixToolkit.UWP
             /// </summary>
             protected virtual void OnDetach()
             {
-                RenderHost = null;
+                EffectsManager = null;
             }
 
             protected void InvalidateRenderEvent(object sender, EventArgs arg)
             {
-                RenderHost?.InvalidateRender();
+                Invalidate(InvalidateTypes.Render);
             }
 
             /// <summary>
@@ -615,7 +630,7 @@ namespace HelixToolkit.UWP
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void InvalidateRender()
             {
-                RenderHost?.InvalidateRender();
+                Invalidate(InvalidateTypes.Render);
             }
 
             /// <summary>
@@ -624,7 +639,7 @@ namespace HelixToolkit.UWP
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             protected void InvalidateSceneGraph()
             {
-                RenderHost?.InvalidateSceneGraph();
+                Invalidate(InvalidateTypes.SceneGraph);
             }
 
             /// <summary>
@@ -633,7 +648,23 @@ namespace HelixToolkit.UWP
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             protected void InvalidatePerFrameRenderables()
             {
-                RenderHost?.InvalidatePerFrameRenderables();
+                Invalidate(InvalidateTypes.PerFrameRenderables);
+            }
+            /// <summary>
+            /// Invalidate by type
+            /// </summary>
+            /// <param name="type"></param>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            protected void Invalidate(InvalidateTypes type)
+            {
+                Invalidated?.Invoke(this, type);              
+                if (parent != null)
+                {
+                    foreach(var node in TreeTraverser.TraverseUp(parent))
+                    {
+                        node.Invalidated?.Invoke(this, type);
+                    }
+                }
             }
             /// <summary>
             /// Updates the element total transforms, determine renderability, etc. by the specified time span.
@@ -1053,6 +1084,7 @@ namespace HelixToolkit.UWP
             {
                 ItemsInternal.Clear();
                 RenderCore.Dispose();
+                Invalidated = null;
                 VisibleChanged = null;
                 TransformChanged = null;
                 OnSetRenderTechnique = null;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/AxisPlaneGridNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/AxisPlaneGridNode.cs
@@ -247,9 +247,9 @@ namespace HelixToolkit.UWP
                 return new AxisPlaneGridCore();
             }
 
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.PlaneGrid];
+                return effectsManager[DefaultRenderTechniqueNames.PlaneGrid];
             }
 
             protected override bool OnHitTest(HitTestContext context, Matrix totalModelMatrix, ref List<HitTestResult> hits)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BatchedMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BatchedMeshNode.cs
@@ -496,7 +496,7 @@ namespace HelixToolkit.UWP
                 {
                     if (Set(ref material, value))
                     {
-                        if (RenderHost != null)
+                        if (EffectsManager != null)
                         {
                             if (IsAttached)
                             {
@@ -505,9 +505,9 @@ namespace HelixToolkit.UWP
                             }
                             else
                             {
-                                var host = RenderHost;
+                                var effectsMgr = EffectsManager;
                                 Detach();
-                                Attach(host);
+                                Attach(effectsMgr);
                             }
                         }
                     }
@@ -553,9 +553,9 @@ namespace HelixToolkit.UWP
                 };
             }
 
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.MeshBatched];
+                return effectsManager[DefaultRenderTechniqueNames.MeshBatched];
             }
 
             /// <summary>
@@ -606,16 +606,9 @@ namespace HelixToolkit.UWP
                 }
             }
 
-            /// <summary>
-            /// This function initialize the Geometry Buffer and Instance Buffer
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return true if attached
-            /// </returns>
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                if (base.OnAttach(host))
+                if (base.OnAttach(effectsManager))
                 {
                     batchingBuffer = new DefaultStaticMeshBatchingBuffer();
                     batchingBuffer.Geometries = Geometries;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BillboardNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/BillboardNode.cs
@@ -52,17 +52,9 @@ namespace HelixToolkit.UWP
                 return buffer;
             }
 
-            /// <summary>
-            /// Override this function to set render technique during Attach Host.
-            /// <para>If <see cref="SceneNode.OnSetRenderTechnique" /> is set, then <see cref="SceneNode.OnSetRenderTechnique" /> instead of <see cref="OnCreateRenderTechnique" /> function will be called.</para>
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return RenderTechnique
-            /// </returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.BillboardText];
+                return effectsManager[DefaultRenderTechniqueNames.BillboardText];
             }
 
             public override bool TestViewFrustum(ref BoundingFrustum viewFrustum)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
@@ -373,17 +373,9 @@ namespace HelixToolkit.UWP
                 return new Plane(v.ToXYZ(), v.W);
             }
 
-            /// <summary>
-            /// Override this function to set render technique during Attach Host.
-            /// <para>If <see cref="SceneNode.OnSetRenderTechnique" /> is set, then <see cref="SceneNode.OnSetRenderTechnique" /> instead of <see cref="OnCreateRenderTechnique" /> function will be called.</para>
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return RenderTechnique
-            /// </returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.CrossSection];
+                return effectsManager[DefaultRenderTechniqueNames.CrossSection];
             }
 
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/DynamicReflectionNode.cs
@@ -184,9 +184,9 @@ namespace HelixToolkit.UWP
                 return new DynamicCubeMapCore();
             }
 
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                if (base.OnAttach(host))
+                if (base.OnAttach(effectsManager))
                 {
                     RenderCore.Attach(this.EffectTechnique);
                     return true;
@@ -227,9 +227,9 @@ namespace HelixToolkit.UWP
                 }
             }
 
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.Skybox];
+                return effectsManager[DefaultRenderTechniqueNames.Skybox];
             }
 
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/EnvironmentMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/EnvironmentMapNode.cs
@@ -88,14 +88,10 @@ namespace HelixToolkit.UWP
                     return new SkyBoxRenderCore();
                 }
             }
-            /// <summary>
-            /// Called when [create render technique].
-            /// </summary>
-            /// <param name="host">The host.</param>
-            /// <returns></returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.Skybox];
+                return effectsManager[DefaultRenderTechniqueNames.Skybox];
             }
 
             public sealed override bool HitTest(HitTestContext context, ref List<HitTestResult> hits)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/InstancingBillboardNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/InstancingBillboardNode.cs
@@ -60,29 +60,15 @@ namespace HelixToolkit.UWP
                 return new InstancingBillboardRenderCore() { ParameterBuffer = this.instanceParamBuffer };
             }
 
-            /// <summary>
-            /// Override this function to set render technique during Attach Host.
-            /// <para>If <see cref="SceneNode.OnSetRenderTechnique" /> is set, then <see cref="SceneNode.OnSetRenderTechnique" /> instead of <see cref="OnCreateRenderTechnique" /> function will be called.</para>
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return RenderTechnique
-            /// </returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.BillboardInstancing];
+                return effectsManager[DefaultRenderTechniqueNames.BillboardInstancing];
             }
-            /// <summary>
-            /// To override Attach routine, please override this.
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return true if attached
-            /// </returns>
-            protected override bool OnAttach(IRenderHost host)
+
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
                 // --- attach
-                if (!base.OnAttach(host))
+                if (!base.OnAttach(effectsManager))
                 {
                     return false;
                 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/InstancingMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/InstancingMeshNode.cs
@@ -89,31 +89,20 @@ namespace HelixToolkit.UWP
             /// The instance parameter buffer
             /// </summary>
             protected IElementsBufferModel<InstanceParameter> instanceParamBuffer = new InstanceParamsBufferModel<InstanceParameter>(InstanceParameter.SizeInBytes);
-            /// <summary>
-            /// Called when [create render technique].
-            /// </summary>
-            /// <param name="host">The host.</param>
-            /// <returns></returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.InstancingMesh];
+                return effectsManager[DefaultRenderTechniqueNames.InstancingMesh];
             }
-            /// <summary>
-            /// Called when [create render core].
-            /// </summary>
-            /// <returns></returns>
+
             protected override RenderCore OnCreateRenderCore()
             {
                 return new InstancingMeshRenderCore() { ParameterBuffer = this.instanceParamBuffer };
             }
-            /// <summary>
-            /// Called when [attach].
-            /// </summary>
-            /// <param name="host">The host.</param>
-            /// <returns></returns>
-            protected override bool OnAttach(IRenderHost host)
+
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                if (base.OnAttach(host))
+                if (base.OnAttach(effectsManager))
                 {
                     instanceParamBuffer.Initialize();
 

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
@@ -228,27 +228,27 @@ namespace HelixToolkit.UWP
             /// <returns>
             /// Return true if attached
             /// </returns>
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                base.OnAttach(host);
+                base.OnAttach(effectsManager);
                 shadowCore = RenderCore as ShadowMapCore;
-                host.SceneGraphUpdated += Host_SceneGraphUpdated;
+                this.Invalidated += Host_SceneGraphUpdated;
                 sceneChanged = true;
                 return true;
             }
 
             protected override void OnDetach()
             {
-                if (RenderHost != null)
-                {
-                    RenderHost.SceneGraphUpdated -= Host_SceneGraphUpdated;
-                }
+                this.Invalidated -= Host_SceneGraphUpdated;
                 base.OnDetach();
             }
 
-            private void Host_SceneGraphUpdated(object sender, System.EventArgs e)
+            private void Host_SceneGraphUpdated(object sender, InvalidateTypes type)
             {
-                sceneChanged = true;
+                if (type == InvalidateTypes.SceneGraph)
+                {
+                    sceneChanged = true;
+                }
             }
 
             /// <summary>
@@ -258,11 +258,11 @@ namespace HelixToolkit.UWP
             /// <returns></returns>
             protected override bool CanRender(RenderContext context)
             {
-                (RenderCore as ShadowMapCore).NeedRender = base.CanRender(context) && RenderHost.IsShadowMapEnabled;
+                (RenderCore as ShadowMapCore).NeedRender = base.CanRender(context) && context.RenderHost.IsShadowMapEnabled;
                 return true;
             }
 
-            private BoundingBox FindSceneBound(FastList<SceneNode> nodes)
+            private BoundingBox FindSceneBound(FastList<SceneNode> nodes) 
             {
                 var box = new BoundingBox();
                 if (nodes.Count > 0)
@@ -358,7 +358,7 @@ namespace HelixToolkit.UWP
                             var dir = Vector3.TransformNormal(dlight.Direction, dlight.ModelMatrix).Normalized();
                             if (AutoCoverCompleteScene)
                             {
-                                if (sceneChanged || IsSceneDynamic)
+                                if (sceneChanged || e.Context.UpdateSceneGraphRequested || IsSceneDynamic)
                                 {
                                     sceneChanged = false;
                                     var boundingBox = FindSceneBound(e.Context.RenderHost.PerFrameOpaqueNodes);

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/LineNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/LineNode.cs
@@ -77,28 +77,17 @@ namespace HelixToolkit.UWP
                     IsScissorEnabled = IsThrowingShadow ? false : IsScissorEnabled
                 };
             }
-            /// <summary>
-            /// Override this function to set render technique during Attach Host.
-            ///<para>If<see cref="SceneNode.OnSetRenderTechnique" /> is set, then<see cref="SceneNode.OnSetRenderTechnique" /> instead of<see cref="OnCreateRenderTechnique" /> function will be called.</para>
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return RenderTechnique
-            /// </returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.Lines];
+                return effectsManager[DefaultRenderTechniqueNames.Lines];
             }
-            /// <summary>
-            /// <para>Determine if this can be rendered.</para>
-            /// </summary>
-            /// <param name="context"></param>
-            /// <returns></returns>
+
             protected override bool CanRender(RenderContext context)
             {
                 if (base.CanRender(context))
                 {
-                    return !RenderHost.IsDeferredLighting;
+                    return !context.RenderHost.IsDeferredLighting;
                 }
                 else
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ParticleStormNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ParticleStormNode.cs
@@ -713,23 +713,15 @@ namespace HelixToolkit.UWP
             {
                 return new ParticleRenderCore();
             }
-            /// <summary>
-            /// Called when [create render technique].
-            /// </summary>
-            /// <param name="host">The host.</param>
-            /// <returns></returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.ParticleStorm];
+                return effectsManager[DefaultRenderTechniqueNames.ParticleStorm];
             }
-            /// <summary>
-            /// Called when [attach].
-            /// </summary>
-            /// <param name="host">The host.</param>
-            /// <returns></returns>
-            protected override bool OnAttach(IRenderHost host)
+
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                base.OnAttach(host);
+                base.OnAttach(effectsManager);
                 InstanceBuffer.Initialize();
                 InstanceBuffer.Elements = Instances;
                 particleCore.InstanceBuffer = InstanceBuffer;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PointNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PointNode.cs
@@ -98,17 +98,9 @@ namespace HelixToolkit.UWP
                 };
             }
 
-            /// <summary>
-            /// Override this function to set render technique during Attach Host.
-            /// <para>If <see cref="SceneNode.OnSetRenderTechnique" /> is set, then <see cref="SceneNode.OnSetRenderTechnique" /> instead of <see cref="OnCreateRenderTechnique" /> function will be called.</para>
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return RenderTechnique
-            /// </returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.Points];
+                return effectsManager[DefaultRenderTechniqueNames.Points];
             }
 
             /// <summary>
@@ -120,7 +112,7 @@ namespace HelixToolkit.UWP
             {
                 if (base.CanRender(context))
                 {
-                    return !RenderHost.IsDeferredLighting;
+                    return !context.RenderHost.IsDeferredLighting;
                 }
                 else
                 {

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PostEffects/NodePostEffectBloom.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PostEffects/NodePostEffectBloom.cs
@@ -164,9 +164,9 @@ namespace HelixToolkit.UWP
             /// <returns>
             /// Return RenderTechnique
             /// </returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.PostEffectBloom];
+                return effectsManager[DefaultRenderTechniqueNames.PostEffectBloom];
             }
 
             public sealed override bool HitTest(HitTestContext context, ref List<HitTestResult> hits)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PostEffects/NodePostEffectBorderHighlight.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PostEffects/NodePostEffectBorderHighlight.cs
@@ -49,17 +49,9 @@ namespace HelixToolkit.UWP
                 EffectName = DefaultRenderTechniqueNames.PostEffectMeshBorderHighlight;
             }
 
-            /// <summary>
-            /// Override this function to set render technique during Attach Host.
-            /// <para>If <see cref="SceneNode.OnSetRenderTechnique" /> is set, then <see cref="SceneNode.OnSetRenderTechnique" /> instead of <see cref="OnCreateRenderTechnique" /> function will be called.</para>
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return RenderTechnique
-            /// </returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.PostEffectMeshBorderHighlight];
+                return effectsManager[DefaultRenderTechniqueNames.PostEffectMeshBorderHighlight];
             }
 
             /// <summary>

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PostEffects/NodePostEffectMeshOutlineBlur.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/PostEffects/NodePostEffectMeshOutlineBlur.cs
@@ -126,17 +126,9 @@ namespace HelixToolkit.UWP
                 return new PostEffectMeshOutlineBlurCore();
             }
 
-            /// <summary>
-            /// Override this function to set render technique during Attach Host.
-            /// <para>If <see cref="SceneNode.OnSetRenderTechnique" /> is set, then <see cref="SceneNode.OnSetRenderTechnique" /> instead of <see cref="OnCreateRenderTechnique" /> function will be called.</para>
-            /// </summary>
-            /// <param name="host"></param>
-            /// <returns>
-            /// Return RenderTechnique
-            /// </returns>
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.PostEffectMeshOutlineBlur];
+                return effectsManager[DefaultRenderTechniqueNames.PostEffectMeshOutlineBlur];
             }
 
             public sealed override bool HitTest(HitTestContext context, ref List<HitTestResult> hits)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenDuplicationNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenDuplicationNode.cs
@@ -112,9 +112,9 @@ namespace HelixToolkit.UWP
                 return new ScreenCloneRenderCore();
             }
 
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.ScreenDuplication];
+                return effectsManager[DefaultRenderTechniqueNames.ScreenDuplication];
             }
 
             protected override bool OnHitTest(HitTestContext context, Matrix totalModelMatrix, ref List<HitTestResult> hits)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenQuadNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenQuadNode.cs
@@ -85,9 +85,9 @@ namespace HelixToolkit.UWP
                 return new DrawScreenQuadCore();
             }
 
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return EffectsManager[DefaultRenderTechniqueNames.ScreenQuad];
+                return effectsManager[DefaultRenderTechniqueNames.ScreenQuad];
             }
 
             public sealed override bool HitTest(HitTestContext context, ref List<HitTestResult> hits)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenSpacedNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ScreenSpacedNode.cs
@@ -97,10 +97,10 @@ namespace HelixToolkit.UWP
 
                 public IRenderHost RenderHost
                 {
-                    get;
+                    set; get;
                 }
 
-                public CameraCore Camera => RenderHost.RenderContext.Camera;
+                public CameraCore Camera => RenderHost != null ? RenderHost.RenderContext.Camera : null;
 
                 public FrustumCameraParams CameraParams
                 {
@@ -114,11 +114,6 @@ namespace HelixToolkit.UWP
                     {
                         CameraParams = Camera.CreateCameraParams(ActualWidth / ActualHeight, NearPlane, FarPlane);                    
                     }
-                }
-
-                public ScreenSpacedContext(IRenderHost host)
-                {
-                    RenderHost = host;
                 }
             }
             #region Properties
@@ -266,7 +261,7 @@ namespace HelixToolkit.UWP
 
             private List<HitTestResult> screenSpaceHits = new List<HitTestResult>();
 
-            private ScreenSpacedContext screenSpacedContext;
+            private readonly ScreenSpacedContext screenSpacedContext = new ScreenSpacedContext();
 
             public ScreenSpacedNode()
             {
@@ -291,24 +286,15 @@ namespace HelixToolkit.UWP
             protected virtual void OnCoordinateSystemChanged(bool e)
             {
             }
-            /// <summary>
-            /// Called when [attach].
-            /// </summary>
-            /// <param name="host">The host.</param>
-            /// <returns></returns>
-            protected override bool OnAttach(IRenderHost host)
+   
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
                 RenderCore.Attach(EffectTechnique);
                 var screenSpaceCore = RenderCore as ScreenSpacedMeshRenderCore;
                 screenSpaceCore.RelativeScreenLocationX = RelativeScreenLocationX;
                 screenSpaceCore.RelativeScreenLocationY = RelativeScreenLocationY;
                 screenSpaceCore.SizeScale = SizeScale;
-                screenSpacedContext = new ScreenSpacedContext(host);
-                //for (int i = 0; i < ItemsInternal.Count; ++i)
-                //{
-                //    ItemsInternal[i].RenderType = RenderType.ScreenSpaced;
-                //}
-                return base.OnAttach(host);
+                return base.OnAttach(effectsManager);
             }
 
             /// <summary>
@@ -320,8 +306,10 @@ namespace HelixToolkit.UWP
                 base.OnDetach();
             }
 
+
             protected override bool OnHitTest(HitTestContext context, Matrix totalModelMatrix, ref List<HitTestResult> hits)
             {
+                screenSpacedContext.RenderHost = context.RenderMatrices.RenderHost;
                 var newRay = new Ray();
                 var hitSP = context.HitPointSP;
                 var preHit = false;

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/SortingGroupNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/SortingGroupNode.cs
@@ -85,10 +85,10 @@ namespace HelixToolkit.UWP
             private readonly List<SortStruct> sortingOpaqueCache = new List<SortStruct>();
             private readonly List<SceneNode> notSorted = new List<SceneNode>();
 
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
                 LastSortTime = 0;
-                return base.OnAttach(host);
+                return base.OnAttach(effectsManager);
             }
 
             public override void UpdateNotRender(RenderContext context)

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ViewBoxNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/ViewBoxNode.cs
@@ -190,14 +190,14 @@ namespace HelixToolkit.UWP
                 UpdateModel(UpDirection);
             }
 
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                if (base.OnAttach(host))
+                if (base.OnAttach(effectsManager))
                 {
                     var material = (ViewBoxMeshModel.Material as ViewCubeMaterialCore);
                     if (material.DiffuseMap == null)
                     {
-                        material.DiffuseMap = ViewBoxTexture ?? new TextureModel(BitmapExtensions.CreateViewBoxTexture(host.EffectsManager,
+                        material.DiffuseMap = ViewBoxTexture ?? new TextureModel(BitmapExtensions.CreateViewBoxTexture(effectsManager,
                             "F", "B", "L", "R", "U", "D", Color.Red, Color.Red, Color.Blue, Color.Blue, Color.Green, Color.Green,
                             Color.White, Color.White, Color.White, Color.White, Color.White, Color.White), true);
                     }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/VolumeTextureNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/VolumeTextureNode.cs
@@ -37,7 +37,7 @@ namespace HelixToolkit.UWP
                 {
                     if (Set(ref material, value))
                     {
-                        if (RenderHost != null)
+                        if (EffectsManager != null)
                         {
                             if (IsAttached)
                             {
@@ -47,7 +47,7 @@ namespace HelixToolkit.UWP
                             else
                             {
                                 Detach();
-                                Attach(RenderHost);
+                                Attach(EffectsManager);
                             }
                         }
                     }
@@ -61,9 +61,9 @@ namespace HelixToolkit.UWP
                 RenderType = RenderType.Transparent;
             }
 
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
-                if (base.OnAttach(host))
+                if (base.OnAttach(effectsManager))
                 {
                     AttachMaterial();
                     return true;
@@ -107,9 +107,9 @@ namespace HelixToolkit.UWP
                 return new VolumeRenderCore() { DefaultStateBinding = StateType.All };
             }
 
-            protected override IRenderTechnique OnCreateRenderTechnique(IRenderHost host)
+            protected override IRenderTechnique OnCreateRenderTechnique(IEffectsManager effectsManager)
             {
-                return host.EffectsManager[DefaultRenderTechniqueNames.Volume3D];
+                return effectsManager[DefaultRenderTechniqueNames.Volume3D];
             }
 
             protected override bool OnHitTest(HitTestContext context, Matrix totalModelMatrix, ref List<HitTestResult> hits)

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -733,6 +733,22 @@ namespace HelixToolkit.UWP
                 UpdatePerFrameRenderableRequested = true;
                 InvalidateRender();
             }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Invalidate(InvalidateTypes type)
+            {
+                switch (type)
+                {
+                    case InvalidateTypes.SceneGraph:
+                        InvalidateSceneGraph();
+                        break;
+                    case InvalidateTypes.Render:
+                        InvalidateRender();
+                        break;
+                    case InvalidateTypes.PerFrameRenderables:
+                        InvalidatePerFrameRenderables();
+                        break;
+                }
+            }
             /// <summary>
             /// Determines whether this instance can render.
             /// </summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
@@ -348,6 +348,14 @@ namespace HelixToolkit.Wpf.SharpDX
                 v.InvalidatePerFrameRenderables();
             }
         }
+
+        public void Invalidate(InvalidateTypes type)
+        {
+            foreach (var v in attachedRenderHosts)
+            {
+                v.Invalidate(type);
+            }
+        }
         /// <summary>
         /// Sets the default render targets.
         /// </summary>
@@ -652,11 +660,18 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     foreach (var renderable in Renderables)
                     {
-                        renderable.Attach(this);
+                        renderable.Invalidated += RenderableInvalidated;
+                        renderable.Attach(EffectsManager);
                     }
                 }
             }
         }
+
+        private void RenderableInvalidated(object sender, InvalidateTypes e)
+        {
+            Invalidate(e);
+        }
+
         /// <summary>
         /// Detaches this instance.
         /// </summary>
@@ -669,8 +684,9 @@ namespace HelixToolkit.Wpf.SharpDX
                 if (Interlocked.Decrement(ref d3dCounter) == 0)
                 {
                     foreach (var renderable in Renderables)
-                    {
+                    {                        
                         renderable.Detach();
+                        renderable.Invalidated -= RenderableInvalidated;
                     }
                 }
                 else if (d3dCounter < 0)
@@ -685,6 +701,7 @@ namespace HelixToolkit.Wpf.SharpDX
             foreach (var renderable in Renderables)
             {
                 renderable.Detach();
+                renderable.Invalidated -= RenderableInvalidated;
             }
         }
         /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/TransformManipulator3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/TransformManipulator3D.cs
@@ -733,7 +733,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 this.manipulator = manipulator;
             }
 
-            protected override bool OnAttach(IRenderHost host)
+            protected override bool OnAttach(IEffectsManager effectsManager)
             {
                 models.Add(manipulator.translationX);
                 models.Add(manipulator.translationY);
@@ -744,7 +744,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 models.Add(manipulator.scaleX);
                 models.Add(manipulator.scaleY);
                 models.Add(manipulator.scaleZ);
-                return base.OnAttach(host);
+                return base.OnAttach(effectsManager);
             }
             protected override bool OnHitTest(HitTestContext context, Matrix totalModelMatrix, ref List<HitTestResult> hits)
             {

--- a/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DX.cs
@@ -317,6 +317,7 @@ namespace HelixToolkit.UWP
                     if (item is Element3D element)
                     {
                         element.SceneNode.Detach();
+                        element.SceneNode.Invalidated -= NodeInvalidated;
                     }
                 }
             }
@@ -330,12 +331,14 @@ namespace HelixToolkit.UWP
                     }
                     if (this.IsAttached && item is Element3D element)
                     {
-                        element.SceneNode.Attach(renderHostInternal);
+                        element.SceneNode.Invalidated += NodeInvalidated;
+                        element.SceneNode.Attach(EffectsManager);
                     }
                 }
             }
             InvalidateRender();
         }
+
 
         protected override void OnApplyTemplate()
         {
@@ -514,7 +517,8 @@ namespace HelixToolkit.UWP
             {
                 foreach (var e in this.OwnedRenderables)
                 {
-                    e.Attach(host);
+                    e.Attach(EffectsManager);
+                    e.Invalidated += NodeInvalidated;
                 }
                 SharedModelContainerInternal?.Attach(host);
                 foreach (var e in this.D2DRenderables)
@@ -523,6 +527,11 @@ namespace HelixToolkit.UWP
                 }
                 IsAttached = true;
             }
+        }
+
+        private void NodeInvalidated(object sender, InvalidateTypes e)
+        {
+            renderHostInternal?.Invalidate(e);
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/ScreenDuplicationViewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/ScreenDuplicationViewport3DX.cs
@@ -314,7 +314,7 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 foreach (var e in this.Renderables)
                 {
-                    e.Attach(host);
+                    e.Attach(EffectsManager);
                 }
                 IsAttached = true;
             }

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
@@ -385,7 +385,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     partItemsControl?.Items.Add(item);
                     if (this.IsAttached && item is Element3D element)
                     {
-                        element.SceneNode.Attach(renderHostInternal);
+                        element.SceneNode.Attach(EffectsManager);
                     }
                 }
             }
@@ -974,7 +974,8 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 foreach (var e in this.OwnedRenderables)
                 {
-                    e.Attach(host);
+                    e.Attach(EffectsManager);
+                    e.Invalidated += NodeInvalidated;
                 }
                 SharedModelContainerInternal?.Attach(host);
                 foreach (var e in this.D2DRenderables)
@@ -983,6 +984,11 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
                 IsAttached = true;
             }
+        }
+
+        private void NodeInvalidated(object sender, InvalidateTypes e)
+        {
+            renderHostInternal?.Invalidate(e);
         }
 
         /// <summary>
@@ -995,6 +1001,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 IsAttached = false;
                 foreach (var e in this.OwnedRenderables)
                 {
+                    e.Invalidated -= NodeInvalidated;
                     e.Detach();
                 }
                 SharedModelContainerInternal?.Detach(this.renderHostInternal);

--- a/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/MeshGeometryModel3DTests.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Tests/Elements3D/MeshGeometryModel3DTests.cs
@@ -34,7 +34,7 @@ namespace HelixToolkit.Wpf.SharpDX.Tests.Elements3D
             var model = new MeshGeometryModel3D { Geometry = geometry };
 
             var canvas = new CanvasMock();
-            model.SceneNode.Attach(canvas.RenderHost);
+            model.SceneNode.Attach(canvas.RenderHost.EffectsManager);
 
             Assert.AreEqual(true, model.IsAttached);
         }


### PR DESCRIPTION
1. Change attach argument in scene node to `IEffectsManager` from `IRenderHost`. Allows multithreading scene node pre-attachment. Which means entire subset of scene graph can be generated and pre-attached in separate thread. However, UI thread should still being used for adding the new sub graph into main graph.

1. Use static arg object to avoid arg object allocations for common property changes in `Geometry3D`.