### PR TITLE
Fix missing TriangleIndecies assignment in `MeshGeometry3D ToMeshGeometry3D(this Geometry.MeshGeometry3D mesh)`. Ref #2097

### DIFF
--- a/Source/HelixToolkit.SharpDX/Converter.cs
+++ b/Source/HelixToolkit.SharpDX/Converter.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using CommunityToolkit.Diagnostics;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace HelixToolkit.SharpDX;
 
@@ -31,7 +33,7 @@ public static class Converter
         return result;
     }
     /// <summary>
-    /// Converts the geometry to a <see cref="SharpDX.MeshGeometry3D"/>.
+    /// Converts the geometry to a <see cref="SharpDX.MeshGeometry3D"/>. Equivalent to MeshBuilder.ToMesh().ToMeshGeometry3D().
     /// All internal mesh builder data are directly assigned to the <see cref="SharpDX.MeshGeometry3D"/> without copying.
     /// User must call <see cref="MeshBuilder.Reset"/> to reset and reuse the mesh builder object to create new meshes.
     /// </summary>
@@ -39,17 +41,7 @@ public static class Converter
     /// <returns></returns>
     public static MeshGeometry3D ToMeshGeometry3D(this MeshBuilder builder)
     {
-        var mg = new MeshGeometry3D()
-        {
-            Normals = builder.Normals,
-            Positions = builder.Positions,
-            TextureCoordinates = builder.TextureCoordinates,
-            TriangleIndices = builder.TriangleIndices,
-            Tangents = builder.Tangents,
-            BiTangents = builder.BiTangents
-        };
-
-        return mg;
+        return builder.ToMesh().ToMeshGeometry3D();
     }
     /// <summary>
     /// Converts the <see cref="SharpDX.MeshGeometry3D"/> to a <see cref="Geometry.MeshGeometry3D"/>.

--- a/Source/HelixToolkit.SharpDX/Converter.cs
+++ b/Source/HelixToolkit.SharpDX/Converter.cs
@@ -83,7 +83,8 @@ public static class Converter
             Normals = mesh.Normals,
             TextureCoordinates = mesh.TextureCoordinates,
             Tangents = mesh.Tangents,
-            BiTangents = mesh.BiTangents
+            BiTangents = mesh.BiTangents,
+            TriangleIndices= mesh.TriangleIndices
         };
     }
 }

--- a/Source/HelixToolkit.SharpDX/Utilities/ImportExport/ObjReader.cs
+++ b/Source/HelixToolkit.SharpDX/Utilities/ImportExport/ObjReader.cs
@@ -1272,12 +1272,14 @@ public class ObjReader : IModelReader
                 specularMapMS = new MemoryStream();
                 fs.CopyTo(specularMapMS);
             }
+            var diffuse = Diffuse.ToColor4();
+            diffuse.Alpha = (float)Dissolved;
             var mat = new PhongMaterialCore()
             {
                 AmbientColor = this.Ambient,
                 //AmbientMap = this.AmbientMap,
 
-                DiffuseColor = new Color4(this.Diffuse.R, this.Diffuse.G, this.Diffuse.B, (float)Dissolved),
+                DiffuseColor = diffuse,
                 DiffuseMap = diffuseMapMS,
 
                 SpecularColor = this.Specular,
@@ -1290,7 +1292,6 @@ public class ObjReader : IModelReader
                 //Illumination = this.Illumination,
 
             };
-
             //return mg.Children.Count != 1 ? mg : mg.Children[0];
             return mat;
         }


### PR DESCRIPTION
1. Fix missing TriangleIndecies assignment in `MeshGeometry3D ToMeshGeometry3D(this Geometry.MeshGeometry3D mesh)`. Ref #2097
1. Fix some type conversion bugs.