### PR TITLE
Fix WINUI package crash after disposing Viewport3DX.

### DIFF
--- a/Source/HelixToolkit.WinUI/CommonDX/HelixToolkitRenderPanel.cs
+++ b/Source/HelixToolkit.WinUI/CommonDX/HelixToolkitRenderPanel.cs
@@ -124,7 +124,6 @@ namespace HelixToolkit.WinUI
             if (panelNativeDesktop != null)
             {
                 panelNativeDesktop.SetSwapChain(IntPtr.Zero);
-                panelNativeDesktop.Release();
                 panelNativeDesktop = null;
             }
         }


### PR DESCRIPTION
Fix WINUI package crash after disposing Viewport3DX. Ref #1925