### PR TITLE
Update gitversion.yml for the branches configuration

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,2 +1,15 @@
 next-version: 3.0.0
-branches: {}
+branches:
+  develop:
+    regex: ^develop
+    mode: ContinuousDeployment
+    tag: alpha
+    increment: Minor
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: true
+    source-branches: []
+    tracks-release-branches: true
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 0
+


### PR DESCRIPTION
Hello,
I've updated the `gitversion.yml` file to add configuration settings for the `develop*` branches.

See https://gitversion.net/docs/reference/configuration#branch-configuration

> By default GitVersion is set up to do Continuous Deployment versioning on the develop branch, but for all other branches, [Continuous Delivery](https://gitversion.net/docs/reference/modes/continuous-delivery) is the default mode.

By default, the Continuous Deployment setting is set for the develop branch. With this PR it will also be applied to the develop3 branch.
Without this change the name of the generated nuget packages is always the same. With this PR the package name for the develop3 branch will be in the same format as the package name for the develop branch.
