### PR TITLE
Fix for intersecting hit tests

### DIFF
--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionDemo.csproj
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/CrossSectionDemo.csproj
@@ -68,6 +68,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="CrossSectionPlaneManipulator3D.cs" />
+    <Compile Include="CustomViewport3DX.cs" />
     <Compile Include="MainViewModel.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/CustomViewport3DX.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/CustomViewport3DX.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Input;
+using HelixToolkit.Wpf.SharpDX;
+
+namespace CrossSectionDemo
+{
+    /// <summary>
+    /// Viewport which does hit test on mouse over
+    /// </summary>
+    public class CustomViewport3DX : Viewport3DX
+    {
+        /// <inheritdoc />
+        protected override void OnPreviewMouseMove(MouseEventArgs e)
+        {
+            if (e == null) throw new ArgumentNullException(nameof(e));
+            base.OnPreviewMouseMove(e);
+
+            // During startup the camera in the render context might be null while the camera in this class isn't.
+            // In that case don't do the hit test. The program is just starting anyway and the model at cursor won't be interesting yet.
+            if (RenderContext?.Camera != null)
+            {
+                IList<HitTestResult> hits = this.FindHits(e.GetPosition(this));
+                ModelAtCursor = hits.Count > 0 ? hits[0].ModelHit : null;
+            }
+            else
+            {
+                ModelAtCursor = null;
+            }
+        }
+
+        public static readonly DependencyProperty ModelAtCursorProperty = DependencyProperty.Register(
+            nameof(ModelAtCursor), typeof(object), typeof(CustomViewport3DX), new PropertyMetadata(default(object)));
+
+        /// <summary>
+        /// The model that the mouse hovers over
+        /// </summary>
+        public object ModelAtCursor
+        {
+            get => GetValue(ModelAtCursorProperty);
+            set => SetValue(ModelAtCursorProperty, value);
+        }
+    }
+}

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainViewModel.cs
@@ -157,8 +157,49 @@
         }
 
         private Vector3? constraintVector = new Vector3(0,1,0);
+        private object modelAtCursor;
 
         public Vector3? ConstraintVector { get => constraintVector; set => SetValue(ref constraintVector, value); }
+
+        public object ModelAtCursor
+        {
+            get => modelAtCursor;
+            set
+            {
+                if (modelAtCursor != value)
+                {
+                    modelAtCursor = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(NameOfModelAtCursor));
+                }
+            }
+        }
+
+
+        public string NameOfModelAtCursor
+        {
+            get
+            {
+                if (ModelAtCursor is GeometryModel3D geometry)
+                {
+                    if (geometry.Geometry == BoxModel)
+                        return nameof(BoxModel);
+                    if (geometry.Geometry == FloorModel)
+                        return nameof(FloorModel);
+                    if (geometry.Geometry == Model)
+                        return nameof(Model);
+                    if (geometry.Geometry == Plane1Model)
+                        return nameof(Plane1Model);
+                    if (geometry.Geometry == Plane2Model)
+                        return nameof(Plane2Model);
+                }
+
+                if (ModelAtCursor is AxisPlaneGridModel3D)
+                    return nameof(AxisPlaneGridModel3D);
+                return null;
+            }
+
+        }
     }
 
 }

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml
@@ -13,13 +13,14 @@
     <Grid Background="Black">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto"
+                              MinWidth="140"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <hx:Viewport3DX
+        <local:CustomViewport3DX
             x:Name="view1"
             Grid.Row="0"
             Grid.Column="0"
@@ -28,14 +29,16 @@
             Camera="{Binding Camera}"
             CameraRotationMode="Trackball"
             EffectsManager="{Binding EffectsManager}"
+            EnableCursorPosition="True"
             FixedRotationPoint="0,0,0"
             FixedRotationPointEnabled="True"
             MSAA="Disable"
             RotateAroundMouseDownPoint="False"
             SubTitle="{Binding SubTitle}"
             TextBrush="Black"
-            UseDefaultGestures="False">
-            <hx:Viewport3DX.InputBindings>
+            UseDefaultGestures="False"
+            ModelAtCursor="{Binding ModelAtCursor, Mode=TwoWay}">
+            <local:CustomViewport3DX.InputBindings>
                 <KeyBinding Key="B" Command="hx:ViewportCommands.BackView" />
                 <KeyBinding Key="F" Command="hx:ViewportCommands.FrontView" />
                 <KeyBinding Key="U" Command="hx:ViewportCommands.TopView" />
@@ -45,7 +48,7 @@
                 <KeyBinding Command="hx:ViewportCommands.ZoomExtents" Gesture="Control+E" />
                 <MouseBinding Command="hx:ViewportCommands.Rotate" Gesture="LeftClick" />
                 <MouseBinding Command="hx:ViewportCommands.Zoom" Gesture="MiddleClick" />
-            </hx:Viewport3DX.InputBindings>
+            </local:CustomViewport3DX.InputBindings>
             <hx:DirectionalLight3D Direction="{Binding Camera.LookDirection}" Color="White" />
             <hx:CrossSectionMeshGeometryModel3D
                 x:Name="crossModel"
@@ -60,8 +63,7 @@
                 Material="{Binding ModelMaterial}"
                 Plane1="{Binding Plane1}"
                 Plane2="{Binding Plane2}"
-                Transform="{Binding ModelTransform}" 
-                Mouse3DDown="geometry_Mouse3DDown" 
+                Transform="{Binding ModelTransform}"
                 />
             <hx:CrossSectionMeshGeometryModel3D
                 x:Name="crossModel2"
@@ -75,8 +77,7 @@
                 IsHitTestVisible="True"
                 Material="{Binding ModelMaterial}"
                 Plane1="{Binding Plane1}"
-                Plane2="{Binding Plane2}"
-                Mouse3DDown="geometry_Mouse3DDown" />
+                Plane2="{Binding Plane2}" />
             <local:CrossSectionPlaneManipulator3D
                 CornerScale="4"
                 CutPlane="{Binding Plane1, Mode=TwoWay}"
@@ -92,7 +93,7 @@
                 SizeScale="10" />
             <hx:AxisPlaneGridModel3D />
            
-        </hx:Viewport3DX>
+        </local:CustomViewport3DX>
         <StackPanel
             Grid.Column="1"
             HorizontalAlignment="Right"
@@ -118,6 +119,9 @@
                 <ComboBoxItem>Intersect</ComboBoxItem>
                 <ComboBoxItem>Substract</ComboBoxItem>
             </ComboBox>
+            <Label Foreground="White"
+
+                Content="{Binding NameOfModelAtCursor}"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WPF.SharpDX/CrossSectionDemo/MainWindow.xaml.cs
@@ -1,17 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace CrossSectionDemo
 {
@@ -30,11 +18,6 @@ namespace CrossSectionDemo
                     (DataContext as IDisposable).Dispose();
                 }
             };
-        }
-
-        private void geometry_Mouse3DDown(object sender, HelixToolkit.Wpf.SharpDX.MouseDown3DEventArgs e)
-        {
-
         }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/CrossSectionMeshNode.cs
@@ -436,14 +436,18 @@ namespace HelixToolkit.UWP
             private static bool RemoveHitPointBehindCrossingPlane(Plane plane, List<HitTestResult> hits, int hitsBeforeCheck)
             {
                 // Loop backwards to remove at end of list when possible
-                for (var i = hits.Count - 1; i >= hitsBeforeCheck; i--)
+                for (int i = hits.Count - 1; i >= hitsBeforeCheck; i--)
                 {
-                    if (hits[i].PointHit.PointToPlanePosition(ref plane) == PlaneIntersectionType.Back)
+                    var pointTimesNormal = (hits[i].PointHit * plane.Normal);
+                    float distanceToPlane = pointTimesNormal.X + pointTimesNormal.Y + pointTimesNormal.Z - plane.D;
+                    if (distanceToPlane < 0)
                     {
                         hits.RemoveAt(i);
                     }
                 }
-                return hits.Count > hitsBeforeCheck;
+                if (hits.Count == hitsBeforeCheck)
+                    return false;
+                return true;
             }
 
             private bool RemoveHitPointInFrontOfAllCrossingPlanes(List<HitTestResult> hits, int hitsBeforeCheck)


### PR DESCRIPTION
Between version 2.12.0 and 2.13.0 the hit test with `CrossSectionMeshGeometryModel3D` stopped working. This can be seen in the CrossSectionDemo in this pull request. In 2.12.0 hit tests are only returned for visible elements, in later versions hit tests for invisible versions are still returned.

In version 2.13.0 and later, the mouse cursor hovering over the ground but in the top right corner a hit for the invisible box model is still found
![image with the mouse cursor hovering over the ground but in the top right corner a hit for the invisible box model is still found](https://user-images.githubusercontent.com/9482927/183852969-d57b324c-ebe2-41c9-ad79-eafc8db9729e.png)

With code from version 2.12.0 and the mouse cursor over the car (with the box model hidden) and in the top right corner the hit test now the correct model.
![The mouse cursor over the car (with the box model hidden) and in the top right corner the hit test now the correct model](https://user-images.githubusercontent.com/9482927/183853704-dd5a5f8f-4789-4a12-9a66-7113f8d1af89.png)

The most likely cause of this error is that the Plane in SharpDX isn't properly defined (see [SharpDX #551](https://github.com/sharpdx/SharpDX/issues/551)). D will get different signs depending on how you create the plane. The implementation in this pull request follows the same sign convention as the shader that hides part of the model and will hence give results consistent with what's seen on the screen.

Note that this merge request doesn't fix problems when subtracting instead of intersecting.