### PR TITLE
Added missing scale to ToBillboardImage3D.

### DIFF
--- a/Source/HelixToolkit.SharpDX/Extensions/BitmapExtensions.cs
+++ b/Source/HelixToolkit.SharpDX/Extensions/BitmapExtensions.cs
@@ -240,7 +240,8 @@ public static class BitmapExtensions
                         UV_TopLeft = new Vector2(rect.Left / imageWidth, rect.Top / imageHeight),
                         UV_BottomRight = new Vector2(rect.Right / imageWidth, rect.Bottom / imageHeight),
                         HorizontalAlignment = x.HorizontalAlignment,
-                        VerticalAlignment = x.VerticalAlignment
+                        VerticalAlignment = x.VerticalAlignment,
+                        Scale = x.Scale,
                     };
                 }))
                 {


### PR DESCRIPTION
Fixing scale on batched text when using;
billboardTextModel3D.FixedSize = false;

now in develop3