### PR TITLE
Fixed NullRefrenceException in CuttingPlaneGroup.CuttingPlanes [WPF]

### DIFF
--- a/Source/HelixToolkit.Wpf.Shared/Visual3Ds/Composite/CuttingPlaneGroup.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Visual3Ds/Composite/CuttingPlaneGroup.cs
@@ -224,7 +224,10 @@ namespace HelixToolkit.Wpf
             var newGeometry = originalGeometry;
             var originalMeshGeometry = originalGeometry as MeshGeometry3D;
 
-            if (this.IsEnabled && originalMeshGeometry != null)
+            if (this.IsEnabled
+                && this.CuttingPlanes != null
+                && originalMeshGeometry != null
+               )
             {
                 var inverseTransform = transform.Inverse;
                 if (inverseTransform == null)


### PR DESCRIPTION
Fixed NullRefrenceException in CuttingPlaneGroup.CuttingPlanes [WPF]