### PR TITLE
Change Wpf.Converter to Wpf.ConverterExtensions, Fix Wpf.Test failed

### DIFF
--- a/Source/HelixToolkit.Wpf.Tests/ExtensionMethods/ConverterExtensionsTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/ExtensionMethods/ConverterExtensionsTests.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HelixToolkit.Wpf;
+using System.Numerics;
+using System.Windows;
+using System.Windows.Media.Media3D;
+namespace HelixToolkit.Wpf.Tests.ExtensionMethods
+{
+    [TestFixture]
+    public class ConverterExtensionsTests
+    {
+        [Test]
+        public void ToFloatArray()
+        {
+            double[]? nullDoubles = null;
+            Assert.AreEqual(null, nullDoubles.ToFloatArray(), "Float array is not null");
+            double[] emptyDoubles = new double[0];
+            Assert.AreEqual(Array.Empty<float>(), emptyDoubles.ToFloatArray(), "Float array is not empty");
+            double[] doubles = new double[] { -1.125d, -1d, 2d, 2.122d };
+            Assert.AreEqual(new float[] { -1.125f, -1f, 2f, 2.122f }, doubles.ToFloatArray(), "Double array is not convert to Float array correctly");
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf.Tests/ExtensionMethods/Vector3DExtensionsTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/ExtensionMethods/Vector3DExtensionsTests.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Windows.Media.Media3D;
 
-namespace HelixToolkit.Wpf.Tests.Helpers;
+namespace HelixToolkit.Wpf.Tests.ExtensionMethods;
 
 // ReSharper disable InconsistentNaming
 [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Reviewed. Suppression is OK here.")]

--- a/Source/HelixToolkit.Wpf.Tests/Geometry/PolygonTriangulationTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Geometry/PolygonTriangulationTests.cs
@@ -16,7 +16,7 @@ public class PolygonTriangulationTests
             new(0, 0), new(1, 0), new(0, 1)
         };
 
-        Int32Collection indices = Converter.ToWndInt32Collection(SweepLinePolygonTriangulator.Triangulate(triangleInPositiveOrientation)) ?? new();
+        Int32Collection indices = ConverterExtensions.ToWndInt32Collection(SweepLinePolygonTriangulator.Triangulate(triangleInPositiveOrientation)) ?? new();
         Assert.That(indices.Count == 3);
         Assert.That(indices[0] == 0);
         Assert.That(indices[1] == 1);
@@ -28,7 +28,7 @@ public class PolygonTriangulationTests
                     new(0, 0), new(0, 1),  new(1, 0)
                 };
 
-        indices = Converter.ToWndInt32Collection(SweepLinePolygonTriangulator.Triangulate(triangleInNegativeOrientation)) ?? new();
+        indices = ConverterExtensions.ToWndInt32Collection(SweepLinePolygonTriangulator.Triangulate(triangleInNegativeOrientation)) ?? new();
         Assert.That(indices.Count == 3);
         Assert.That(indices[0] == 0);
         Assert.That(indices[1] == 2);

--- a/Source/HelixToolkit.Wpf.Tests/Geometry/Ray3DTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Geometry/Ray3DTests.cs
@@ -21,8 +21,7 @@ public class Ray3DTests
         var ray = new Ray3D(new Point3D(0, 0, 0), new Vector3D(1, 2, 3));
         var p0 = new Point3D(0.1, 0.2, 0.3);
         var p = ray.GetNearest(p0);
-        var d = p0.DistanceTo(p);
-        Assert.AreEqual(0, d, 1e-12);
+        Assert.AreEqual(0, p0.DistanceTo(p), 1e-12);
     }
 
     [Test]
@@ -32,8 +31,7 @@ public class Ray3DTests
         var p0 = new Point3D(0.1, 2, 3);
         var pe = new Point3D(0.1, 0, 0);
         var p = ray.GetNearest(p0);
-        var d = pe.DistanceTo(p);
-        Assert.AreEqual(0, d, 1e-12);
+        Assert.AreEqual(0, pe.DistanceTo(p), 1e-12);
     }
 
     [Test]

--- a/Source/HelixToolkit.Wpf.Tests/Geometry/Ray3DTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Geometry/Ray3DTests.cs
@@ -21,17 +21,18 @@ public class Ray3DTests
         var ray = new Ray3D(new Point3D(0, 0, 0), new Vector3D(1, 2, 3));
         var p0 = new Point3D(0.1, 0.2, 0.3);
         var p = ray.GetNearest(p0);
-        Assert.AreEqual(0, p0.DistanceTo(p), 1e-12);
+        Assert.AreEqual(0, p0.DistanceTo(p), 1e-6);
     }
 
     [Test]
     public void GetNearest_PointOffRay()
     {
         var ray = new Ray3D(new Point3D(0, 0, 0), new Vector3D(1, 0, 0));
-        var p0 = new Point3D(0.1, 2, 3);
-        var pe = new Point3D(0.1, 0, 0);
+        double x = 0.1;
+        var p0 = new Point3D(x, 2, 3);
+        var pe = new Point3D(x, 0, 0);
         var p = ray.GetNearest(p0);
-        Assert.AreEqual(0, pe.DistanceTo(p), 1e-12);
+        Assert.AreEqual(0, pe.DistanceTo(p), 1e-8);
     }
 
     [Test]

--- a/Source/HelixToolkit.Wpf.Tests/HelixToolkit.Wpf.Tests.csproj
+++ b/Source/HelixToolkit.Wpf.Tests/HelixToolkit.Wpf.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0-windows;net48</TargetFrameworks>

--- a/Source/HelixToolkit.Wpf.Tests/Helpers/StereoHelperTests.cs
+++ b/Source/HelixToolkit.Wpf.Tests/Helpers/StereoHelperTests.cs
@@ -1,7 +1,7 @@
 ﻿using NUnit.Framework;
 using System.Diagnostics.CodeAnalysis;
 
-namespace HelixToolkit.Wpf.Tests;
+namespace HelixToolkit.Wpf.Tests.Helpers;
 
 // ReSharper disable InconsistentNaming
 [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Reviewed. Suppression is OK here.")]

--- a/Source/HelixToolkit.Wpf/Converter.cs
+++ b/Source/HelixToolkit.Wpf/Converter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Windows;
 
 namespace HelixToolkit.Wpf;
 
@@ -33,7 +34,7 @@ public static class Converter
 
         for (int i = 0; i < array.Length; i++)
         {
-            result[i] = (double)(decimal)array[i];
+            result[i] = array[i];
         }
 
         return result;
@@ -43,7 +44,7 @@ public static class Converter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static System.Windows.Point ToWndPoint(this System.Numerics.Vector2 vector)
     {
-        return new System.Windows.Point((double)(decimal)vector.X, (double)(decimal)vector.Y);
+        return new System.Windows.Point(vector.X, vector.Y);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -55,7 +56,7 @@ public static class Converter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static System.Windows.Size ToWndSize(this System.Numerics.Vector2 vector)
     {
-        return new System.Windows.Size((double)(decimal)vector.X, (double)(decimal)vector.Y);
+        return new System.Windows.Size(vector.X, vector.Y);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -67,7 +68,7 @@ public static class Converter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static System.Windows.Vector ToWndVector(this System.Numerics.Vector2 vector)
     {
-        return new System.Windows.Vector((double)(decimal)vector.X, (double)(decimal)vector.Y);
+        return new System.Windows.Vector(vector.X, vector.Y);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -81,7 +82,7 @@ public static class Converter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static System.Windows.Media.Media3D.Point3D ToWndPoint3D(this System.Numerics.Vector3 vector)
     {
-        return new System.Windows.Media.Media3D.Point3D((double)(decimal)vector.X, (double)(decimal)vector.Y, (double)(decimal)vector.Z);
+        return new System.Windows.Media.Media3D.Point3D(vector.X, vector.Y, vector.Z);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -93,7 +94,7 @@ public static class Converter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static System.Windows.Media.Media3D.Vector3D ToWndVector3D(this System.Numerics.Vector3 vector)
     {
-        return new System.Windows.Media.Media3D.Vector3D((double)(decimal)vector.X, (double)(decimal)vector.Y, (double)(decimal)vector.Z);
+        return new System.Windows.Media.Media3D.Vector3D(vector.X, vector.Y, vector.Z);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -105,7 +106,7 @@ public static class Converter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static System.Windows.Media.Media3D.Size3D ToWndSize3D(this System.Numerics.Vector3 vector)
     {
-        return new System.Windows.Media.Media3D.Size3D((double)(decimal)vector.X, (double)(decimal)vector.Y, (double)(decimal)vector.Z);
+        return new System.Windows.Media.Media3D.Size3D(vector.X, vector.Y, vector.Z);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -119,7 +120,7 @@ public static class Converter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static System.Windows.Media.Media3D.Point4D ToWnPoint4D(this System.Numerics.Vector4 vector)
     {
-        return new System.Windows.Media.Media3D.Point4D((double)(decimal)vector.X, (double)(decimal)vector.Y, (double)(decimal)vector.Z, (double)(decimal)vector.W);
+        return new System.Windows.Media.Media3D.Point4D(vector.X, vector.Y, vector.Z, vector.W);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,10 +135,10 @@ public static class Converter
     public static System.Windows.Media.Media3D.Matrix3D ToWndMatrix3D(this System.Numerics.Matrix4x4 matrix)
     {
         return new System.Windows.Media.Media3D.Matrix3D(
-            (double)(decimal)matrix.M11, (double)(decimal)matrix.M12, (double)(decimal)matrix.M13, (double)(decimal)matrix.M14,
-            (double)(decimal)matrix.M21, (double)(decimal)matrix.M22, (double)(decimal)matrix.M23, (double)(decimal)matrix.M24,
-            (double)(decimal)matrix.M31, (double)(decimal)matrix.M32, (double)(decimal)matrix.M32, (double)(decimal)matrix.M34,
-            (double)(decimal)matrix.M41, (double)(decimal)matrix.M42, (double)(decimal)matrix.M43, (double)(decimal)matrix.M44);
+            matrix.M11, matrix.M12, matrix.M13, matrix.M14,
+            matrix.M21, matrix.M22, matrix.M23, matrix.M24,
+            matrix.M31, matrix.M32, matrix.M32, matrix.M34,
+            matrix.M41, matrix.M42, matrix.M43, matrix.M44);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -451,7 +452,7 @@ public static class Converter
 
         for (int i = 0; i < collection.Count; i++)
         {
-            newCollection.Add((double)(decimal)collection[i]);
+            newCollection.Add((double)collection[i]);
         }
 
         return newCollection;

--- a/Source/HelixToolkit.Wpf/Exporters/StlExporter.cs
+++ b/Source/HelixToolkit.Wpf/Exporters/StlExporter.cs
@@ -111,7 +111,7 @@ public sealed class StlExporter : Exporter<BinaryWriter>
         var normals = mesh.Normals;
         if (normals == null || normals.Count != mesh.Positions.Count)
         {
-            normals = Converter.ToWndVector3DCollection(MeshGeometryHelper.CalculateNormals(mesh.ToMeshGeometry3D()));
+            normals = ConverterExtensions.ToWndVector3DCollection(MeshGeometryHelper.CalculateNormals(mesh.ToMeshGeometry3D()));
         }
 
         // TODO: Also handle non-uniform scale

--- a/Source/HelixToolkit.Wpf/ExtensionMethods/ConverterExtensions.cs
+++ b/Source/HelixToolkit.Wpf/ExtensionMethods/ConverterExtensions.cs
@@ -3,7 +3,7 @@ using System.Windows;
 
 namespace HelixToolkit.Wpf;
 
-public static class Converter
+public static class ConverterExtensions
 {
     #region Array
     public static float[]? ToFloatArray(this double[]? array)
@@ -12,7 +12,10 @@ public static class Converter
         {
             return null;
         }
-
+        else if (array.Length == 0)
+        {
+            return Array.Empty<float>();
+        }
         var result = new float[array.Length];
 
         for (int i = 0; i < array.Length; i++)
@@ -29,7 +32,10 @@ public static class Converter
         {
             return null;
         }
-
+        else if (array.Length == 0)
+        {
+            return Array.Empty<double>();
+        }
         var result = new double[array.Length];
 
         for (int i = 0; i < array.Length; i++)
@@ -268,7 +274,7 @@ public static class Converter
     #endregion
 
     #region Collection
-    public static System.Windows.Media.Media3D.Vector3DCollection? ToWndVector3DCollection(IList<System.Numerics.Vector3>? collection)
+    public static System.Windows.Media.Media3D.Vector3DCollection? ToWndVector3DCollection( this IList<System.Numerics.Vector3>? collection)
     {
         if (collection is null)
         {
@@ -319,7 +325,7 @@ public static class Converter
         return newCollection;
     }
 
-    public static System.Windows.Media.Media3D.Point3DCollection? ToWndPoint3DCollection(IList<System.Numerics.Vector3>? collection)
+    public static System.Windows.Media.Media3D.Point3DCollection? ToWndPoint3DCollection(this IList<System.Numerics.Vector3>? collection)
     {
         if (collection is null)
         {
@@ -370,7 +376,7 @@ public static class Converter
         return newCollection;
     }
 
-    public static System.Windows.Media.PointCollection? ToWndPointCollection(IList<System.Numerics.Vector2>? collection)
+    public static System.Windows.Media.PointCollection? ToWndPointCollection(this IList<System.Numerics.Vector2>? collection)
     {
         if (collection is null)
         {
@@ -404,7 +410,7 @@ public static class Converter
         return newCollection;
     }
 
-    public static System.Windows.Media.Int32Collection? ToWndInt32Collection(IList<int>? collection)
+    public static System.Windows.Media.Int32Collection? ToWndInt32Collection(this IList<int>? collection)
     {
         if (collection is null)
         {
@@ -441,7 +447,7 @@ public static class Converter
         return newCollection;
     }
 
-    public static System.Windows.Media.DoubleCollection? ToWndDoubleCollection(IList<float>? collection)
+    public static System.Windows.Media.DoubleCollection? ToWndDoubleCollection(this IList<float>? collection)
     {
         if (collection is null)
         {


### PR DESCRIPTION
- [Revert "Fix float to double conversion](https://github.com/helix-toolkit/helix-toolkit/commit/42cd3dfcc5d425db9ca0f0bcf8ff9fd262370a73) 
due to using (double)(decimal) also makes the result less accurate (see the photo) and bad performance.   
![image](https://github.com/helix-toolkit/helix-toolkit/assets/48544354/53b1e22f-5249-4a4c-a89b-fdc1e3727513)