### PR TITLE
Fix light camera property change does not trigger re-render in shadow map.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
@@ -155,12 +155,15 @@ namespace HelixToolkit.UWP
             {
                 set
                 {
-                    if(lightCamera != null)
+                    if (lightCamera != null)
                     {
                         lightCamera.PropertyChanged -= LightCamera_PropertyChanged;
                     }
                     SetAffectsRender(ref lightCamera, value);
-                    lightCamera.PropertyChanged += LightCamera_PropertyChanged;
+                    if (lightCamera != null)
+                    {
+                        lightCamera.PropertyChanged += LightCamera_PropertyChanged;
+                    }
                 }
                 get => lightCamera;
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Scene/Lights/ShadowMapNode.cs
@@ -146,13 +146,25 @@ namespace HelixToolkit.UWP
                     return nearField;
                 }
             }
+
+            private ProjectionCameraCore lightCamera = null;
             /// <summary>
             /// Distance of the directional light from origin
             /// </summary>
             public ProjectionCameraCore LightCamera
             {
-                set; get;
-            } = null;
+                set
+                {
+                    if(lightCamera != null)
+                    {
+                        lightCamera.PropertyChanged -= LightCamera_PropertyChanged;
+                    }
+                    SetAffectsRender(ref lightCamera, value);
+                    lightCamera.PropertyChanged += LightCamera_PropertyChanged;
+                }
+                get => lightCamera;
+            }
+
             /// <summary>
             /// Gets or sets a value indicating whether shadow map should automatically cover complete scene. Only effective with directional light.
             /// <para>Limitation: Currently unable to properly cover BoneSkinned model animation.</para>
@@ -219,6 +231,11 @@ namespace HelixToolkit.UWP
                 c.Bias = (float)Bias;
                 c.Width = (int)(Resolution.Width);
                 c.Height = (int)(Resolution.Height);
+            }
+
+            private void LightCamera_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+            {
+                InvalidateRender();
             }
 
             /// <summary>


### PR DESCRIPTION
Fix light camera property change does not trigger re-render in shadow map. Ref #1839