### PR TITLE
Simplify children disposal. Avoid needing to call dispose to release event handler.

### DIFF
--- a/Source/HelixToolkit.UWP.Shared/Model/Element3D/Abstract/GroupElement3D.cs
+++ b/Source/HelixToolkit.UWP.Shared/Model/Element3D/Abstract/GroupElement3D.cs
@@ -39,7 +39,10 @@ namespace HelixToolkit.UWP
                 new PropertyMetadata(null,
                     (d, e) =>
                     {
-                        (d as GroupElement3D).OnItemsSourceChanged(e.NewValue as IList<Element3D>);
+                        if (d is GroupElement3D g && g.IsAttached)
+                        {
+                            g.OnItemsSourceChanged(e.NewValue as IList<Element3D>);
+                        }
                     }));
 
         /// <summary>
@@ -134,6 +137,24 @@ namespace HelixToolkit.UWP
         public GroupElement3D()
         {
             Children.CollectionChanged += Items_CollectionChanged;
+            SceneNode.Attached += SceneNode_Attached;
+            SceneNode.Detached += SceneNode_Detached;
+        }
+
+        private void SceneNode_Attached(object sender, EventArgs e)
+        {
+            if (ItemsSource != null)
+            {
+                OnItemsSourceChanged(ItemsSource);
+            }
+        }
+
+        private void SceneNode_Detached(object sender, EventArgs e)
+        {
+            if (itemsSourceInternal != null)
+            {
+                OnItemsSourceChanged(null);
+            }
         }
 
         protected override void OnApplyTemplate()
@@ -229,10 +250,6 @@ namespace HelixToolkit.UWP
                 {
                     s.CollectionChanged -= S_CollectionChanged;
                 }
-                foreach (var child in itemsSourceInternal)
-                {
-                    Children.Remove(child);
-                }
             }
             if (itemsSourceInternal == null && itemsSource != null && Children.Count > 0)
             {
@@ -287,29 +304,6 @@ namespace HelixToolkit.UWP
                     Children.Move(e.OldStartingIndex, e.NewStartingIndex);
                     break;
             }
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (itemsSourceInternal is INotifyCollectionChanged s)
-                {
-                    s.CollectionChanged -= S_CollectionChanged;
-                }
-                if (itemsSourceInternal != null)
-                {
-                    foreach (var item in itemsSourceInternal)
-                    {
-                        item.Dispose();
-                    }
-                }
-                foreach (var child in Children)
-                {
-                    child.Dispose();
-                }
-            }
-            base.Dispose(disposing);
         }
     }
 }

--- a/Source/HelixToolkit.UWP.Shared/Model/Element3D/Abstract/GroupElement3D.cs
+++ b/Source/HelixToolkit.UWP.Shared/Model/Element3D/Abstract/GroupElement3D.cs
@@ -244,6 +244,8 @@ namespace HelixToolkit.UWP
 
         private void OnItemsSourceChanged(IList<Element3D> itemsSource)
         {
+            if (itemsSourceInternal == itemsSource)
+            { return; }
             if (itemsSourceInternal != null)
             {
                 if (itemsSourceInternal is INotifyCollectionChanged s)

--- a/Source/HelixToolkit.UWP.Shared/Model/Element3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.UWP.Shared/Model/Element3D/ItemsModel3D.cs
@@ -27,7 +27,10 @@ namespace HelixToolkit.UWP
             DependencyProperty.Register("ItemsSource", typeof(IEnumerable), typeof(ItemsModel3D),
                 new PropertyMetadata(null,
                     (d, e) => {
-                        (d as ItemsModel3D).OnItemsSourceChanged(e);
+                        if (d is ItemsModel3D itemsModel && itemsModel.IsAttached)
+                        {
+                            itemsModel.OnItemsSourceChanged(e.NewValue as IEnumerable);
+                        }
                     }));
 
         /// <summary>
@@ -143,7 +146,7 @@ namespace HelixToolkit.UWP
         } = new ObservableElement3DCollection();
 
         private readonly ItemsControl itemsControl = new ItemsControl();
-        private IEnumerable itemsSource = null;
+        private IEnumerable itemsSourceInternal = null;
 
         public ItemCollection Items => itemsControl.Items;
 
@@ -153,8 +156,25 @@ namespace HelixToolkit.UWP
         /// </summary>
         public ItemsModel3D()
         {
-            Children.CollectionChanged += Items_CollectionChanged;            
-        }      
+            Children.CollectionChanged += Items_CollectionChanged;
+            SceneNode.Attached += SceneNode_Attached;
+            SceneNode.Detached += SceneNode_Detached;
+        }
+        private void SceneNode_Attached(object sender, EventArgs e)
+        {
+            if (ItemsSource != null)
+            {
+                OnItemsSourceChanged(ItemsSource);
+            }
+        }
+
+        private void SceneNode_Detached(object sender, EventArgs e)
+        {
+            if (itemsSourceInternal != null)
+            {
+                OnItemsSourceChanged(null);
+            }
+        }
 
         protected override void OnApplyTemplate()
         {
@@ -236,32 +256,35 @@ namespace HelixToolkit.UWP
             }
         }
 
-        private void OnItemsSourceChanged(DependencyPropertyChangedEventArgs e)
+        private void OnItemsSourceChanged(IEnumerable itemsSource)
         {
-            if (e.OldValue is INotifyCollectionChanged o)
+            if (itemsSourceInternal is INotifyCollectionChanged o)
             {
                 o.CollectionChanged -= ItemsModel3D_CollectionChanged;
             }
-            itemsSource = null;
+            itemsSourceInternal = null;
             foreach (Element3D item in Children)
             {
                 item.DataContext = null;
             }
-
+            if (itemsSourceInternal == null && itemsSource != null && Children.Count > 0)
+            {
+                throw new InvalidOperationException("Children must be empty before using ItemsSource");
+            }
             Clear();
+            itemsSourceInternal = itemsSource;
+            if (itemsSource == null)
+            {
+                return;
+            }
 
-            if (e.NewValue is INotifyCollectionChanged n)
+            if (itemsSource is INotifyCollectionChanged n)
             {
                 n.CollectionChanged -= ItemsModel3D_CollectionChanged;
                 n.CollectionChanged += ItemsModel3D_CollectionChanged;
             }
 
-            if (ItemsSource == null)
-            {
-                return;
-            }
-            itemsSource = ItemsSource;
-            AddItems(ItemsSource);
+            AddItems(itemsSource);
 
             if (Children.Count > 0)
             {
@@ -388,23 +411,6 @@ namespace HelixToolkit.UWP
             var node = SceneNode as GroupNode;
             node.Clear();
             Children.Clear();
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (itemsSource is INotifyCollectionChanged n)
-                {
-                    n.CollectionChanged -= ItemsModel3D_CollectionChanged;
-                }
-                foreach (var item in elementDict)
-                {
-                    item.Value?.Dispose();
-                }
-                Clear();
-            }
-            base.Dispose(disposing);
         }
     }
 }

--- a/Source/HelixToolkit.UWP.Shared/Model/Element3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.UWP.Shared/Model/Element3D/ItemsModel3D.cs
@@ -258,11 +258,12 @@ namespace HelixToolkit.UWP
 
         private void OnItemsSourceChanged(IEnumerable itemsSource)
         {
+            if (itemsSourceInternal == itemsSource)
+            { return; }
             if (itemsSourceInternal is INotifyCollectionChanged o)
             {
                 o.CollectionChanged -= ItemsModel3D_CollectionChanged;
             }
-            itemsSourceInternal = null;
             foreach (Element3D item in Children)
             {
                 item.DataContext = null;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -30,11 +30,14 @@ namespace HelixToolkit.Wpf.SharpDX
         /// ItemsSource for binding to collection. Please use ObservableElement3DCollection for observable, otherwise may cause memory leak.
         /// </summary>
         public static readonly DependencyProperty ItemsSourceProperty =
-            DependencyProperty.Register("ItemsSource", typeof(IList<Element3D>), typeof(GroupElement3D),
+            DependencyProperty.Register("ItemsSource", typeof(IEnumerable<Element3D>), typeof(GroupElement3D),
                 new PropertyMetadata(null,
                     (d, e) =>
                     {
-                        (d as GroupElement3D).OnItemsSourceChanged(e.NewValue as IList<Element3D>);
+                        if (d is GroupElement3D group && group.IsAttached)
+                        {
+                            group.OnItemsSourceChanged(e.NewValue as IEnumerable<Element3D>);
+                        }
                     }));
 
         /// <summary>
@@ -117,7 +120,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        private IList<Element3D> itemsSourceInternal;
+        private IEnumerable<Element3D> itemsSourceInternal;
         /// <summary>
         /// Gets the children.
         /// </summary>
@@ -134,8 +137,26 @@ namespace HelixToolkit.Wpf.SharpDX
         /// </summary>
         public GroupElement3D()
         {
-            Children.CollectionChanged += Items_CollectionChanged;
             Loaded += GroupElement3D_Loaded;
+            Children.CollectionChanged += Items_CollectionChanged;
+            SceneNode.Attached += SceneNode_Attached;
+            SceneNode.Detached += SceneNode_Detached;
+        }
+
+        private void SceneNode_Attached(object sender, EventArgs e)
+        {          
+            if (ItemsSource != null)
+            {
+                OnItemsSourceChanged(ItemsSource);
+            }
+        }
+
+        private void SceneNode_Detached(object sender, EventArgs e)
+        {
+            if (itemsSourceInternal != null)
+            {
+                OnItemsSourceChanged(null);
+            }
         }
 
         private void GroupElement3D_Loaded(object sender, RoutedEventArgs e)
@@ -227,7 +248,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
         }
 
-        private void OnItemsSourceChanged(IList<Element3D> itemsSource)
+        private void OnItemsSourceChanged(IEnumerable<Element3D> itemsSource)
         {
             if (itemsSourceInternal != null)
             {
@@ -290,29 +311,6 @@ namespace HelixToolkit.Wpf.SharpDX
                     Children.Move(e.OldStartingIndex, e.NewStartingIndex);
                     break;
             }
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (itemsSourceInternal is INotifyCollectionChanged s)
-                {
-                    s.CollectionChanged -= S_CollectionChanged;
-                }
-                if (itemsSourceInternal != null)
-                {
-                    foreach (var item in itemsSourceInternal)
-                    {
-                        item.Dispose();
-                    }
-                }
-                foreach (var child in Children)
-                {
-                    child.Dispose();
-                }
-            }
-            base.Dispose(disposing);
         }
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/AbstractElements3D/GroupElement3D.cs
@@ -250,6 +250,8 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private void OnItemsSourceChanged(IEnumerable<Element3D> itemsSource)
         {
+            if (itemsSourceInternal == itemsSource) 
+            { return; }
             if (itemsSourceInternal != null)
             {
                 if (itemsSourceInternal is INotifyCollectionChanged s)

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/ItemsModel3D.cs
@@ -156,6 +156,8 @@ namespace HelixToolkit.Wpf.SharpDX
 
         private void ItemsSourceChanged(IEnumerable itemsSource)
         {
+            if (itemsSourceInternal == itemsSource)
+            { return; }
             if (itemsSourceInternal is INotifyCollectionChanged o)
             {
                 o.CollectionChanged -= ItemsModel3D_CollectionChanged;

--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/ItemsModel3D.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Model/Elements3D/ItemsModel3D.cs
@@ -45,7 +45,13 @@ namespace HelixToolkit.Wpf.SharpDX
             "ItemsSource",
             typeof(IEnumerable),
             typeof(ItemsModel3D),
-            new PropertyMetadata(null, (s, e) => ((ItemsModel3D)s).ItemsSourceChanged(e)));
+            new PropertyMetadata(null, (s, e) =>
+            {
+                if (s is ItemsModel3D itemsModel && itemsModel.IsAttached)
+                {
+                    itemsModel.ItemsSourceChanged(e.NewValue as IEnumerable);
+                }
+            }));
 
         /// <summary>
         /// Add octree manager to use octree hit test.
@@ -124,23 +130,37 @@ namespace HelixToolkit.Wpf.SharpDX
         }
 
         private readonly Dictionary<object, Element3D> elementDict = new Dictionary<object, Element3D>();
+        private IEnumerable itemsSourceInternal;
 
-        /// <summary>
-        /// Handles changes in the ItemsSource property.
-        /// </summary>
-        /// <param name="e">
-        /// The <see cref="DependencyPropertyChangedEventArgs"/> instance containing the event data.
-        /// </param>
-        /// <exception cref="System.InvalidOperationException">
-        /// Cannot create a Model3D from ItemTemplate.
-        /// </exception>
-        private void ItemsSourceChanged(DependencyPropertyChangedEventArgs e)
+        public ItemsModel3D()
         {
-            if (e.OldValue is INotifyCollectionChanged o)
+            SceneNode.Attached += SceneNode_Attached;
+            SceneNode.Detached += SceneNode_Detached;
+        }
+
+        private void SceneNode_Attached(object sender, EventArgs e)
+        {
+            if (ItemsSource != null)
+            {
+                ItemsSourceChanged(ItemsSource);
+            }
+        }
+
+        private void SceneNode_Detached(object sender, EventArgs e)
+        {
+            if (itemsSourceInternal != null)
+            {
+                ItemsSourceChanged(null);
+            }
+        }
+
+        private void ItemsSourceChanged(IEnumerable itemsSource)
+        {
+            if (itemsSourceInternal is INotifyCollectionChanged o)
             {
                 o.CollectionChanged -= ItemsModel3D_CollectionChanged;
             }
-            if (e.OldValue == null && e.NewValue != null && Children.Count > 0)
+            if (itemsSourceInternal == null && itemsSource != null && Children.Count > 0)
             {
                 throw new InvalidOperationException("Children must be empty before using ItemsSource");
             }
@@ -148,20 +168,22 @@ namespace HelixToolkit.Wpf.SharpDX
             elementDict.Clear();
             Children.Clear();
 
-            if (e.NewValue is INotifyCollectionChanged n)
+            itemsSourceInternal = itemsSource;
+
+            if (itemsSourceInternal is INotifyCollectionChanged n)
             {
                 n.CollectionChanged -= ItemsModel3D_CollectionChanged;
                 n.CollectionChanged += ItemsModel3D_CollectionChanged;
             }
 
-            if (ItemsSource == null)
+            if (itemsSourceInternal == null)
             {
                 return;
             }
 
             if (this.ItemTemplate == null)
             {
-                foreach (var item in this.ItemsSource)
+                foreach (var item in this.itemsSourceInternal)
                 {
                     if (item is Element3D model)
                     {
@@ -176,7 +198,7 @@ namespace HelixToolkit.Wpf.SharpDX
             }
             else
             {
-                foreach (var item in this.ItemsSource)
+                foreach (var item in this.itemsSourceInternal)
                 {
                     if (this.ItemTemplate.LoadContent() is Element3D model)
                     {
@@ -306,23 +328,6 @@ namespace HelixToolkit.Wpf.SharpDX
             var node = SceneNode as GroupNode;
             node.Clear();
             Children.Clear();
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (ItemsSource is INotifyCollectionChanged n)
-                {
-                    n.CollectionChanged -= ItemsModel3D_CollectionChanged;
-                }
-                foreach (var item in elementDict)
-                {
-                    item.Value?.Dispose();
-                }
-                Clear();
-            }
-            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
Simplify children disposal. Avoid needing to call dispose to release event handler.