### PR TITLE
Move ViewportCore into sharpdx shared project.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
+++ b/Source/HelixToolkit.SharpDX.Shared/HelixToolkit.SharpDX.Shared.projitems
@@ -202,6 +202,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Render\RenderHost\DX11RenderHostConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\DepthStencilFormatHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\StringHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Viewport\ViewportCore.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Viewport\ViewportCoreProperties.cs" />
     <Compile Include="..\HelixToolkit.SharpDX.Shared\ShaderManager\StructArrayPool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShaderManager\MaterialVariablePool.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShaderManager\TextureResourceManager.cs" />

--- a/Source/HelixToolkit.SharpDX.Shared/Model/Camera/Camera.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Model/Camera/Camera.cs
@@ -124,7 +124,7 @@ namespace HelixToolkit.UWP
                             target.Z);
             }
 
-#if CORE
+
             private Vector3 targetPosition;
             private Vector3 targetLookDirection;
             private Vector3 targetUpDirection;
@@ -212,7 +212,6 @@ namespace HelixToolkit.UWP
             {
                 aniTime = 0;
             }
-#endif
         }
 
         public abstract class ProjectionCameraCore : CameraCore

--- a/Source/HelixToolkit.SharpDX.Shared/Viewport/ViewportCore.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Viewport/ViewportCore.cs
@@ -5,7 +5,15 @@ Copyright (c) 2018 Helix Toolkit contributors
 using global::SharpDX;
 using System;
 
-namespace HelixToolkit.SharpDX.Core.Controls
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
 {
     using Cameras;
     using Model.Scene;

--- a/Source/HelixToolkit.SharpDX.Shared/Viewport/ViewportCoreProperties.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Viewport/ViewportCoreProperties.cs
@@ -2,7 +2,15 @@
 using System.Collections.Generic;
 using SharpDX;
 
-namespace HelixToolkit.SharpDX.Core.Controls
+#if !NETFX_CORE
+namespace HelixToolkit.Wpf.SharpDX
+#else
+#if CORE
+namespace HelixToolkit.SharpDX.Core
+#else
+namespace HelixToolkit.UWP
+#endif
+#endif
 {
     using Model.Scene;
     using Model.Scene2D;

--- a/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DX.cs
@@ -57,7 +57,7 @@ namespace HelixToolkit.UWP
     /// Renders the contained 3-D content within the 2-D layout bounds of the Viewport3DX element.
     /// </summary>
     [ContentProperty(Name = "Items")]
-    [TemplatePart(Name = ViewportPartNames.PART_RenderTarget, Type =typeof(SwapChainRenderHost))]
+    [TemplatePart(Name = ViewportPartNames.PART_RenderTarget, Type =typeof(HelixToolkitRenderPanel))]
     [TemplatePart(Name = ViewportPartNames.PART_CoordinateGroup, Type = typeof(ItemsControl))]
     [TemplatePart(Name = ViewportPartNames.PART_HostPresenter, Type =typeof(ContentPresenter))]
     [TemplatePart(Name = ViewportPartNames.PART_ItemsContainer, Type = typeof(ItemsControl))]
@@ -258,7 +258,7 @@ namespace HelixToolkit.UWP
         private void Viewport3DX_DpiChanged(DisplayInformation sender, object args)
         {
             var dpi = sender.RawPixelsPerViewPixel;
-            if (hostPresenter != null && hostPresenter.Content is SwapChainRenderHost host)
+            if (hostPresenter != null && hostPresenter.Content is HelixToolkitRenderPanel host)
             {
                 host.DpiScale = (float)dpi;
             }
@@ -369,7 +369,7 @@ namespace HelixToolkit.UWP
             hostPresenter = GetTemplateChild(ViewportPartNames.PART_HostPresenter) as ContentPresenter;
             if (hostPresenter != null)
             {
-                var host = new SwapChainRenderHost(EnableDeferredRendering);
+                var host = new HelixToolkitRenderPanel(EnableDeferredRendering);
                 hostPresenter.Content = host;
 #if WINDOWS_UWP
                 var view = DisplayInformation.GetForCurrentView();
@@ -379,7 +379,7 @@ namespace HelixToolkit.UWP
 #endif
                 host.DpiScale = (float)dpi;
                 host.EnableDpiScale = EnableDpiScale;
-                renderHostInternal = (hostPresenter.Content as SwapChainRenderHost).RenderHost;
+                renderHostInternal = (hostPresenter.Content as HelixToolkitRenderPanel).RenderHost;
                 if (renderHostInternal != null)
                 {
                     renderHostInternal.RenderConfiguration.RenderD2D = false;

--- a/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DXProperties.cs
+++ b/Source/HelixToolkit.UWP.Shared/Controls/Viewport3DXProperties.cs
@@ -2517,7 +2517,7 @@ namespace HelixToolkit.UWP
             DependencyProperty.Register("EnableDpiScale", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e)=> 
             {
                 var viewport = (d as Viewport3DX);
-                if (viewport.hostPresenter != null && viewport.hostPresenter.Content is SwapChainRenderHost host)
+                if (viewport.hostPresenter != null && viewport.hostPresenter.Content is HelixToolkitRenderPanel host)
                 {
                     host.EnableDpiScale = (bool)e.NewValue;
                 }

--- a/Source/HelixToolkit.UWP/CommonDX/HelixToolkitRenderPanel.cs
+++ b/Source/HelixToolkit.UWP/CommonDX/HelixToolkitRenderPanel.cs
@@ -17,7 +17,7 @@ namespace HelixToolkit.UWP
     using Windows.UI.Popups;
     using Windows.UI.Xaml;
 
-    public class SwapChainRenderHost : SwapChainPanel
+    public class HelixToolkitRenderPanel : SwapChainPanel
     {       
         /// <summary>
         /// Fired whenever an exception occurred on this object.
@@ -57,7 +57,7 @@ namespace HelixToolkit.UWP
             get => enableDpiScale;
         }
 
-        public SwapChainRenderHost(bool enableDeferredRendering)
+        public HelixToolkitRenderPanel(bool enableDeferredRendering)
         {   
             if (enableDeferredRendering)
             {

--- a/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
+++ b/Source/HelixToolkit.UWP/HelixToolkit.UWP.csproj
@@ -137,7 +137,7 @@
   <ItemGroup>
     <Compile Include="CommonDX\CompositionTargetEx.cs" />
     <Compile Include="CommonDX\SwapChainCompositionRenderHost.cs" />
-    <Compile Include="CommonDX\SwapChainRenderHost.cs" />
+    <Compile Include="CommonDX\HelixToolkitRenderPanel.cs" />
     <Compile Include="Properties\AssemblyDescription.cs" />
     <EmbeddedResource Include="Properties\HelixToolkit.UWP.rd.xml" />
   </ItemGroup>

--- a/Source/HelixToolkit.WinUI/CommonDX/HelixToolkitRenderPanel.cs
+++ b/Source/HelixToolkit.WinUI/CommonDX/HelixToolkitRenderPanel.cs
@@ -20,7 +20,7 @@ namespace HelixToolkit.WinUI
     using HelixToolkit.SharpDX.Core;
 
     // https://github.com/RolandKoenig/SeeingSharp2/blob/dae33fd85f38a781a348155aa1ee07ce1f170152/SeeingSharp.WinUI/Multimedia/Views/SeeingSharpPanelPainter.cs
-    public class SwapChainRenderHost : SwapChainPanel
+    public class HelixToolkitRenderPanel : SwapChainPanel
     {       
         /// <summary>
         /// Fired whenever an exception occurred on this object.
@@ -63,7 +63,7 @@ namespace HelixToolkit.WinUI
             get => enableDpiScale;
         }
 
-        public SwapChainRenderHost(bool enableDeferredRendering)
+        public HelixToolkitRenderPanel(bool enableDeferredRendering)
         {
             if (enableDeferredRendering)
             {


### PR DESCRIPTION
Move ViewportCore into sharpdx shared project, so both SharpDX.Wpf and UWP projects are able to do offscreen rendering easier. Ref #1845