### PR TITLE
fix the difference size of ZoomExtends of Viewport3DX between camera

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/CameraExtensions.cs
@@ -574,9 +574,9 @@ namespace HelixToolkit.Wpf.SharpDX
             // var target = Camera.Position + Camera.LookDirection;
             if (camera is IPerspectiveCameraModel pcam)
             {
-                var disth = radius / Math.Tan(0.5 * pcam.FieldOfView * Math.PI / 180);
+                var disth = radius / Math.Tan(0.75 * pcam.FieldOfView * Math.PI / 180);
                 var vfov = pcam.FieldOfView / viewport.ActualWidth * viewport.ActualHeight;
-                var distv = radius / Math.Tan(0.5 * vfov * Math.PI / 180);
+                var distv = radius / Math.Tan(0.75 * vfov * Math.PI / 180);
 
                 var dist = Math.Max(disth, distv);
                 var dir = camera.LookDirection;


### PR DESCRIPTION
For the ZoomExtends function of Viewport3DX, the size of scene is different between two types of camera. For PerspectiveCamera, the size is about 1/3 of the viewport, but for OrthographicCamera the size is about 1/2 of the viewport. So I change the function to achieve that the sizes are almost the same.