### PR TITLE
Fix rendering doesn't update after removing item from Viewport3DX.Items.

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Controls/Viewport3DX.cs
@@ -391,6 +391,7 @@ namespace HelixToolkit.Wpf.SharpDX
                     }
                 }
             }
+            InvalidateRender();
         }
 
         /// <summary>


### PR DESCRIPTION
Fix rendering doesn't update after removing item from Viewport3DX.Items.#2001