### PR TITLE
Add EnableParallelUpdate property

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.Properties.cs
@@ -19,7 +19,7 @@ namespace HelixToolkit.Wpf.SharpDX
 {
     using Controls;
     using Elements2D;
-
+    using HelixToolkit.Wpf.SharpDX.Render;
 
     /// <summary>
     /// Provides the dependency properties for Viewport3DX.
@@ -1233,6 +1233,18 @@ namespace HelixToolkit.Wpf.SharpDX
                         viewport.renderHostInternal.InvalidatePerFrameRenderables();
                     }
                 }));
+
+        /// <summary>
+        /// The enable parallel update property. <see cref="EnableParallelUpdate"/>
+        /// </summary>
+        public static readonly DependencyProperty EnableParallelUpdateProperty =
+            DependencyProperty.Register("EnableParallelUpdate", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(true, (d, e) => {
+                var viewport = d as Viewport3DX;
+                if (viewport.renderHostInternal != null && viewport.renderHostInternal is DefaultRenderHost renderHost)
+                {
+                    renderHost.EnableParallelUpdate = (bool)e.NewValue;
+                }
+            }));
 
         /// <summary>
         /// The enable ssao property
@@ -3367,6 +3379,17 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
+        /// <summary>
+        /// Enable some tasks in the render loop to be run parallel on separate threads.
+        /// This may cause the ui to be unresponsive if there are already parallel tasks running
+        /// causing the updates to wait until there are avaliable threads to execute the updates.
+        /// Default is enabled.
+        /// </summary>
+        public bool EnableParallelUpdate
+        {
+            get { return (bool)GetValue(EnableParallelUpdateProperty); }
+            set { SetValue(EnableParallelUpdateProperty, value); }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether [enable ScreenSpaced Ambient Occlusion].


### PR DESCRIPTION
I noticed when running parallel tasks in my program that the user interface becomes less responsive and the 3d viewer might stutter a bit. I've located it to be because or the .Wait for tasks in the renderloop. Since all threads are busy doing computational work, there are no available threads to do the tasks requested by Helix.

As you can see from the dotTrace screenshot below, from the 12 seconds that are used to UpdateAndRender. 11 seconds are used to Wait for the tasks to complete. 

![image](https://user-images.githubusercontent.com/7237827/216349212-6a46341f-5fa8-4789-b226-75e68e8f25b2.png)

I've added an EnableParallelUpdate property that can be set to false to do all the updates on the main thread. 

If you want to test this out, you can check out my branch, where I have updated the CustomShaderDemo with an example.