### PR TITLE
Fix null reference exception in GeometryRenderCore.OnAttachBuffers()

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Core/Abstract/GeometryRenderCore.cs
@@ -193,7 +193,8 @@ namespace HelixToolkit.UWP
             /// <param name="vertStartSlot"></param>
             protected virtual bool OnAttachBuffers(DeviceContextProxy context, ref int vertStartSlot)
             {
-                if (GeometryBuffer.AttachBuffers(context, ref vertStartSlot, EffectTechnique.EffectsManager))
+                if (GeometryBuffer != null && EffectTechnique != null &&
+                    GeometryBuffer.AttachBuffers(context, ref vertStartSlot, EffectTechnique.EffectsManager))
                 {
                     InstanceBuffer.AttachBuffer(context, ref vertStartSlot);
                     return true;


### PR DESCRIPTION
This pull request fixes a null reference exception I suddenly got in parts of the program. Not sure if this really solves the problem, but it stops the crash at least.