### PR TITLE
Improve wpf collection converters performance

### DIFF
--- a/Source/HelixToolkit.Wpf/ExtensionMethods/FloatingPointArrayConverters.cs
+++ b/Source/HelixToolkit.Wpf/ExtensionMethods/FloatingPointArrayConverters.cs
@@ -1,0 +1,191 @@
+﻿#if NET6_0_OR_GREATER
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics;
+#endif
+
+namespace HelixToolkit.Wpf;
+
+internal static class FloatingPointArrayConverters
+{
+    public unsafe static void ConvertFloatToDouble<T1, T2>(int arrayCount, T1[] floatArray, T2[] doubleArray)
+    {
+#if NET8_0_OR_GREATER
+        if (Avx512F.IsSupported)
+        {
+            int floatCount = Vector256<float>.Count;
+            int length = arrayCount / floatCount;
+
+#pragma warning disable CS8500
+            fixed (void* floatDataPtr = floatArray)
+            fixed (void* doubleDataPtr = doubleArray)
+#pragma warning restore CS8500
+            {
+                float* floatData = (float*)floatDataPtr;
+                double* doubleData = (double*)doubleDataPtr;
+
+                for (nuint i = 0; i < (uint)length; i++)
+                {
+                    Vector256<float> d = Avx.LoadVector256(floatData);
+                    Vector512<double> r = Avx512F.ConvertToVector512Double(d);
+                    Avx512F.Store(doubleData, r);
+
+                    floatData += floatCount;
+                    doubleData += floatCount;
+                }
+
+                for (int i = length * floatCount; i < arrayCount; i++)
+                {
+                    *doubleData = *floatData;
+                    floatData++;
+                    doubleData++;
+                }
+            }
+
+            return;
+        }
+#endif
+
+#if NET6_0_OR_GREATER
+        if (Avx.IsSupported)
+        {
+            int floatCount = Vector128<float>.Count;
+            int length = arrayCount / floatCount;
+
+#pragma warning disable CS8500
+            fixed (void* floatDataPtr = floatArray)
+            fixed (void* doubleDataPtr = doubleArray)
+#pragma warning restore CS8500
+            {
+                float* floatData = (float*)floatDataPtr;
+                double* doubleData = (double*)doubleDataPtr;
+
+                for (nuint i = 0; i < (uint)length; i++)
+                {
+                    Vector128<float> d = Sse.LoadVector128(floatData);
+                    Vector256<double> r = Avx.ConvertToVector256Double(d);
+                    Avx.Store(doubleData, r);
+
+                    floatData += floatCount;
+                    doubleData += floatCount;
+                }
+
+                for (int i = length * floatCount; i < arrayCount; i++)
+                {
+                    *doubleData = *floatData;
+                    floatData++;
+                    doubleData++;
+                }
+            }
+
+            return;
+        }
+#endif
+
+#pragma warning disable CS8500
+        fixed (void* floatDataPtr = floatArray)
+        fixed (void* doubleDataPtr = doubleArray)
+#pragma warning restore CS8500
+        {
+            float* floatData = (float*)floatDataPtr;
+            double* doubleData = (double*)doubleDataPtr;
+
+            for (int i = 0; i < arrayCount; i++)
+            {
+                *doubleData = *floatData;
+                floatData++;
+                doubleData++;
+            }
+        }
+    }
+
+    public unsafe static void ConvertDoubleToFloat<T1, T2>(int arrayCount, T1[] doubleArray, T2[] floatArray)
+    {
+#if NET8_0_OR_GREATER
+        if (Avx512F.IsSupported)
+        {
+            int doubleCount = Vector512<double>.Count;
+            int length = arrayCount / doubleCount;
+
+#pragma warning disable CS8500
+            fixed (void* doubleDataPtr = doubleArray)
+            fixed (void* floatDataPtr = floatArray)
+#pragma warning restore CS8500
+            {
+                double* doubleData = (double*)doubleDataPtr;
+                float* floatData = (float*)floatDataPtr;
+
+                for (nuint i = 0; i < (uint)length; i++)
+                {
+                    Vector512<double> d = Avx512F.LoadVector512(doubleData);
+                    Vector256<float> r = Avx512F.ConvertToVector256Single(d);
+                    Avx.Store(floatData, r);
+
+                    doubleData += doubleCount;
+                    floatData += doubleCount;
+                }
+
+                for (int i = length * doubleCount; i < arrayCount; i++)
+                {
+                    *floatData = (float)*doubleData;
+                    doubleData++;
+                    floatData++;
+                }
+            }
+
+            return;
+        }
+#endif
+
+#if NET6_0_OR_GREATER
+        if (Avx.IsSupported)
+        {
+            int doubleCount = Vector256<double>.Count;
+            int length = arrayCount / doubleCount;
+
+#pragma warning disable CS8500
+            fixed (void* doubleDataPtr = doubleArray)
+            fixed (void* floatDataPtr = floatArray)
+#pragma warning restore CS8500
+            {
+                double* doubleData = (double*)doubleDataPtr;
+                float* floatData = (float*)floatDataPtr;
+
+                for (nuint i = 0; i < (uint)length; i++)
+                {
+                    Vector256<double> d = Avx.LoadVector256(doubleData);
+                    Vector128<float> r = Avx.ConvertToVector128Single(d);
+                    Sse.Store(floatData, r);
+
+                    doubleData += doubleCount;
+                    floatData += doubleCount;
+                }
+
+                for (int i = length * doubleCount; i < arrayCount; i++)
+                {
+                    *floatData = (float)*doubleData;
+                    doubleData++;
+                    floatData++;
+                }
+            }
+
+            return;
+        }
+#endif
+
+#pragma warning disable CS8500
+        fixed (void* doubleDataPtr = doubleArray)
+        fixed (void* floatDataPtr = floatArray)
+#pragma warning restore CS8500
+        {
+            double* doubleData = (double*)doubleDataPtr;
+            float* floatData = (float*)floatDataPtr;
+
+            for (int i = 0; i < arrayCount; i++)
+            {
+                *floatData = (float)*doubleData;
+                doubleData++;
+                floatData++;
+            }
+        }
+    }
+}

--- a/Source/HelixToolkit.Wpf/ExtensionMethods/ListExtensions.cs
+++ b/Source/HelixToolkit.Wpf/ExtensionMethods/ListExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System.Reflection.Emit;
+using System.Reflection;
+
+namespace HelixToolkit.Wpf;
+
+internal static class ListExtensions
+{
+    private static class ArrayAccessor<T>
+    {
+        public static readonly Func<List<T>, T[]> Getter;
+
+        static ArrayAccessor()
+        {
+            var dm = new DynamicMethod(
+                "get",
+                MethodAttributes.Static | MethodAttributes.Public,
+                CallingConventions.Standard,
+                typeof(T[]),
+                new Type[] { typeof(List<T>) },
+                typeof(ArrayAccessor<T>),
+                true);
+
+            var il = dm.GetILGenerator();
+
+            il.Emit(OpCodes.Ldarg_0); // Load List<T> argument
+            il.Emit(OpCodes.Ldfld,
+                typeof(List<T>).GetField("_items",
+                BindingFlags.NonPublic | BindingFlags.Instance)!); // Replace argument by field
+            il.Emit(OpCodes.Ret); // Return field
+
+            Getter = (Func<List<T>, T[]>)dm.CreateDelegate(typeof(Func<List<T>, T[]>));
+        }
+    }
+
+    public static T[] GetInternalArray<T>(this List<T> list)
+    {
+        return ArrayAccessor<T>.Getter(list);
+    }
+
+    public static void SetInternalSize<T>(this List<T> list, int size)
+    {
+        list.GetType().GetField("_size", BindingFlags.NonPublic | BindingFlags.Instance)
+            !.SetValue(list, size);
+    }
+}

--- a/Source/HelixToolkit.Wpf/ExtensionMethods/WpfCollectionExtensions.cs
+++ b/Source/HelixToolkit.Wpf/ExtensionMethods/WpfCollectionExtensions.cs
@@ -1,0 +1,146 @@
+﻿using System.Reflection;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
+
+namespace HelixToolkit.Wpf;
+
+internal static class WpfCollectionExtensions
+{
+    /// <summary>
+    /// Minimal size of internal ArrayItemList.
+    /// </summary>
+    /// <remarks>
+    /// See https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/Shared/MS/Utility/FrugalList.cs
+    /// When the capacity is 1 the store type is SingleItemList.
+    /// When the capacity is between 2 and 3 the store type is ThreeItemList.
+    /// When the capacity is between 4 and 6 the store type is SixItemList.
+    /// When the capacity is greater than 6 the store type is ArrayItemList.
+    /// </remarks>
+    public const int InternalArrayMinSize = 6;
+
+    public static Point3D[]? GetInternalArray(this Point3DCollection list)
+    {
+        return GetCollectionInternalArray<Point3DCollection, Point3D>(list);
+    }
+
+    public static void SetInternalCount(this Point3DCollection list, int count)
+    {
+        SetCollectionInternalCount(list, count);
+    }
+
+    public static Vector3D[]? GetInternalArray(this Vector3DCollection list)
+    {
+        return GetCollectionInternalArray<Vector3DCollection, Vector3D>(list);
+    }
+
+    public static void SetInternalCount(this Vector3DCollection list, int count)
+    {
+        SetCollectionInternalCount(list, count);
+    }
+
+    public static Vector[]? GetInternalArray(this VectorCollection list)
+    {
+        return GetCollectionInternalArray<VectorCollection, Vector>(list);
+    }
+
+    public static void SetInternalCount(this VectorCollection list, int count)
+    {
+        SetCollectionInternalCount(list, count);
+    }
+
+    public static Point[]? GetInternalArray(this PointCollection list)
+    {
+        return GetCollectionInternalArray<PointCollection, Point>(list);
+    }
+
+    public static void SetInternalCount(this PointCollection list, int count)
+    {
+        SetCollectionInternalCount(list, count);
+    }
+
+    public static int[]? GetInternalArray(this Int32Collection list)
+    {
+        return GetCollectionInternalArray<Int32Collection, int>(list);
+    }
+
+    public static void SetInternalCount(this Int32Collection list, int count)
+    {
+        SetCollectionInternalCount(list, count);
+    }
+
+    public static double[]? GetInternalArray(this DoubleCollection list)
+    {
+        return GetCollectionInternalArray<DoubleCollection, double>(list);
+    }
+
+    public static void SetInternalCount(this DoubleCollection list, int count)
+    {
+        SetCollectionInternalCount(list, count);
+    }
+
+    private static TItem[]? GetCollectionInternalArray<TCollection, TItem>(TCollection list)
+    {
+        object? collection = list!.GetType().GetField("_collection", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(list);
+
+        if (collection is null)
+        {
+            return null;
+        }
+
+        object? listStore = collection.GetType().GetField("_listStore", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(collection);
+
+        if (listStore is null)
+        {
+            return null;
+        }
+
+        object? items = listStore.GetType().GetField("_entries", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(listStore);
+
+        if (items is null)
+        {
+            return null;
+        }
+
+        TItem[]? array = items as TItem[];
+
+        if (array is null)
+        {
+            return null;
+        }
+
+        return array;
+    }
+
+    private static bool SetCollectionInternalCount<TCollection>(TCollection list, int count)
+    {
+        object? collection = list!.GetType().GetField("_collection", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(list);
+
+        if (collection is null)
+        {
+            return false;
+        }
+
+        object? listStore = collection.GetType().GetField("_listStore", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(collection);
+
+        if (listStore is null)
+        {
+            return false;
+        }
+
+        FieldInfo? countField = listStore.GetType().GetField("_count", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        if (countField is null)
+        {
+            return false;
+        }
+
+        countField.SetValue(listStore, count);
+        return true;
+    }
+}

--- a/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
+++ b/Source/HelixToolkit.Wpf/HelixToolkit.Wpf.csproj
@@ -16,6 +16,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'True'">true</ContinuousIntegrationBuild>
     <IsPackable>true</IsPackable>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello,
I've modified the extension methods in the Wpf project which convert the float to double and double to float collections. I've improved the performance using the hardware intrinsics (sse and avx). This reduces the execution time for .Net 6 and .Net 8 while still using the same memory size.

Here are the results of a few benchmarks:
```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4317/23H2/2023Update/SunValley3)
.NET SDK 8.0.403
  Job-LOZNNX : .NET 8.0.10 (8.0.1024.46610), X64 RyuJIT AVX2

InvocationCount=1  IterationCount=1  LaunchCount=1  
UnrollFactor=1  WarmupCount=1  Error=NA  

```
| Method                             | Mean       | Ratio | Allocated | Alloc Ratio |
|----------------------------------- |-----------:|------:|----------:|------------:|
| DoubleToFloat_Current              |  12.153 ms |  1.00 |  38.15 MB |        1.00 |
| DoubleToFloat_New                  |   9.292 ms |  0.76 |  38.15 MB |        1.00 |
|                                    |            |       |           |             |
| FloatToDouble_Current              |  14.040 ms |  1.00 |  76.29 MB |        1.00 |
| FloatToDouble_New                  |  12.788 ms |  0.91 |  76.29 MB |        1.00 |
|                                    |            |       |           |             |
| MeshBuilder_Current                |   8.732 ms |  1.00 |   8.92 MB |        1.00 |
| MeshBuilder_New                    |   2.017 ms |  0.23 |   8.93 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToFloat_Current         |  69.686 ms |  1.00 |  38.15 MB |        1.00 |
| Collection_ToFloat_New             |   9.342 ms |  0.13 |  38.15 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToInt32_Current         |   5.583 ms |  1.00 |  38.15 MB |        1.00 |
| Collection_ToInt32_New             |   4.600 ms |  0.82 |  38.15 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToVector2Point_Current  |  17.807 ms |  1.00 |  15.26 MB |        1.00 |
| Collection_ToVector2Point_New      |   4.805 ms |  0.27 |  15.26 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToVector2Vector_Current |  18.171 ms |  1.00 |  15.26 MB |        1.00 |
| Collection_ToVector2Vector_New     |   4.656 ms |  0.26 |  15.26 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToVector3Point_Current  |   9.582 ms |  1.00 |  11.44 MB |        1.00 |
| Collection_ToVector3Point_New      |   3.534 ms |  0.37 |  11.45 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToVector3Vector_Current |   9.717 ms |  1.00 |  11.44 MB |        1.00 |
| Collection_ToVector3Vector_New     |   3.561 ms |  0.37 |  11.45 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToWndDouble_Current     | 165.270 ms |  1.00 |  76.29 MB |        1.00 |
| Collection_ToWndDouble_New         |  13.273 ms |  0.08 |   76.3 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToWndInt32_Current      |   5.066 ms |  1.00 |  38.15 MB |        1.00 |
| Collection_ToWndInt32_New          |   4.821 ms |  0.95 |  38.15 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToWndPoint_Current      |  44.642 ms |  1.00 |  30.52 MB |        1.00 |
| Collection_ToWndPoint_New          |   8.324 ms |  0.19 |  30.52 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToWndPoint3D_Current    |  28.818 ms |  1.00 |  22.89 MB |        1.00 |
| Collection_ToWndPoint3D_New        |   7.047 ms |  0.24 |  22.89 MB |        1.00 |
|                                    |            |       |           |             |
| Collection_ToWndVector3D_Current   |  29.180 ms |  1.00 |  22.89 MB |        1.00 |
| Collection_ToWndVector3D_New       |   7.151 ms |  0.25 |  22.89 MB |        1.00 |
