### PR TITLE
Correct y axis color typo

### DIFF
--- a/Source/HelixToolkit.SharpDX.SharedModel/Element3D/CoordinateSystemModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Element3D/CoordinateSystemModel3D.cs
@@ -61,7 +61,7 @@ namespace HelixToolkit.Wpf.SharpDX
 #endif          
                 (d, e) =>
                 {
-                    ((d as Element3DCore).SceneNode as CoordinateSystemNode).AxisXColor = ((Media.Color)e.NewValue).ToColor4();
+                    ((d as Element3DCore).SceneNode as CoordinateSystemNode).AxisYColor = ((Media.Color)e.NewValue).ToColor4();
                 }));
         /// <summary>
         /// <see cref="AxisZColor"/>


### PR DESCRIPTION
Minor bug in which y axis color of the coordinate system can not be changed