### PR TITLE
[V3] Reduce memory allocations in collections

### DIFF
--- a/Source/HelixToolkit.Maths/Collections/Color4Collection.cs
+++ b/Source/HelixToolkit.Maths/Collections/Color4Collection.cs
@@ -1,7 +1,5 @@
 ﻿using HelixToolkit.Maths;
 using System.ComponentModel;
-using System.Globalization;
-using System.Text;
 
 namespace HelixToolkit;
 
@@ -29,16 +27,15 @@ public sealed class Color4Collection : FastList<Color4>
 
         var th = new TokenizerHelper(source, formatProvider);
         var resource = new Color4Collection();
-
         Color4 value;
 
         while (th.NextToken())
         {
             value = new Color4(
-                Convert.ToSingle(th.GetCurrentToken(), formatProvider),
-                Convert.ToSingle(th.NextTokenRequired(), formatProvider),
-                Convert.ToSingle(th.NextTokenRequired(), formatProvider),
-                Convert.ToSingle(th.NextTokenRequired(), formatProvider));
+                NumericHelpers.ParseSingle(th.GetCurrentToken(), formatProvider),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), formatProvider),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), formatProvider),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), formatProvider));
 
             resource.Add(value);
         }
@@ -53,17 +50,27 @@ public sealed class Color4Collection : FastList<Color4>
             return string.Empty;
         }
 
-        var str = new StringBuilder();
+        var builder = new DefaultInterpolatedStringHandler(this.Count * 4 - 1, this.Count * 4, provider);
+        Color4 value;
+
         for (var i = 0; i < this.Count; i++)
         {
-            //str.AppendFormat(provider, "{0:" + format + "}", this[i]);
-            str.AppendFormat(provider, "{0},{1},{2},{3}", this[i].Red, this[i].Green, this[i].Blue, this[i].Alpha);
+            value = this[i];
+
+            builder.AppendFormatted(value.Red);
+            builder.AppendLiteral(",");
+            builder.AppendFormatted(value.Green);
+            builder.AppendLiteral(",");
+            builder.AppendFormatted(value.Blue);
+            builder.AppendLiteral(",");
+            builder.AppendFormatted(value.Alpha);
+
             if (i != this.Count - 1)
             {
-                str.Append(' ');
+                builder.AppendLiteral(" ");
             }
         }
 
-        return str.ToString();
+        return builder.ToStringAndClear();
     }
 }

--- a/Source/HelixToolkit.Maths/Collections/IntCollection.cs
+++ b/Source/HelixToolkit.Maths/Collections/IntCollection.cs
@@ -1,6 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Globalization;
-using System.Text;
 
 namespace HelixToolkit;
 
@@ -25,11 +23,13 @@ public sealed class IntCollection : FastList<int>
     public static IntCollection Parse(string source)
     {
         IFormatProvider formatProvider = CultureInfo.InvariantCulture;
+
         var th = new TokenizerHelper(source, formatProvider);
         var resource = new IntCollection();
+
         while (th.NextToken())
         {
-            var value = Convert.ToInt32(th.GetCurrentToken(), formatProvider);
+            int value = NumericHelpers.ParseInt32(th.GetCurrentToken(), formatProvider);
             resource.Add(value);
         }
 
@@ -40,19 +40,23 @@ public sealed class IntCollection : FastList<int>
     {
         if (this.Count == 0)
         {
-            return String.Empty;
+            return string.Empty;
         }
 
-        var str = new StringBuilder();
+        var builder = new DefaultInterpolatedStringHandler(this.Count - 1, this.Count, provider);
+
         for (var i = 0; i < this.Count; i++)
         {
-            str.AppendFormat(provider, "{0:" + format + "}", this[i]);
+            int value = this[i];
+
+            builder.AppendFormatted(value);
+
             if (i != this.Count - 1)
             {
-                str.Append(' ');
+                builder.AppendLiteral(" ");
             }
         }
 
-        return str.ToString();
+        return builder.ToStringAndClear();
     }
 }

--- a/Source/HelixToolkit.Maths/Collections/Vector2Collection.cs
+++ b/Source/HelixToolkit.Maths/Collections/Vector2Collection.cs
@@ -1,6 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Globalization;
-using System.Text;
 
 namespace HelixToolkit;
 
@@ -28,14 +26,13 @@ public sealed class Vector2Collection : FastList<Vector2>
 
         var th = new TokenizerHelper(source, formatProvider);
         var resource = new Vector2Collection();
-
         Vector2 value;
 
         while (th.NextToken())
         {
             value = new Vector2(
-                Convert.ToSingle(th.GetCurrentToken(), formatProvider),
-                Convert.ToSingle(th.NextTokenRequired(), formatProvider));
+                NumericHelpers.ParseSingle(th.GetCurrentToken(), formatProvider),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), formatProvider));
 
             resource.Add(value);
         }
@@ -50,17 +47,23 @@ public sealed class Vector2Collection : FastList<Vector2>
             return string.Empty;
         }
 
-        var str = new StringBuilder();
+        var builder = new DefaultInterpolatedStringHandler(this.Count * 2 - 1, this.Count * 2, provider);
+        Vector2 value;
+
         for (var i = 0; i < this.Count; i++)
         {
-            //str.AppendFormat(provider, "{0:" + format + "}", this[i]);
-            str.AppendFormat(provider, "{0},{1}", this[i].X, this[i].Y);
+            value = this[i];
+
+            builder.AppendFormatted(value.X);
+            builder.AppendLiteral(",");
+            builder.AppendFormatted(value.Y);
+
             if (i != this.Count - 1)
             {
-                str.Append(' ');
+                builder.AppendLiteral(" ");
             }
         }
 
-        return str.ToString();
+        return builder.ToStringAndClear();
     }
 }

--- a/Source/HelixToolkit.Maths/Collections/Vector3Collection.cs
+++ b/Source/HelixToolkit.Maths/Collections/Vector3Collection.cs
@@ -1,6 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Globalization;
-using System.Text;
 
 namespace HelixToolkit;
 
@@ -28,15 +26,14 @@ public sealed class Vector3Collection : FastList<Vector3>
 
         var th = new TokenizerHelper(source, formatProvider);
         var resource = new Vector3Collection();
-
         Vector3 value;
 
         while (th.NextToken())
         {
             value = new Vector3(
-                Convert.ToSingle(th.GetCurrentToken(), formatProvider),
-                Convert.ToSingle(th.NextTokenRequired(), formatProvider),
-                Convert.ToSingle(th.NextTokenRequired(), formatProvider));
+                NumericHelpers.ParseSingle(th.GetCurrentToken(), formatProvider),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), formatProvider),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), formatProvider));
 
             resource.Add(value);
         }
@@ -51,17 +48,25 @@ public sealed class Vector3Collection : FastList<Vector3>
             return string.Empty;
         }
 
-        var str = new StringBuilder();
+        var builder = new DefaultInterpolatedStringHandler(this.Count * 3 - 1, this.Count * 3, provider);
+        Vector3 value;
+
         for (var i = 0; i < this.Count; i++)
         {
-            //str.AppendFormat(provider, "{0:" + format + "}", this[i]);
-            str.AppendFormat(provider, "{0},{1},{2}", this[i].X, this[i].Y, this[i].Z);
+            value = this[i];
+
+            builder.AppendFormatted(value.X);
+            builder.AppendLiteral(",");
+            builder.AppendFormatted(value.Y);
+            builder.AppendLiteral(",");
+            builder.AppendFormatted(value.Z);
+
             if (i != this.Count - 1)
             {
-                str.Append(' ');
+                builder.AppendLiteral(" ");
             }
         }
 
-        return str.ToString();
+        return builder.ToStringAndClear();
     }
 }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/Color4Converter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/Color4Converter.cs
@@ -41,10 +41,10 @@ public sealed class Color4Converter : FromToStringTypeConverter
             {
                 var th = new TokenizerHelper(source, CultureInfo.InvariantCulture);
                 var result = new Color4(
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
                 return result;
             }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/ColorConverter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/ColorConverter.cs
@@ -27,10 +27,10 @@ public sealed class ColorConverter : FromToStringTypeConverter
             catch (FormatException) { }
             var th = new TokenizerHelper(source, CultureInfo.InvariantCulture);
             var result = new Color(
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
             return result;
         }
         else if (value is System.Windows.Media.Color color)

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/QuaternionConverter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/QuaternionConverter.cs
@@ -17,10 +17,10 @@ public sealed class QuaternionConverter : FromToStringTypeConverter
         {
             var th = new TokenizerHelper(source, CultureInfo.InvariantCulture);
             var result = new Quaternion(
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
             return result;
         }
 

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/Vector2Converter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/Vector2Converter.cs
@@ -46,8 +46,8 @@ public sealed class Vector2Converter : FromToStringTypeConverter
             {
                 var th = new TokenizerHelper(source, CultureInfo.InvariantCulture);
                 var result = new Vector2(
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
                 return result;
             }
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/Vector3Converter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/Vector3Converter.cs
@@ -47,9 +47,9 @@ public sealed class Vector3Converter : FromToStringTypeConverter
             {
                 var th = new TokenizerHelper(source, CultureInfo.InvariantCulture);
                 var result = new Vector3(
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                    Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                    NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
                 return result;
             }
         }

--- a/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/Vector4Converter.cs
+++ b/Source/HelixToolkit.Wpf.SharpDX/Utilities/TypeConverters/Vector4Converter.cs
@@ -19,10 +19,10 @@ public sealed class Vector4Converter : FromToStringTypeConverter
         {
             var th = new TokenizerHelper(source, CultureInfo.InvariantCulture);
             var result = new Vector4(
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
-                Convert.ToSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture),
+                NumericHelpers.ParseSingle(th.NextTokenRequired(), CultureInfo.InvariantCulture));
             return result;
         }
 

--- a/Source/HelixToolkit.Wpf/Helpers/GZipHelper.cs
+++ b/Source/HelixToolkit.Wpf/Helpers/GZipHelper.cs
@@ -22,7 +22,7 @@ public static class GZipHelper
         using (var infile = File.OpenRead(source))
         {
             input = new byte[infile.Length];
-            infile.Read(input, 0, input.Length);
+            _ = infile.Read(input, 0, input.Length);
         }
 
         var dest = Path.ChangeExtension(source, ext + "z");

--- a/Source/HelixToolkit/DefaultInterpolatedStringHandler.cs
+++ b/Source/HelixToolkit/DefaultInterpolatedStringHandler.cs
@@ -1,0 +1,47 @@
+﻿#if NET6_0_OR_GREATER
+#else
+using System.Text;
+#endif
+
+namespace System.Runtime.CompilerServices;
+
+#if NET6_0_OR_GREATER
+#else
+public ref struct DefaultInterpolatedStringHandler
+{
+    private readonly IFormatProvider? _provider;
+
+    private readonly StringBuilder _builder;
+
+    public DefaultInterpolatedStringHandler(int literalLength, int formattedCount)
+        : this(literalLength, formattedCount, null)
+    {
+    }
+
+    public DefaultInterpolatedStringHandler(int literalLength, int formattedCount, IFormatProvider? provider)
+    {
+        _provider = provider;
+        _builder = new();
+    }
+
+    public void AppendLiteral(string value)
+    {
+        _builder.Append(value);
+    }
+
+    public void AppendFormatted<T>(T value)
+    {
+        _builder.AppendFormat(_provider, "{0}", value);
+    }
+
+    public string ToStringAndClear()
+    {
+        return _builder.ToString();
+    }
+
+    public override string ToString()
+    {
+        return _builder.ToString();
+    }
+}
+#endif

--- a/Source/HelixToolkit/HelixToolkit.csproj
+++ b/Source/HelixToolkit/HelixToolkit.csproj
@@ -35,6 +35,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/HelixToolkit/NumericHelpers.cs
+++ b/Source/HelixToolkit/NumericHelpers.cs
@@ -1,0 +1,36 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace HelixToolkit;
+
+public static class NumericHelpers
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int ParseInt32(ReadOnlySpan<char> s, IFormatProvider? provider)
+    {
+#if NET8_0_OR_GREATER
+        return int.Parse(s, provider);
+#else
+        return int.Parse(s.ToString(), provider);
+#endif
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float ParseSingle(ReadOnlySpan<char> s, IFormatProvider? provider)
+    {
+#if NET8_0_OR_GREATER
+        return float.Parse(s, provider);
+#else
+        return float.Parse(s.ToString(), provider);
+#endif
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double ParseDouble(ReadOnlySpan<char> s, IFormatProvider? provider)
+    {
+#if NET8_0_OR_GREATER
+        return double.Parse(s, provider);
+#else
+        return double.Parse(s.ToString(), provider);
+#endif
+    }
+}

--- a/Source/HelixToolkit/TokenizerHelper.cs
+++ b/Source/HelixToolkit/TokenizerHelper.cs
@@ -70,7 +70,7 @@ public sealed class TokenizerHelper
         }
     }
 
-    public string? GetCurrentToken()
+    public ReadOnlySpan<char> GetCurrentToken()
     {
         // if no current token, return null 
         if (this.currentTokenIndex < 0)
@@ -78,7 +78,7 @@ public sealed class TokenizerHelper
             return null;
         }
 
-        return this.str.Substring(this.currentTokenIndex, this.currentTokenLength);
+        return this.str.AsSpan(this.currentTokenIndex, this.currentTokenLength);
     }
 
     /// <summary> 
@@ -105,7 +105,7 @@ public sealed class TokenizerHelper
     /// Advances to the NextToken, throwing an exception if not present
     /// </summary>
     /// <returns>The next token found</returns>
-    public string? NextTokenRequired()
+    public ReadOnlySpan<char> NextTokenRequired()
     {
         if (!NextToken(false))
         {
@@ -119,7 +119,7 @@ public sealed class TokenizerHelper
     /// Advances to the NextToken, throwing an exception if not present 
     /// </summary> 
     /// <returns>The next token found</returns>
-    public string? NextTokenRequired(bool allowQuotedToken)
+    public ReadOnlySpan<char> NextTokenRequired(bool allowQuotedToken)
     {
         if (!NextToken(allowQuotedToken))
         {


### PR DESCRIPTION
Hello,
I've improved the collections to reduce memory usage.
I've also fixed a few build errors.

The `Parse` methods use `ReadOnlySpan<char>`.
The `ConvertToString` methods use `DefaultInterpolatedStringHandler` of .Net 6.

Here are a few benchmarks:

| Method                                    | Mean        | Ratio | Allocated | Alloc Ratio |
|------------------------------------------ |------------:|------:|----------:|------------:|
| Color4Collection_ConvertToString_Current  |   953.30 μs |  1.00 |  354.5 KB |        1.00 |
| Color4Collection_ConvertToString_New      |   702.10 μs |  0.74 |  46.43 KB |        0.13 |
|                                           |             |       |           |             |
| Color4Collection_Parse_Current            | 1,268.30 μs |  1.00 | 275.27 KB |        1.00 |
| Color4Collection_Parse_New                | 1,233.80 μs |  0.97 |  64.64 KB |        0.23 |
|                                           |             |       |           |             |
| IntCollection_ConvertToString_Current     |   102.40 μs |  1.00 |  71.36 KB |        1.00 |
| IntCollection_ConvertToString_New         |    27.90 μs |  0.27 |   7.73 KB |        0.11 |
|                                           |             |       |           |             |
| IntCollection_Parse_Current               |   159.30 μs |  1.00 |  39.84 KB |        1.00 |
| IntCollection_Parse_New                   |   146.60 μs |  0.92 |   8.66 KB |        0.22 |
|                                           |             |       |           |             |
| Vector2Collection_ConvertToString_Current |   309.20 μs |  1.00 |  97.29 KB |        1.00 |
| Vector2Collection_ConvertToString_New     |   226.30 μs |  0.73 |  17.77 KB |        0.18 |
|                                           |             |       |           |             |
| Vector2Collection_Parse_Current           |   431.85 μs |  1.00 |  78.79 KB |        1.00 |
| Vector2Collection_Parse_New               |   407.00 μs |  0.94 |  16.65 KB |        0.21 |
|                                           |             |       |           |             |
| Vector3Collection_ConvertToString_Current |   451.90 μs |  1.00 | 130.16 KB |        1.00 |
| Vector3Collection_ConvertToString_New     |   332.90 μs |  0.74 |  27.54 KB |        0.21 |
|                                           |             |       |           |             |
| Vector3Collection_Parse_Current           |   605.20 μs |  1.00 |  118.3 KB |        1.00 |
| Vector3Collection_Parse_New               |   594.70 μs |  0.98 |  24.63 KB |        0.21 |
