### PR TITLE
Adding `IncreaseSwapchainFPS` property for sharpdx wpf viewport.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderBuffers/DX11RenderBufferBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderBuffers/DX11RenderBufferBase.cs
@@ -225,10 +225,10 @@ namespace HelixToolkit.UWP
             } = MSAALevel.Disable;
 #endif
             /// <summary>
-            /// The vertical synchronize internal. Only valid under swapchain rendering mode. Default = 1
+            /// The vertical synchronize internal. Only valid under swapchain rendering mode. Default = 0
             /// <para>0: disable; 1: Sync with frame; More detail: <see cref="SwapChain.Present(int, PresentFlags)"/></para>
             /// </summary>
-            public int VSyncInterval = 1;
+            public int VSyncInterval = 0;
             /// <summary>
             /// The currently used Direct3D Device
             /// </summary>

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFSurfaceSwapChain.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/DPFSurfaceSwapChain.cs
@@ -88,6 +88,11 @@ namespace HelixToolkit.Wpf.SharpDX
             get => enableDpiScale;
         }
 
+        public bool IncreaseFPS
+        {
+            set; get;
+        } = true;
+
         public double DpiScale { set => winformHost.DpiScale = value; get => winformHost.DpiScale; }
 
         public DPFSurfaceSwapChain(bool deferredRendering = false, bool attachedToWindow = true)
@@ -236,7 +241,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private void CompositionTarget_Rendering(object sender, RenderingEventArgs e)
         {
-            if (RenderHost.UpdateAndRender())
+            if (RenderHost.UpdateAndRender() && IncreaseFPS)
             {
                 image3D?.InvalidateD3DImage();
             }
@@ -392,7 +397,7 @@ namespace HelixToolkit.Wpf.SharpDX
                 {
                     Windowed = true,
                     SwapEffect = SwapEffect.Discard,
-                    PresentationInterval = PresentInterval.Immediate,
+                    PresentationInterval = PresentInterval.Default,
                     BackBufferHeight = 1,
                     BackBufferWidth = 1,
                     BackBufferFormat = Format.Unknown

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
@@ -1336,6 +1336,15 @@ namespace HelixToolkit.Wpf.SharpDX
                 }
             }));
 
+        public static readonly DependencyProperty IncreaseSwapchainFPSProperty =
+            DependencyProperty.Register("IncreaseSwapchainFPS", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) => {
+                var viewport = d as Viewport3DX;
+                if (viewport.hostPresenter != null && viewport.hostPresenter.Content is DPFSurfaceSwapChain surface)
+                {
+                    surface.IncreaseFPS = (bool)e.NewValue;
+                }
+            }));
+
         /// <summary>
         /// Background Color
         /// </summary>
@@ -3542,6 +3551,17 @@ namespace HelixToolkit.Wpf.SharpDX
             {
                 SetValue(EnableDpiScaleProperty, value);
             }
+        }
+
+        /// <summary>
+        /// Increase swapchain fps by speed up the wpf composition target frame rate.
+        /// This may negatively impact the performance on low end graphics card.
+        /// Default is enabled.
+        /// </summary>
+        public bool IncreaseSwapchainFPS
+        {
+            get { return (bool)GetValue(IncreaseSwapchainFPSProperty); }
+            set { SetValue(IncreaseSwapchainFPSProperty, value); }
         }
     }
 }


### PR DESCRIPTION
Ref: #1867
1. Adding `IncreaseSwapchainFPS` property for  `Helixtoolkit.SharpDX.Wpf` viewport.
2. Disable swapchain vsync in `Helixtoolkit.SharpDX.Wpf` by default to avoid shuttering.
