### PR TITLE
Fixed rectangle selection cause model3D.Bounds is empty, improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 1. Fixed bounding sphere is not properly transformed with non-uniform scaling matrix. (WPF.SharpDX/UWP/WinUI)
 1. Fixed the difference size of ZoomExtends of Viewport3DX between different cameras. (WPF.SharpDX/UWP/WinUI)
 1. Fix memory leak by disposing entire tree if top node is being disposed. (WPF.SharpDX/UWP/WinUI)
+1. Fix missing edge clicking, incorrect model updirection in ViewCubeVisual3d (WPF)
 
 ## [2.23.0]
 

--- a/Source/HelixToolkit.Wpf.Shared/Geometry/LineSegment.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Geometry/LineSegment.cs
@@ -14,7 +14,7 @@ namespace HelixToolkit.Wpf
     /// <summary>
     /// Represents a line segment in two-dimensional space.
     /// </summary>
-    public class LineSegment
+    public struct LineSegment
     {
         /// <summary>
         /// The first point of the line segment.

--- a/Source/HelixToolkit.Wpf.Shared/Geometry/Triangle.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Geometry/Triangle.cs
@@ -14,7 +14,7 @@ namespace HelixToolkit.Wpf
     /// <summary>
     /// Represents a triangle in two-dimensional space.
     /// </summary>
-    public class Triangle
+    public struct Triangle
     {
         /// <summary>
         /// The first point of the triangle.

--- a/Source/HelixToolkit.Wpf.Shared/Helpers/Viewport3DHelper.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Helpers/Viewport3DHelper.cs
@@ -245,15 +245,16 @@ namespace HelixToolkit.Wpf
                     }
                     else if (rectangle.IntersectsWith(visualBound))
                     {
-                        // transform the positions of the mesh to screen coordinates
-                        var point2Ds = geometry.Positions.Select(transform.Transform).Select(viewport.Point3DtoPoint2D).ToArray();
-                        var meshPoints = new Point[geometry.TriangleIndices.Count];
-                        for (var i = 0; i < geometry.TriangleIndices.Count; i += 3)
+                        int indicesCount = geometry.TriangleIndices.Count;
+                        Point3D[] meshPositions = new Point3D[indicesCount];
+                        for (var i = 0; i < indicesCount; i += 3)
                         {
-                            meshPoints[i] = point2Ds[geometry.TriangleIndices[i]];
-                            meshPoints[i + 1] = point2Ds[geometry.TriangleIndices[i + 1]];
-                            meshPoints[i + 2] = point2Ds[geometry.TriangleIndices[i + 2]];
+                            meshPositions[i] = geometry.Positions[geometry.TriangleIndices[i]];
+                            meshPositions[i + 1] = geometry.Positions[geometry.TriangleIndices[i + 1]];
+                            meshPositions[i + 2] = geometry.Positions[geometry.TriangleIndices[i + 2]];
                         }
+                        // transform the positions of the mesh to screen coordinates
+                        var meshPoints = meshPositions.Select(transform.Transform).Select(viewport.Point3DtoPoint2D).ToArray();
                         double minX = meshPoints.Min(x => x.X);
                         double minY = meshPoints.Min(x => x.Y);
                         double maxX = meshPoints.Max(x => x.X);

--- a/Source/HelixToolkit.Wpf.Shared/Helpers/Viewport3DHelper.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Helpers/Viewport3DHelper.cs
@@ -245,21 +245,61 @@ namespace HelixToolkit.Wpf
                     }
                     else if (rectangle.IntersectsWith(visualBound))
                     {
-                        int indicesCount = geometry.TriangleIndices.Count;
-                        Point3D[] meshPositions = new Point3D[indicesCount];
-                        for (var i = 0; i < indicesCount; i += 3)
-                        {
-                            meshPositions[i] = geometry.Positions[geometry.TriangleIndices[i]];
-                            meshPositions[i + 1] = geometry.Positions[geometry.TriangleIndices[i + 1]];
-                            meshPositions[i + 2] = geometry.Positions[geometry.TriangleIndices[i + 2]];
-                        }
                         // transform the positions of the mesh to screen coordinates
-                        var meshPoints = meshPositions.Select(transform.Transform).Select(viewport.Point3DtoPoint2D).ToArray();
-                        double minX = meshPoints.Min(x => x.X);
-                        double minY = meshPoints.Min(x => x.Y);
-                        double maxX = meshPoints.Max(x => x.X);
-                        double maxY = meshPoints.Max(x => x.Y);
-                        Rect geometryBound = new Rect(new Point(minX, minY), new Point(maxX, maxY));
+                        Point[] meshPoints;
+
+                        var point2Ds = TransformPoints3dTo2d(viewport, transform, geometry.Positions.ToArray());
+
+                        int[] distinctTriangleIndices = geometry.TriangleIndices.Distinct().ToArray();
+                        if (geometry.Positions.Count == distinctTriangleIndices.Length)//MeshGeometry3D maybe (high probability) is origin (have not edited like is cutted...)
+                        {
+                            /* Get bound points by Transform Rect3D of MeshGeometry3D.Bounds to Rect 2d through 8 corner point
+                             *
+                             *              Z | Up   
+                             *                |
+                             *        p4______|_________p7
+                             *        /|      |        /|
+                             *       / |      |       / |
+                             *      /  |      |      /  |
+                             *  p5 |----------------|p6 |
+                             *     |   |      |     |   |
+                             *     |   |    O +-----|---------- Y Left
+                             *     | p0|_____/______|___|p3
+                             *     |  /     /       |   /
+                             *     | /     /        |  /
+                             *     |/     /         | /
+                             *  p1 |_____/__________|/p2
+                             *          /
+                             *       X / Front
+                             */
+
+                            Rect3D rect3d = geometry.Bounds;
+                            Point3D p0 = rect3d.Location;
+                            Point3D p1 = new Point3D(p0.X + rect3d.SizeX, p0.Y, p0.Z);
+                            Point3D p2 = new Point3D(p0.X + rect3d.SizeX, p0.Y + rect3d.SizeY, p0.Z);
+                            Point3D p3 = new Point3D(p0.X, p0.Y + rect3d.SizeY, p0.Z);
+
+                            Point3D p4 = new Point3D(p0.X, p0.Y, p0.Z + rect3d.SizeZ);
+                            Point3D p5 = new Point3D(p1.X, p1.Y, p1.Z + rect3d.SizeZ);
+                            Point3D p6 = new Point3D(p2.X, p2.Y, p2.Z + rect3d.SizeZ);
+                            Point3D p7 = new Point3D(p3.X, p3.Y, p3.Z + rect3d.SizeZ);
+
+                            Point3D[] point3dCorners = new Point3D[8] { p0, p1, p2, p3, p4, p5, p6, p7 };
+                            meshPoints= TransformPoints3dTo2d(viewport, transform, point3dCorners);
+                        }
+                        else //MeshGeometry3D maybe (high probability) is changed from origin model3D (like is cutted...)
+                        {
+                            //Get all point in actual mesh position 
+                            int length = distinctTriangleIndices.Length;
+                            meshPoints = new Point[length];
+                            for (var i = 0; i < length; i++)
+                            {
+                                int triangleIndice = distinctTriangleIndices[i];
+                                int pointIndex = geometry.TriangleIndices[triangleIndice];
+                                meshPoints[i] = point2Ds[pointIndex];
+                            }
+                        }
+                        Rect geometryBound = GetBound2d(meshPoints);
 
                         if (rectangle.Contains(geometryBound))// object is both inside and touch
                         {
@@ -268,9 +308,13 @@ namespace HelixToolkit.Wpf
                         else if (mode == SelectionHitMode.Touch && rectangle.IntersectsWith(geometryBound))
                         {
                             // evaluate each triangle
-                            for (var i = 0; i < meshPoints.Length; i += 3)
+                            int triangleIndiceCount = geometry.TriangleIndices.Count;
+                            for (var i = 0; i < triangleIndiceCount; i += 3)
                             {
-                                var triangle = new Triangle(meshPoints[i], meshPoints[i + 1], meshPoints[i + 2]);
+                                var p1 = point2Ds[geometry.TriangleIndices[i]];
+                                var p2 = point2Ds[geometry.TriangleIndices[i + 1]];
+                                var p3 = point2Ds[geometry.TriangleIndices[i + 2]];
+                                var triangle = new Triangle(p1, p2, p3);
                                 // check if triangle touched/inside with rectangle
                                 if (triangle.IsCompletelyInside(rectangle)
                                          || triangle.IntersectsWith(rectangle)
@@ -284,6 +328,39 @@ namespace HelixToolkit.Wpf
                     }
                 });
             return results;
+            Point[] TransformPoints3dTo2d(Viewport3D viewport3d, Transform3D transform3d, Point3D[] point3ds)
+            {
+                int length = point3ds.Length;
+                Point[] point2ds = new Point[length];
+                for (int i = 0; i < length; i++)
+                {
+                    Point3D transformedPoint3d = transform3d.Transform(point3ds[i]);
+                    Point point2d = viewport3d.Point3DtoPoint2D(transformedPoint3d);
+                    point2ds[i] = point2d;
+                }
+                return point2ds;
+            }
+            Rect GetBound2d(Point[] point2ds)
+            {
+                double minX = point2ds[0].X;
+                double minY = point2ds[0].Y;
+                double maxX = point2ds[0].X;
+                double maxY = point2ds[0].Y;
+                for (int i = 1; i < point2ds.Length; i++)
+                {
+                    Point pi = point2ds[i];
+                    if (pi.X < minX)
+                        minX = pi.X;
+                    else if (pi.X > maxX)
+                        maxX = pi.X;
+                    if (pi.Y < minY)
+                        minY = pi.Y;
+                    else if (pi.Y > maxY)
+                        maxY = pi.Y;
+                }
+                return new Rect(new Point(minX, minY), new Point(maxX, maxY));
+            }
+
         }
 
         /// <summary>

--- a/Source/HelixToolkit.Wpf.Shared/Helpers/Viewport3DHelper.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Helpers/Viewport3DHelper.cs
@@ -295,8 +295,7 @@ namespace HelixToolkit.Wpf
                             for (var i = 0; i < length; i++)
                             {
                                 int triangleIndice = distinctTriangleIndices[i];
-                                int pointIndex = geometry.TriangleIndices[triangleIndice];
-                                meshPoints[i] = point2Ds[pointIndex];
+                                meshPoints[i] = point2Ds[triangleIndice];
                             }
                         }
                         Rect geometryBound = GetBound2d(meshPoints);

--- a/Source/HelixToolkit.Wpf.Shared/Visual3Ds/Composite/BoundingBoxVisual3D.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Visual3Ds/Composite/BoundingBoxVisual3D.cs
@@ -92,37 +92,14 @@ namespace HelixToolkit.Wpf
         /// </summary>
         protected virtual void OnBoxChanged()
         {
-            this.Children.Clear();
             if (this.BoundingBox.IsEmpty)
             {
                 return;
             }
-
-            Rect3D bb = this.BoundingBox;
-
-            var p0 = new Point3D(bb.X, bb.Y, bb.Z);
-            var p1 = new Point3D(bb.X, bb.Y + bb.SizeY, bb.Z);
-            var p2 = new Point3D(bb.X + bb.SizeX, bb.Y + bb.SizeY, bb.Z);
-            var p3 = new Point3D(bb.X + bb.SizeX, bb.Y, bb.Z);
-            var p4 = new Point3D(bb.X, bb.Y, bb.Z + bb.SizeZ);
-            var p5 = new Point3D(bb.X, bb.Y + bb.SizeY, bb.Z + bb.SizeZ);
-            var p6 = new Point3D(bb.X + bb.SizeX, bb.Y + bb.SizeY, bb.Z + bb.SizeZ);
-            var p7 = new Point3D(bb.X + bb.SizeX, bb.Y, bb.Z + bb.SizeZ);
-
-            this.AddEdge(p0, p1);
-            this.AddEdge(p1, p2);
-            this.AddEdge(p2, p3);
-            this.AddEdge(p3, p0);
-
-            this.AddEdge(p4, p5);
-            this.AddEdge(p5, p6);
-            this.AddEdge(p6, p7);
-            this.AddEdge(p7, p4);
-
-            this.AddEdge(p0, p4);
-            this.AddEdge(p1, p5);
-            this.AddEdge(p2, p6);
-            this.AddEdge(p3, p7);
+            MeshBuilder meshBuilder = new MeshBuilder(false, false);
+            meshBuilder.AddBoundingBox(this.BoundingBox, Diameter);
+            GeometryModel3D geoBoundingBox = new GeometryModel3D(meshBuilder.ToMesh(), MaterialHelper.CreateMaterial(Fill));
+            this.Content = geoBoundingBox;
         }
 
         /// <summary>
@@ -130,13 +107,13 @@ namespace HelixToolkit.Wpf
         /// </summary>
         protected virtual void OnFillChanged()
         {
-            foreach (MeshElement3D item in this.Children)
+            GeometryModel3D geoBoundingBox = Content as GeometryModel3D;
+            if (geoBoundingBox is null)
             {
-                if (item != null)
-                {
-                    item.Fill = this.Fill;
-                }
+                return;
             }
+            geoBoundingBox.Material = MaterialHelper.CreateMaterial(Fill);
+
         }
 
         /// <summary>
@@ -166,28 +143,5 @@ namespace HelixToolkit.Wpf
         {
             ((BoundingBoxVisual3D)d).OnFillChanged();
         }
-
-        /// <summary>
-        /// Adds an edge.
-        /// </summary>
-        /// <param name="p1">
-        /// The start point.
-        /// </param>
-        /// <param name="p2">
-        /// The end point.
-        /// </param>
-        private void AddEdge(Point3D p1, Point3D p2)
-        {
-            var fv = new PipeVisual3D();
-            fv.BeginEdit();
-            fv.Diameter = this.Diameter;
-            fv.ThetaDiv = 10;
-            fv.Fill = this.Fill;
-            fv.Point1 = p1;
-            fv.Point2 = p2;
-            fv.EndEdit();
-            this.Children.Add(fv);
-        }
-
     }
 }

--- a/Source/HelixToolkit.Wpf.Shared/Visual3Ds/Composite/BoundingBoxVisual3D.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Visual3Ds/Composite/BoundingBoxVisual3D.cs
@@ -22,7 +22,7 @@ namespace HelixToolkit.Wpf
         /// Identifies the <see cref="BoundingBox"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty BoundingBoxProperty = DependencyProperty.Register(
-            "BoundingBox", typeof(Rect3D), typeof(BoundingBoxVisual3D), new UIPropertyMetadata(new Rect3D(), BoxChanged));
+            "BoundingBox", typeof(Rect3D), typeof(BoundingBoxVisual3D), new UIPropertyMetadata(Rect3D.Empty, BoxChanged));
 
         /// <summary>
         /// Identifies the <see cref="Diameter"/> dependency property.
@@ -94,6 +94,7 @@ namespace HelixToolkit.Wpf
         {
             if (this.BoundingBox.IsEmpty)
             {
+                this.Content = null;
                 return;
             }
             MeshBuilder meshBuilder = new MeshBuilder(false, false);


### PR DESCRIPTION
- Remove the magic number in ViewCubeVisual3D [WPF]
- Fixed rectangle selection cause Model3D.Bounds is Empty, improve performance  [WPF]. ref #1954 
- Make BoundingBoxVisual3D into one model [WPF]