### PR TITLE
make repeat mode (PlayOnce) of animation works right

### DIFF
--- a/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
+++ b/Source/Examples/WPF.SharpDX/BoneSkinDemo/MainViewModel.cs
@@ -88,6 +88,7 @@ namespace BoneSkinDemo
                     reset = true;
                     var curr = scene.Animations.Where(x => x.Name == value).FirstOrDefault();
                     animationUpdater = new NodeAnimationUpdater(curr);
+                    animationUpdater.RepeatMode = selectedRepeatMode;
                 }
             }
             get { return selectedAnimation; }
@@ -101,6 +102,7 @@ namespace BoneSkinDemo
                 if(SetValue(ref selectedRepeatMode, value))
                 {
                     reset = true;
+                    if (animationUpdater != null) animationUpdater.RepeatMode = value;
                 }
             }
             get { return selectedRepeatMode; }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Animations/NodeAnimationUpdater.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Animations/NodeAnimationUpdater.cs
@@ -79,6 +79,7 @@ namespace HelixToolkit.UWP
                     {
                         case AnimationRepeatMode.PlayOnce:
                             UpdateBoneSkinMesh();
+                            isStartFrame = false;
                             SetToStart();
                             return;
                         case AnimationRepeatMode.PlayOnceHold:


### PR DESCRIPTION
When the repeat mode of animation is PlayOne, the animation will not go back to the first frame. This modification fixed this bug, and make the PlayOnce worked right, and also fix the problem in BoneSkinDemo