### PR TITLE
Added missing scale to ToBillboardImage3D.

### DIFF
--- a/Source/HelixToolkit.SharpDX.Shared/Extensions/BitmapExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.Shared/Extensions/BitmapExtensions.cs
@@ -295,7 +295,8 @@ namespace HelixToolkit.UWP
                                  UV_TopLeft = new Vector2(rect.Left / imageWidth, rect.Top / imageHeight),
                                  UV_BottomRight = new Vector2(rect.Right / imageWidth, rect.Bottom / imageHeight),
                                  HorizontalAlignment = x.HorizontalAlignment,
-                                 VerticalAlignment = x.VerticalAlignment
+                                 VerticalAlignment = x.VerticalAlignment,
+                                 Scale = x.Scale,
                              };
                          }))
                         {


### PR DESCRIPTION
Fixing scale on batched text when using; 
billboardTextModel3D.FixedSize = false;