### PR TITLE
Rect3D to BoundingBox conversion needs to use Size properties to calculate equivalent Maximum Point

### DIFF
--- a/Source/HelixToolkit.Wpf.SharpDX.Shared/Extensions/CameraExtensions.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX.Shared/Extensions/CameraExtensions.cs
@@ -541,7 +541,7 @@ namespace HelixToolkit.Wpf.SharpDX
 
         public static BoundingBox ToBoundingBox(this Rect3D bounds)
         {
-            return new BoundingBox(bounds.Location.ToVector3(), bounds.Location.ToVector3() + new Vector3((float)bounds.X, (float)bounds.Y, (float)bounds.Z));
+            return new BoundingBox(bounds.Location.ToVector3(), bounds.Location.ToVector3() + new Vector3((float)bounds.SizeX, (float)bounds.SizeY, (float)bounds.SizeZ));
         }
         /// <summary>
         /// Zooms to fit the specified bounding rectangle.


### PR DESCRIPTION
### Purpose

In testing the new `ZoomExtents` algorithm I noticed that this conversion method was always producing Zero dimension bounding box.  The X, Y, and Z props are the same as the `Location`.  This should give you the correct equivalent Maximum point location.  