### PR TITLE
ObjReader.cs, GetFullPath method: If base path is non-existent, tryin…

### DIFF
--- a/Source/HelixToolkit.Wpf.Shared/Importers/ObjReader.cs
+++ b/Source/HelixToolkit.Wpf.Shared/Importers/ObjReader.cs
@@ -1205,7 +1205,13 @@ namespace HelixToolkit.Wpf
                     path = path.Substring(1);
                 }
 
-                return !string.IsNullOrWhiteSpace(basePath) ? Path.GetFullPath(Path.Combine(basePath, path)) : "";
+                if (string.IsNullOrWhiteSpace(basePath))
+                {
+                    // If base path is non-existent, trying to set it to absolute path of the current folder.
+                    basePath = AppDomain.CurrentDomain.BaseDirectory;
+                }
+
+                return !string.IsNullOrWhiteSpace(basePath) ? Path.GetFullPath(Path.Combine(basePath, path)) : string.Empty;
             }
         }
     }


### PR DESCRIPTION
…g to set it to absolute path of the current folder, otherwise local files are loaded without a material.