### PR TITLE
Make HitResult as abstract

### DIFF
--- a/Source/HelixToolkit.Wpf/Helpers/Viewport3DHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/Viewport3DHelper.cs
@@ -132,7 +132,7 @@ public static class Viewport3DHelper
     /// <param name="filterCallback">The method that represents the hit test filter callback value./></param>
     /// <param name="resultCallback">The method that represents the hit test result callback value.</param>
     /// <returns> List of hits, sorted with the nearest hit first.</returns>
-    public static IList<HitResult>? FindHits(this Viewport3D viewport, Point position, HitTestFilterCallback? filterCallback = null, HitTestResultCallback? resultCallback = null)
+    public static IList<PointHitResult>? FindHits(this Viewport3D viewport, Point position, HitTestFilterCallback? filterCallback = null, HitTestResultCallback? resultCallback = null)
     {
         if (viewport is null)
         {
@@ -143,7 +143,7 @@ public static class Viewport3DHelper
             ThrowHelper.ThrowArgumentNullException(nameof(viewport.Camera));
         }
 
-        List<HitResult> result = new List<HitResult>();
+        List<PointHitResult> result = new List<PointHitResult>();
         Point3D cameraPosition = new Point3D();
         if (viewport.Camera is ProjectionCamera projectionCamera)
         {
@@ -168,7 +168,7 @@ public static class Viewport3DHelper
                     Point3D position = GetGlobalHitPosition(rayHit, viewport);
                     Vector3D normalHit = GetNormalHit(rayHit) ?? new Vector3D(0, 0, 1);
                     double distance = (cameraPosition - position).Length;
-                    HitResult hitResult = new HitResult(rayHit, distance, position, normalHit);
+                    PointHitResult hitResult = new PointHitResult(rayHit, distance, position, normalHit);
                     result.Add(hitResult);
                 }
             }
@@ -1324,107 +1324,6 @@ public static class Viewport3DHelper
             if (group != null)
             {
                 SearchFor(group.Children, type, output);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a rectangle hit result.
-    /// </summary>
-    public sealed class RectangleHitResult
-    {
-        /// <summary>
-        /// Gets the hit model.
-        /// </summary>
-        public Model3D? Model { get; }
-
-        /// <summary>
-        /// Gets the hit visual.
-        /// </summary>
-        public Visual3D? Visual { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RectangleHitResult" /> class.
-        /// </summary>
-        /// <param name="model">The hit model.</param>
-        /// <param name="visual">The hit visual.</param>
-        public RectangleHitResult(Model3D? model, Visual3D? visual)
-        {
-            this.Model = model;
-            this.Visual = visual;
-        }
-    }
-
-    /// <summary>
-    /// A hit result.
-    /// </summary>
-    public sealed class HitResult
-    {
-        public HitResult(RayMeshGeometry3DHitTestResult? rayHit, double distance, Point3D position, Vector3D normal)
-        {
-            this.RayHit = rayHit;
-            this.Distance = distance;
-            this.Position = position;
-            this.Normal = normal;
-        }
-
-        /// <summary>
-        /// Gets the distance.
-        /// </summary>
-        /// <value>The distance.</value>
-        public double Distance { get; }
-
-        /// <summary>
-        /// Gets the mesh.
-        /// </summary>
-        /// <value>The mesh.</value>
-        public MeshGeometry3D? Mesh
-        {
-            get
-            {
-                return this.RayHit?.MeshHit;
-            }
-        }
-
-        /// <summary>
-        /// Gets the model.
-        /// </summary>
-        /// <value>The model.</value>
-        public Model3D? Model
-        {
-            get
-            {
-                return this.RayHit?.ModelHit;
-            }
-        }
-
-        /// <summary>
-        /// Gets the normal.
-        /// </summary>
-        /// <value>The normal.</value>
-        public Vector3D Normal { get; }
-
-        /// <summary>
-        /// Gets the position.
-        /// </summary>
-        /// <value>The position.</value>
-        public Point3D Position { get; }
-
-        /// <summary>
-        /// Gets the ray hit.
-        /// </summary>
-        /// <value>The ray hit.</value>
-        public RayMeshGeometry3DHitTestResult? RayHit { get; }
-
-        /// <summary>
-        /// Gets the visual.
-        /// </summary>
-        /// <value>The visual.</value>
-        public Visual3D? Visual
-        {
-            get
-            {
-                return this.RayHit?.VisualHit;
             }
         }
     }

--- a/Source/HelixToolkit.Wpf/SelectionCommands/CombinedSelectionCommand.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/CombinedSelectionCommand.cs
@@ -122,7 +122,7 @@ public sealed class CombinedSelectionCommand : SelectionCommand
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         void HandlePointSelection()
         {
-            IList<Viewport3DHelper.HitResult>? res = this.Viewport.FindHits(this.selectionRect.Location) ?? new List<Viewport3DHelper.HitResult>();
+            IList<PointHitResult>? res = this.Viewport.FindHits(this.selectionRect.Location) ?? new List<PointHitResult>();
             var selectedModels = res.Select(hit => hit.Model).ToList();
             this.OnModelsSelected(new ModelsSelectedByPointEventArgs(selectedModels, this.selectionRect.Location));
             var selectedVisuals = res.Select(hit => hit.Visual).ToList();
@@ -131,7 +131,7 @@ public sealed class CombinedSelectionCommand : SelectionCommand
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         void HandleRectangleSelection()
         {
-            IEnumerable<Viewport3DHelper.RectangleHitResult> res = this.Viewport.FindHits(this.selectionRect, this.SelectionHitMode);
+            IEnumerable<RectangleHitResult> res = this.Viewport.FindHits(this.selectionRect, this.SelectionHitMode);
             var selectedModels = res.Select(hit => hit.Model).ToList();
             this.OnModelsSelected(new ModelsSelectedByRectangleEventArgs(selectedModels, this.selectionRect));
             var selectedVisuals = res.Select(hit => hit.Visual).ToList();

--- a/Source/HelixToolkit.Wpf/SelectionCommands/HitTestResult.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/HitTestResult.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Media3D;
+using System.Windows.Media;
+
+namespace HelixToolkit.Wpf
+{
+    public interface IHitResult
+    {
+        public Model3D? Model { get; }
+        public Visual3D? Visual { get; }
+    }
+
+    /// <summary>
+    /// Represents a rectangle hit result.
+    /// </summary>
+    public sealed class RectangleHitResult : IHitResult
+    {
+        /// <summary>
+        /// Gets the hit model.
+        /// </summary>
+        public Model3D? Model { get; }
+
+        /// <summary>
+        /// Gets the hit visual.
+        /// </summary>
+        public Visual3D? Visual { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RectangleHitResult" /> class.
+        /// </summary>
+        /// <param name="model">The hit model.</param>
+        /// <param name="visual">The hit visual.</param>
+        public RectangleHitResult(Model3D? model, Visual3D? visual)
+        {
+            this.Model = model;
+            this.Visual = visual;
+        }
+    }
+
+    /// <summary>
+    /// A hit result.
+    /// </summary>
+    public sealed class PointHitResult : IHitResult
+    {
+        /// <summary>
+        /// Gets the model.
+        /// </summary>
+        /// <value>The model.</value>
+        public Model3D? Model
+        {
+            get
+            {
+                return this.RayHit?.ModelHit;
+            }
+        }
+
+        /// <summary>
+        /// Gets the visual.
+        /// </summary>
+        /// <value>The visual.</value>
+        public Visual3D? Visual
+        {
+            get
+            {
+                return this.RayHit?.VisualHit;
+            }
+        }
+        /// <summary>
+        /// Gets the distance.
+        /// </summary>
+        /// <value>The distance.</value>
+        public double Distance { get; }
+
+        /// <summary>
+        /// Gets the mesh.
+        /// </summary>
+        /// <value>The mesh.</value>
+        public MeshGeometry3D? Mesh
+        {
+            get
+            {
+                return this.RayHit?.MeshHit;
+            }
+        }
+
+        /// <summary>
+        /// Gets the normal.
+        /// </summary>
+        /// <value>The normal.</value>
+        public Vector3D Normal { get; }
+
+        /// <summary>
+        /// Gets the position.
+        /// </summary>
+        /// <value>The position.</value>
+        public Point3D Position { get; }
+
+        /// <summary>
+        /// Gets the ray hit.
+        /// </summary>
+        /// <value>The ray hit.</value>
+        public RayMeshGeometry3DHitTestResult? RayHit { get; }
+
+        public PointHitResult(RayMeshGeometry3DHitTestResult? rayHit, double distance, Point3D position, Vector3D normal)
+        {
+            this.RayHit = rayHit;
+            this.Distance = distance;
+            this.Position = position;
+            this.Normal = normal;
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf/SelectionCommands/RectangleSelectionCommand.cs
+++ b/Source/HelixToolkit.Wpf/SelectionCommands/RectangleSelectionCommand.cs
@@ -3,6 +3,7 @@ using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows;
+using System.Windows.Media.Media3D;
 
 namespace HelixToolkit.Wpf;
 
@@ -90,8 +91,8 @@ public sealed class RectangleSelectionCommand : SelectionCommand
     {
         this.HideRectangle();
 
-        var res = this.Viewport.FindHits(this.selectionRect, this.SelectionHitMode);
-        var selectedModels = res.Select(hit => hit.Model).ToList();
+        IEnumerable<RectangleHitResult> res = this.Viewport.FindHits(this.selectionRect, this.SelectionHitMode);
+        List<Model3D?> selectedModels = res.Select(hit => hit.Model).ToList();
 
         // We do not handle the point selection, unless no models are selected.
         // If no models are selected, we clear the existing selection.
@@ -101,7 +102,7 @@ public sealed class RectangleSelectionCommand : SelectionCommand
         }
 
         this.OnModelsSelected(new ModelsSelectedByRectangleEventArgs(selectedModels, this.selectionRect));
-        var selectedVisuals = res.Select(hit => hit.Visual).ToList();
+        List<Visual3D?> selectedVisuals = res.Select(hit => hit.Visual).ToList();
         this.OnVisualsSelected(new VisualsSelectedByRectangleEventArgs(selectedVisuals, this.selectionRect));
     }
 

--- a/Source/HelixToolkit.Wpf/Visual3Ds/MeshVisuals/TruncatedConeVisual3D.cs
+++ b/Source/HelixToolkit.Wpf/Visual3Ds/MeshVisuals/TruncatedConeVisual3D.cs
@@ -49,7 +49,7 @@ public class TruncatedConeVisual3D : MeshElement3D
     /// Identifies the <see cref="ThetaDiv"/> dependency property.
     /// </summary>
     public static readonly DependencyProperty ThetaDivProperty = DependencyProperty.Register(
-        "ThetaDiv", typeof(int), typeof(TruncatedConeVisual3D), new PropertyMetadata(35, GeometryChanged));
+        "ThetaDiv", typeof(int), typeof(TruncatedConeVisual3D), new PropertyMetadata(36, GeometryChanged));
 
     /// <summary>
     /// Identifies the <see cref="TopCap"/> dependency property.


### PR DESCRIPTION
Change class name `HitResult` to `PointHitResult`.
Reason:   
1. the name `PointHitResult` is more clearly named.  
2. I'm planning to support selection by point with point range. For example, pick a point and apply the range selection is a rectangle/ circle around the given point. This class may have the name `RangePointHitResult` or `CustomPointHitResult`. Some objects like `LineVisual3D` is so thin to pick by a point on the line
