### PR TITLE
Improve component

### DIFF
--- a/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
+++ b/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
@@ -827,7 +827,7 @@ namespace HelixToolkit.Wpf
 
 #if !NETFX_CORE
         /// <summary>
-        /// Adds the edges of a bounding box as cylinders.
+        /// Adds the edges of a bounding box as pipes.
         /// </summary>
         /// <param name="boundingBox">
         /// The bounding box.
@@ -846,7 +846,7 @@ namespace HelixToolkit.Wpf
             var p6 = new Point3D((DoubleOrSingle)boundingBox.X + (DoubleOrSingle)boundingBox.SizeX, (DoubleOrSingle)boundingBox.Y + (DoubleOrSingle)boundingBox.SizeY, (DoubleOrSingle)boundingBox.Z + (DoubleOrSingle)boundingBox.SizeZ);
             var p7 = new Point3D((DoubleOrSingle)boundingBox.X + (DoubleOrSingle)boundingBox.SizeX, (DoubleOrSingle)boundingBox.Y, (DoubleOrSingle)boundingBox.Z + (DoubleOrSingle)boundingBox.SizeZ);
 
-            Action<Point3D, Point3D> addEdge = (c1, c2) => this.AddCylinder(c1, c2, diameter, 10);
+            Action<Point3D, Point3D> addEdge = (c1, c2) => this.AddPipe(c1, c2,0, diameter, 10);
 
             addEdge(p0, p1);
             addEdge(p1, p2);

--- a/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
+++ b/Source/HelixToolkit.Shared/Geometry/MeshBuilder.cs
@@ -2019,11 +2019,11 @@ namespace HelixToolkit.Wpf
         /// <param name="thetaDiv">
         /// The number of divisions around the cylinders.
         /// </param>
-        public void AddPipes(IList<Vector3D> points, IList<int> edges, double diameter = 1, int thetaDiv = 32)
+        public void AddPipes(IList<Point3D> points, IList<int> edges, double diameter = 1, int thetaDiv = 32)
         {
             for (var i = 0; i < edges.Count - 1; i += 2)
             {
-                this.AddCylinder((Point3D)points[edges[i]], (Point3D)points[edges[i + 1]], diameter, thetaDiv);
+                this.AddCylinder(points[edges[i]], points[edges[i + 1]], diameter, thetaDiv);
             }
         }
         /// <summary>

--- a/Source/HelixToolkit.Shared/Geometry/MeshGeometryHelper.cs
+++ b/Source/HelixToolkit.Shared/Geometry/MeshGeometryHelper.cs
@@ -283,13 +283,13 @@ namespace HelixToolkit.Wpf
             var p = new Point3DCollection();
             var ti = new Int32Collection();
             Vector3DCollection n = null;
-            if (input.Normals != null)
+            if (input.Normals != null && input.Normals.Count>0)
             {
                 n = new Vector3DCollection();
             }
 
             PointCollection tc = null;
-            if (input.TextureCoordinates != null)
+            if (input.TextureCoordinates != null && input.TextureCoordinates.Count > 0 )
             {
                 tc = new PointCollection();
             }
@@ -311,7 +311,7 @@ namespace HelixToolkit.Wpf
                 ti.Add(i0);
                 ti.Add(i1);
                 ti.Add(i2);
-                if (n != null && input.Normals.Count>0)
+                if (n != null)
                 {
                     n.Add(input.Normals[index0]);
                     n.Add(input.Normals[index1]);


### PR DESCRIPTION
- Fixed System.OutOfRange in MeshGeometryHelper
- Update change IList<Vector3D> to IList<Point3D> in MeshBuilder.AddPipes()  #1983 
- Update MeshBuilder.AddBoundingBox() uses AddPipe() instead of AddCylinder()