### PR TITLE
Fix WinUI crash. Ref #1977

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Interface/IRenderHost.cs
@@ -475,5 +475,9 @@ namespace HelixToolkit.UWP
         /// <param name="clearBackBuffer">if set to <c>true</c> [clear back buffer].</param>
         /// <param name="clearDepthStencilBuffer">if set to <c>true</c> [clear depth stencil buffer].</param>
         void ClearRenderTarget(DeviceContextProxy context, bool clearBackBuffer, bool clearDepthStencilBuffer);
+        /// <summary>
+        /// Use separate thread to do non-rendering related tasks during render call.
+        /// </summary>
+        bool EnableParallelProcessing { set; get; }
     }
 }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -220,6 +220,7 @@ namespace HelixToolkit.UWP
             protected override void PreRender(bool invalidateSceneGraph, bool invalidatePerFrameRenderables)
             {
                 base.PreRender(invalidateSceneGraph, invalidatePerFrameRenderables);
+                parallelThread.Enabled = EnableParallelProcessing;
 
                 SeparateRenderables(RenderContext, invalidateSceneGraph, invalidatePerFrameRenderables);
                 if (invalidateSceneGraph)
@@ -348,7 +349,7 @@ namespace HelixToolkit.UWP
                     renderer.RenderToPingPongBuffer(RenderContext, ref renderParameter);
                     renderParameter.IsMSAATexture = false;
                     renderParameter.CurrentTargetTexture = RenderBuffer.FullResPPBuffer.CurrentTexture;
-                    renderParameter.RenderTargetView[0] = RenderBuffer.FullResPPBuffer.CurrentRTV;                                 
+                    renderParameter.RenderTargetView[0] = RenderBuffer.FullResPPBuffer.CurrentRTV;
                 }
                 if (postEffectNodes.Count > 0)
                 {
@@ -391,7 +392,7 @@ namespace HelixToolkit.UWP
                         {
                             ++start;
                         }
-                    }                       
+                    }
                 }
                 renderer.RenderToBackBuffer(RenderContext, ref renderParameter);
                 numRendered += preProcNodes.Count + postEffectNodes.Count + screenSpacedNodes.Count;
@@ -405,7 +406,7 @@ namespace HelixToolkit.UWP
 
             private int DoDepthPrepass()
             {
-                renderer.ImmediateContext.ClearDepthStencilView(RenderBuffer.DepthStencilBufferNoMSAA, 
+                renderer.ImmediateContext.ClearDepthStencilView(RenderBuffer.DepthStencilBufferNoMSAA,
                     DepthStencilClearFlags.Depth | DepthStencilClearFlags.Stencil);
                 renderer.ImmediateContext.SetRenderTarget(RenderBuffer.DepthStencilBufferNoMSAA, null);
                 RenderContext.CustomPassName = DefaultPassNames.DepthPrepass;
@@ -495,7 +496,9 @@ namespace HelixToolkit.UWP
             protected override void OnStartD3D()
             {
                 base.OnStartD3D();
+#if !WINUI
                 parallelThread.Start();
+#endif
             }
 
             /// <summary>
@@ -510,7 +513,9 @@ namespace HelixToolkit.UWP
                 RemoveAndDispose(ref asyncTask);
                 RemoveAndDispose(ref getTriangleCountTask);
                 RemoveAndDispose(ref getPostEffectCoreTask);
+#if !WINUI
                 parallelThread.Stop();
+#endif
                 Clear(true, true);
                 base.OnEndingD3D();
             }

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/DefaultRenderHost.cs
@@ -6,11 +6,9 @@ using SharpDX;
 using SharpDX.Direct3D11;
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
 #if DX11_1
 using Device = SharpDX.Direct3D11.Device1;
 using DeviceContext = SharpDX.Direct3D11.DeviceContext1;
@@ -343,7 +341,7 @@ namespace HelixToolkit.UWP
                 numRendered += renderer.RenderTransparent(RenderContext, transparentNodesInFrustum, ref renderParameter);
 
                 getPostEffectCoreTask?.Wait();
-                getPostEffectCoreTask = null;
+                RemoveAndDispose(ref getPostEffectCoreTask);
                 if (RenderConfiguration.FXAALevel != FXAALevel.None
                     || postEffectNodes.Count > 0 || globalEffectNodes.Count > 0)
                 {
@@ -424,9 +422,9 @@ namespace HelixToolkit.UWP
             protected override void PostRender()
             {
                 asyncTask?.Wait();
-                asyncTask = null;
+                RemoveAndDispose(ref asyncTask);
                 getTriangleCountTask?.Wait();
-                getTriangleCountTask = null;
+                RemoveAndDispose(ref getTriangleCountTask);
             }
 
             /// <summary>
@@ -509,9 +507,9 @@ namespace HelixToolkit.UWP
                 asyncTask?.Wait();
                 getTriangleCountTask?.Wait();
                 getPostEffectCoreTask?.Wait();
-                asyncTask = null;
-                getTriangleCountTask = null;
-                getPostEffectCoreTask = null;
+                RemoveAndDispose(ref asyncTask);
+                RemoveAndDispose(ref getTriangleCountTask);
+                RemoveAndDispose(ref getPostEffectCoreTask);
                 parallelThread.Stop();
                 Clear(true, true);
                 base.OnEndingD3D();

--- a/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Render/RenderHost/RenderHostBase.cs
@@ -610,6 +610,8 @@ namespace HelixToolkit.UWP
             /// The feature level.
             /// </value>
             public global::SharpDX.Direct3D.FeatureLevel FeatureLevel { get; private set; } = global::SharpDX.Direct3D.FeatureLevel.Level_11_0;
+
+            public bool EnableParallelProcessing { set; get; } = true;
             #endregion
             #endregion
 

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/AsyncTasks/AsyncActionThread.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/AsyncTasks/AsyncActionThread.cs
@@ -21,10 +21,7 @@ namespace HelixToolkit.UWP
 
         public void SetAction(Action action)
         {
-            lock (waitable)
-            {
-                this.action = action;
-            }
+            this.action = action;
         }
 
         public void Trigger()
@@ -92,7 +89,7 @@ namespace HelixToolkit.UWP
             if (!running || !Enabled)
             {
                 action.Invoke();
-                return null; 
+                return null;
             }
             var obj = AsyncActionWaitable.Get();
             obj.SetAction(action);

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/AsyncTasks/AsyncActionThread.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/AsyncTasks/AsyncActionThread.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 
 #if !NETFX_CORE
@@ -15,18 +13,27 @@ namespace HelixToolkit.UWP
 #endif
 #endif
 {
-    internal sealed class AsyncActionWaitable
+    internal sealed class AsyncActionWaitable : DisposeObject
     {
         private readonly object waitable = new object();
         private AsyncActionWaitable() { }
-        public Action Action;
+        private Action action;
+
+        public void SetAction(Action action)
+        {
+            lock (waitable)
+            {
+                this.action = action;
+            }
+        }
 
         public void Trigger()
         {
             lock (waitable)
             {
-                Action?.Invoke();
-                Action = null;
+                var a = action;
+                action = null;
+                a?.Invoke();
                 Monitor.Pulse(waitable);
             }
         }
@@ -35,7 +42,7 @@ namespace HelixToolkit.UWP
         {
             lock (waitable)
             {
-                if (Action == null)
+                if (action == null)
                 {
                     return;
                 }
@@ -47,13 +54,24 @@ namespace HelixToolkit.UWP
 
         public static AsyncActionWaitable Get()
         {
-            return pool.TryTake(out var obj) ? obj : new AsyncActionWaitable();
+            if (!pool.TryTake(out AsyncActionWaitable obj))
+            {
+                obj = new AsyncActionWaitable
+                {
+                    AddBackToPool = Put
+                };
+            }
+            obj.IncRef();
+            return obj;
         }
 
-        public static void Put(AsyncActionWaitable obj)
+        static void Put(DisposeObject obj)
         {
-            obj.Action = null;
-            pool.Add(obj);
+            if (obj is AsyncActionWaitable t)
+            {
+                t.action = null;
+                pool.Add(t);
+            }
         }
     }
     /// <summary>
@@ -69,10 +87,10 @@ namespace HelixToolkit.UWP
 
         public AsyncActionWaitable EnqueueAction(Action action)
         {
-            if (!running) 
+            if (!running)
             { return null; }
             var obj = AsyncActionWaitable.Get();
-            obj.Action = action;
+            obj.SetAction(action);
             lock (jobs)
             {
                 jobs.Enqueue(obj);
@@ -100,7 +118,6 @@ namespace HelixToolkit.UWP
                             var job = jobs.Dequeue();
                             Monitor.Exit(jobs);
                             job.Trigger();
-                            AsyncActionWaitable.Put(job);
                             Monitor.Enter(jobs);
                         }
                         Monitor.Wait(jobs, 100);
@@ -108,7 +125,7 @@ namespace HelixToolkit.UWP
                 }
                 Clear();
             });
-            jobThread.Priority = ThreadPriority.Highest;
+            jobThread.Priority = ThreadPriority.AboveNormal;
             jobThread.Start();
         }
 
@@ -136,7 +153,7 @@ namespace HelixToolkit.UWP
             {
                 while (jobs.Count > 0)
                 {
-                    AsyncActionWaitable.Put(jobs.Dequeue());
+                    jobs.Dequeue().Dispose();
                 }
             }
         }

--- a/Source/HelixToolkit.SharpDX.Shared/Utilities/AsyncTasks/AsyncActionThread.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Utilities/AsyncTasks/AsyncActionThread.cs
@@ -85,10 +85,15 @@ namespace HelixToolkit.UWP
         private volatile bool running = true;
         private bool disposedValue;
 
+        public bool Enabled { set; get; }
+
         public AsyncActionWaitable EnqueueAction(Action action)
         {
-            if (!running)
-            { return null; }
+            if (!running || !Enabled)
+            {
+                action.Invoke();
+                return null; 
+            }
             var obj = AsyncActionWaitable.Get();
             obj.SetAction(action);
             lock (jobs)

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
@@ -628,6 +628,8 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public event EventHandler<IEffectsManager> EffectsManagerChanged;
 
+        public bool EnableParallelProcessing { set; get; }
+
         public ModelContainer3DX()
         {
             this.IsHitTestVisible = false;

--- a/Source/HelixToolkit.WinUI/CommonDX/HelixToolkitRenderPanel.cs
+++ b/Source/HelixToolkit.WinUI/CommonDX/HelixToolkitRenderPanel.cs
@@ -69,13 +69,13 @@ namespace HelixToolkit.WinUI
             if (enableDeferredRendering)
             {
                 renderHost = new SwapChainCompositionRenderHost((device) => { return new DeferredContextRenderer(device, new AutoRenderTaskScheduler()); });
-                // renderHost = new SwapChainSurfaceRenderHost(swapChainPanelNativePtr, (device) => { return new DeferredContextRenderer(device, new AutoRenderTaskScheduler()); });
             }
             else
             {
                 renderHost = new SwapChainCompositionRenderHost();
-                // renderHost = new SwapChainSurfaceRenderHost(swapChainPanelNativePtr);
             }
+            // Disable parallel processing until this issue is fixed: https://github.com/microsoft/microsoft-ui-xaml/issues/8501
+            renderHost.EnableParallelProcessing = false;
             renderHost.OnNewRenderTargetTexture += SwapChainRenderHost_OnNewRenderTargetTexture;
             renderHost.StartRenderLoop += SwapChainRenderHost_StartRenderLoop;
             renderHost.StopRenderLoop += SwapChainRenderHost_StopRenderLoop;


### PR DESCRIPTION
1. Improve async action thread implementation.
2. Fix WinUI crash. Ref #1977. Disable parallel processing in render call for now.