### PR TITLE
[V3] Improve namespaces in SharpDX shared project

### DIFF
--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/Camera.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/Camera.cs
@@ -2,10 +2,13 @@
 using SharpDX;
 using System.Diagnostics;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/ICameraModel.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/ICameraModel.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Cameras;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/IOrthographicCameraModel.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/IOrthographicCameraModel.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public interface IOrthographicCameraModel : IProjectionCameraModel

--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/IPerspectiveCameraModel.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/IPerspectiveCameraModel.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public interface IPerspectiveCameraModel

--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/IProjectionCameraModel.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/IProjectionCameraModel.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public interface IProjectionCameraModel : ICameraModel

--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/OrthographicCamera.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/OrthographicCamera.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Cameras;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -127,10 +130,14 @@ public class OrthographicCamera : ProjectionCamera, IOrthographicCameraModel
         LookDirection = lookDir.ToVector3D();
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new OrthographicCamera();
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/PerspectiveCamera.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/PerspectiveCamera.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Cameras;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -61,10 +64,14 @@ public class PerspectiveCamera : ProjectionCamera, IPerspectiveCameraModel
         camera.NearPlaneDistance = (float)this.NearPlaneDistance;
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new PerspectiveCamera();
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Camera/ProjectionCamera.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Camera/ProjectionCamera.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Cameras;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/HelixItemsControl.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/HelixItemsControl.cs
@@ -1,22 +1,31 @@
-﻿#if WINUI
-#else
+﻿#if false
+#elif WINUI
+#elif WPF
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class HelixItemsControl : ItemsControl
 {
     public HelixItemsControl()
     {
-#if WINUI
+#if false
+#elif WINUI
         ManipulationMode = ManipulationModes.None;
-#else
+#elif WPF
         Focusable = false;
+#else
+#error Unknown framework
 #endif
         IsHitTestVisible = false;
         this.DefaultStyleKey = typeof(HelixItemsControl);

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/ModelContainer3DX.cs
@@ -10,15 +10,21 @@ using System.ComponentModel;
 using Device = SharpDX.Direct3D11.Device1;
 using DeviceContext = SharpDX.Direct3D11.DeviceContext1;
 
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Utilities;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -374,8 +380,12 @@ public class ModelContainer3DX : HelixItemsControl, IModelContainer
     /// The color of the clear.
     /// </value>
     /// <exception cref="NotImplementedException"></exception>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 ClearColor
     {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/CameraSetting.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/CameraSetting.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/ManipulationAction.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/ManipulationAction.cs
@@ -1,19 +1,29 @@
-﻿#if WINUI
-#else
+﻿#if false
+#elif WINUI
+#elif WPF
 using System.ComponentModel;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
 /// Specifies constants that define actions performed by manipulation.
 /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
 [TypeConverter(typeof(ManipulationActionConverter))]
+#else
+#error Unknown framework
 #endif
 public enum ManipulationAction
 {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/ManipulationActionExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/ManipulationActionExtensions.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public static class ManipulationActionExtensions

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/ManipulationBinding.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/ManipulationBinding.cs
@@ -1,13 +1,19 @@
 ﻿using System.Windows.Input;
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using System.ComponentModel;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -20,8 +26,12 @@ public class ManipulationBinding : InputBinding
     /// </summary>
     public int FingerCount => (this.Gesture as ManipulationGesture)?.FingerCount ?? 0;
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(ManipulationGestureConverter))]
+#else
+#error Unknown framework
 #endif
     public override InputGesture? Gesture
     {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/ManipulationEventArgs.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/MouseHandlers/ManipulationEventArgs.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Controls/Viewport3DX_Properties.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Controls/Viewport3DX_Properties.cs
@@ -1,20 +1,26 @@
 ﻿using HelixToolkit.SharpDX;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Elements2D;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Controls;
 using HelixToolkit.Wpf.SharpDX.Elements2D;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -487,12 +493,16 @@ public partial class Viewport3DX
                 }
             }));
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     /// <summary>
     /// The enable swap chain rendering property
     /// </summary>
     public static readonly DependencyProperty EnableSwapChainRenderingProperty
         = DependencyProperty.Register("EnableSwapChainRendering", typeof(bool), typeof(Viewport3DX), new PropertyMetadata(false));
+#else
+#error Unknown framework
 #endif
 
     /// <summary>
@@ -567,11 +577,15 @@ public partial class Viewport3DX
                 return;
             }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             if (viewport.hostPresenter != null && viewport.hostPresenter.Content is DPFSurfaceSwapChain surface)
             {
                 surface.IncreaseFPS = (bool)e.NewValue;
             }
+#else
+#error Unknown framework
 #endif
         }));
 
@@ -601,7 +615,8 @@ public partial class Viewport3DX
     public static readonly DependencyProperty InfoForegroundProperty = DependencyProperty.Register(
         "InfoForeground", typeof(Brush), typeof(Viewport3DX), new PropertyMetadata(new SolidColorBrush(UIColors.Blue)));
 
-#if WINUI
+#if false
+#elif WINUI
     /// <summary>
     /// The mouse input controller property
     /// </summary>
@@ -615,6 +630,9 @@ public partial class Viewport3DX
 
             viewport.CameraController.InputController = e.NewValue == null ? new InputController() : e.NewValue as InputController;
         }));
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
     /// <summary>
@@ -2214,7 +2232,9 @@ public partial class Viewport3DX
         }
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     /// <summary>
     /// <para>Use HwndHost as rendering surface, swapchain for rendering. Much faster than using D3DImage.</para> 
     /// <para>Drawbacks: The rendering surface will cover all WPF controls in the same Viewport region. Move controls out of viewport region to solve this problem.</para>
@@ -2232,6 +2252,8 @@ public partial class Viewport3DX
             return (bool)GetValue(EnableSwapChainRenderingProperty);
         }
     }
+#else
+#error Unknown framework
 #endif
 
     /// <summary>
@@ -2413,7 +2435,8 @@ public partial class Viewport3DX
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     /// <summary>
     /// Gets or sets the mouse input controller.
     /// </summary>
@@ -2431,6 +2454,9 @@ public partial class Viewport3DX
             return (InputController)GetValue(InputControllerProperty);
         }
     }
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
     /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Converters/BoolToVisibilityConverter.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Converters/BoolToVisibilityConverter.cs
@@ -1,23 +1,32 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Data;
-#else
+#elif WPF
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public sealed class BoolToVisibilityConverter : IValueConverter
 {
-#if WINUI
+#if false
+#elif WINUI
     public object? Convert(object? value, Type targetType, object? parameter, string language)
-#else
+#elif WPF
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+#else
+#error Unknown framework
 #endif
     {
         if (value is bool v)
@@ -30,10 +39,13 @@ public sealed class BoolToVisibilityConverter : IValueConverter
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     public object? ConvertBack(object? value, Type targetType, object? parameter, string language)
-#else
+#elif WPF
     public object? ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+#else
+#error Unknown framework
 #endif
     {
         if (value is Visibility v)

--- a/Source/HelixToolkit.SharpDX.SharedModel/Converters/EmptyStringToVisibilityConverter.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Converters/EmptyStringToVisibilityConverter.cs
@@ -1,15 +1,21 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Data;
-#else
+#elif WPF
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public sealed class EmptyStringToVisibilityConverter : IValueConverter
@@ -27,10 +33,13 @@ public sealed class EmptyStringToVisibilityConverter : IValueConverter
     /// </summary>
     public bool Inverted { get; set; }
 
-#if WINUI
+#if false
+#elif WINUI
     public object? Convert(object? value, Type targetType, object? parameter, string language)
-#else
+#elif WPF
     public object? Convert(object? value, Type targetType, object parameter, CultureInfo culture)
+#else
+#error Unknown framework
 #endif
     {
         if (targetType == typeof(Visibility) && value is string s)
@@ -47,10 +56,13 @@ public sealed class EmptyStringToVisibilityConverter : IValueConverter
         return null;
     }
 
-#if WINUI
+#if false
+#elif WINUI
     public object? ConvertBack(object? value, Type targetType, object? parameter, string language)
-#else
+#elif WPF
     public object ConvertBack(object? value, Type targetType, object parameter, CultureInfo culture)
+#else
+#error Unknown framework
 #endif
     {
         throw new NotImplementedException();

--- a/Source/HelixToolkit.SharpDX.SharedModel/Converters/NotNullToVisibilityConverter.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Converters/NotNullToVisibilityConverter.cs
@@ -1,22 +1,32 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Data;
-#else
+#elif WPF
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
 /// A not-null reference to Visibility value converter.
 /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
 [ValueConversion(typeof(object), typeof(Visibility))]
+#else
+#error Unknown framework
 #endif
 public sealed class NotNullToVisibilityConverter : IValueConverter
 {
@@ -33,10 +43,13 @@ public sealed class NotNullToVisibilityConverter : IValueConverter
     /// </summary>
     public bool Inverted { get; set; }
 
-#if WINUI
+#if false
+#elif WINUI
     public object? Convert(object? value, Type targetType, object? parameter, string language)
-#else
+#elif WPF
     public object? Convert(object? value, Type targetType, object parameter, CultureInfo culture)
+#else
+#error Unknown framework
 #endif
     {
         if (targetType == typeof(Visibility))
@@ -53,10 +66,13 @@ public sealed class NotNullToVisibilityConverter : IValueConverter
         return null;
     }
 
-#if WINUI
+#if false
+#elif WINUI
     public object? ConvertBack(object? value, Type targetType, object? parameter, string language)
-#else
+#elif WPF
     public object ConvertBack(object? value, Type targetType, object parameter, CultureInfo culture)
+#else
+#error Unknown framework
 #endif
     {
         throw new NotImplementedException();

--- a/Source/HelixToolkit.SharpDX.SharedModel/Extensions/CommonExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Extensions/CommonExtensions.cs
@@ -1,24 +1,31 @@
 ﻿using D2D = SharpDX.Direct2D1;
 using SharpDX.Mathematics.Interop;
 
-#if WINUI
+#if false
+#elif WINUI
 using Media = Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using System.Windows;
 using Media = System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Extensions;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Extensions;
+#else
+#error Unknown framework
 #endif
 
 public static class CommonExtensions
 {
     public static global::SharpDX.DirectWrite.FontWeight ToDXFontWeight(this FontWeight fontWeight)
     {
-#if WINUI
+#if false
+#elif WINUI
         var w = fontWeight.Weight;
         if (w == FontWeights.Black.Weight)
         {
@@ -64,7 +71,7 @@ public static class CommonExtensions
         {
             return global::SharpDX.DirectWrite.FontWeight.Normal;
         }
-#else
+#elif WPF
         if (fontWeight == FontWeights.Black)
         {
             return global::SharpDX.DirectWrite.FontWeight.Black;
@@ -133,12 +140,15 @@ public static class CommonExtensions
         {
             return global::SharpDX.DirectWrite.FontWeight.Normal;
         }
+#else
+#error Unknown framework
 #endif
     }
 
     public static global::SharpDX.DirectWrite.FontStyle ToDXFontStyle(this FontStyle style)
     {
-#if WINUI
+#if false
+#elif WINUI
         if (style == FontStyle.Italic)
         {
             return global::SharpDX.DirectWrite.FontStyle.Italic;
@@ -155,7 +165,7 @@ public static class CommonExtensions
         {
             return global::SharpDX.DirectWrite.FontStyle.Normal;
         }
-#else
+#elif WPF
         if (style == FontStyles.Italic)
         {
             return global::SharpDX.DirectWrite.FontStyle.Italic;
@@ -172,6 +182,8 @@ public static class CommonExtensions
         {
             return global::SharpDX.DirectWrite.FontStyle.Normal;
         }
+#else
+#error Unknown framework
 #endif
     }
 
@@ -215,7 +227,9 @@ public static class CommonExtensions
                 )
                 );
         }
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
         else if (brush is Media.RadialGradientBrush radial)
         {
             return new D2D.RadialGradientBrush(target,
@@ -234,6 +248,8 @@ public static class CommonExtensions
                     radial.SpreadMethod.ToD2DExtendMode()
                 ));
         }
+#else
+#error Unknown framework
 #endif
         else
         {
@@ -264,12 +280,13 @@ public static class CommonExtensions
         };
     }
 
-#if WINUI
+#if false
+#elif WINUI
     public static D2D.DashStyle ToD2DDashStyle(this D2D.DashStyle style)
     {
         return style;
     }
-#else
+#elif WPF
     public static D2D.DashStyle ToD2DDashStyle(this Media.DashStyle? style)
     {
         if (style is null)
@@ -298,6 +315,8 @@ public static class CommonExtensions
             return D2D.DashStyle.Solid;
         }
     }
+#else
+#error Unknown framework
 #endif
     public static global::SharpDX.DirectWrite.TextAlignment ToD2DTextAlignment(this TextAlignment alignment)
     {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Extensions/Geometry3DExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Extensions/Geometry3DExtensions.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Extensions/MaterialExtension.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Extensions/MaterialExtension.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public static class MaterialExtension

--- a/Source/HelixToolkit.SharpDX.SharedModel/Extensions/Media3DExtension.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Extensions/Media3DExtension.cs
@@ -2,10 +2,13 @@
 using SharpDX.Mathematics.Interop;
 using System.Runtime.CompilerServices;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public static class Media3DExtension
@@ -79,7 +82,9 @@ public static class Media3DExtension
         //return System.Windows.Media.Color.FromScRgb(color.Alpha, color.Red, color.Green, color.Blue);
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Vector3 ToVector3(this Point3D point)
     {
@@ -125,8 +130,10 @@ public static class Media3DExtension
         var matrix = trafo.Value;
         return new Vector4((float)matrix.OffsetX, (float)matrix.OffsetY, (float)matrix.OffsetZ, (float)matrix.M44);
     }
-
+#else
+#error Unknown framework
 #endif
+
     public static Matrix3x3 ToMatrix3x3(this UIMatrix m)
     {
         return new Matrix3x3((float)m.M11, (float)m.M12, 0, (float)m.M21, (float)m.M22, 0f, (float)m.OffsetX, (float)m.OffsetY, 1f);
@@ -136,7 +143,9 @@ public static class Media3DExtension
         return new Matrix3x2((float)m.M11, (float)m.M12, (float)m.M21, (float)m.M22, (float)m.OffsetX, (float)m.OffsetY);
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Matrix3D ToMatrix3D(this Matrix m)
     {
@@ -220,5 +229,7 @@ public static class Media3DExtension
         g.Children.Add(t1);
         return g;
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Extensions/TypeConvertExtensions.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Extensions/TypeConvertExtensions.cs
@@ -1,9 +1,12 @@
 ﻿using Scene2D = HelixToolkit.SharpDX.Model.Scene2D;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Extensions;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Extensions;
+#else
+#error Unknown framework
 #endif
 
 public static class TypeConvertExtensions
@@ -13,8 +16,12 @@ public static class TypeConvertExtensions
         return v switch
         {
             UIVisibility.Collapsed => Scene2D.Visibility.Collapsed,
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             UIVisibility.Hidden => Scene2D.Visibility.Hidden,
+#else
+#error Unknown framework
 #endif
             UIVisibility.Visible => Scene2D.Visibility.Visible,
             _ => Scene2D.Visibility.Visible,

--- a/Source/HelixToolkit.SharpDX.SharedModel/GlobalUsings.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/GlobalUsings.cs
@@ -6,7 +6,8 @@ global using Matrix3x2 = System.Numerics.Matrix3x2;
 global using Plane = System.Numerics.Plane;
 global using Quaternion = System.Numerics.Quaternion;
 global using HelixToolkit.Maths;
-#if WINUI
+#if false
+#elif WINUI
 global using Microsoft.UI.Text;
 global using Microsoft.UI.Xaml;
 global using Microsoft.UI.Xaml.Controls;
@@ -35,7 +36,7 @@ global using Freezable = Microsoft.UI.Xaml.DependencyObject;
 global using UIInputEventArgs = Microsoft.UI.Xaml.Input.PointerRoutedEventArgs;
 global using InputEventArgs = Microsoft.UI.Xaml.Input.PointerRoutedEventArgs;
 global using IRenderCanvas = HelixToolkit.WinUI.SharpDX.HelixToolkitRenderPanel;
-#else
+#elif WPF
 //global using System.Windows;
 //global using System.Windows.Controls;
 global using DependencyProperty = System.Windows.DependencyProperty;
@@ -65,4 +66,6 @@ global using FrameworkControl = System.Windows.FrameworkContentElement;
 global using Animatable = System.Windows.Media.Animation.Animatable;
 global using Freezable = System.Windows.Freezable;
 global using UIInputEventArgs = System.Windows.Input.InputEventArgs;
+#else
+#error Unknown framework
 #endif

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/Clickable2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/Clickable2D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
 using System.Diagnostics;
 using System.Windows.Input;
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public abstract class Clickable2D : Border2D
@@ -33,27 +39,39 @@ public abstract class Clickable2D : Border2D
     #endregion
 
     #region Events
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     public static readonly RoutedEvent Clicked2DEvent =
         EventManager.RegisterRoutedEvent("Clicked2D", RoutingStrategy.Bubble, typeof(Mouse2DRoutedEventHandler), typeof(Clickable2D));
 
     public static readonly RoutedEvent DoubleClicked2DEvent =
         EventManager.RegisterRoutedEvent("DoubleClicked2D", RoutingStrategy.Bubble, typeof(Mouse2DRoutedEventHandler), typeof(Clickable2D));
 
+#else
+#error Unknown framework
 #endif
 
     public event Mouse2DRoutedEventHandler Clicked2D
     {
         add
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             AddHandler(Clicked2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
         remove
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             RemoveHandler(Clicked2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
     }
@@ -62,21 +80,33 @@ public abstract class Clickable2D : Border2D
     {
         add
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             AddHandler(DoubleClicked2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
         remove
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             RemoveHandler(DoubleClicked2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
     }
     #endregion
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     private long lastClickedTime = 0;
+#else
+#error Unknown framework
 #endif
 
     public Clickable2D()
@@ -103,7 +133,9 @@ public abstract class Clickable2D : Border2D
 
     private void Clickable2D_MouseDown2D(object? sender, Mouse2DEventArgs e)
     {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
         if (e.InputArgs is TouchEventArgs || (e.InputArgs is MouseEventArgs m && m.LeftButton == MouseButtonState.Pressed))
         {
             long time = e.InputArgs.Timestamp;
@@ -124,6 +156,8 @@ public abstract class Clickable2D : Border2D
             }
             lastClickedTime = time;
         }
+#else
+#error Unknown framework
 #endif
     }
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ContentElement2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ContentElement2D.cs
@@ -1,7 +1,8 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene2D;
 using UIBindable = System.ComponentModel.BindableAttribute;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
 using HelixToolkit.WinUI.SharpDX.Extensions;
 using Microsoft.UI.Xaml.Data;
@@ -9,7 +10,7 @@ using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment;
 using VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
 using HelixToolkit.Wpf.SharpDX.Extensions;
 using System.Windows;
@@ -18,18 +19,26 @@ using System.Windows.Markup;
 using System.Windows.Media;
 using HorizontalAlignment = System.Windows.HorizontalAlignment;
 using VerticalAlignment = System.Windows.VerticalAlignment;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 [ContentProperty(Name = "Content2D")]
-#else
+#elif WPF
 [ContentProperty("Content2D")]
+#else
+#error Unknown framework
 #endif
 public abstract class ContentElement2D : Element2D
 {
@@ -80,8 +89,12 @@ public abstract class ContentElement2D : Element2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty BackgroundProperty
         = DependencyProperty.Register("Background", typeof(Brush), typeof(ContentElement2D),
@@ -95,8 +108,12 @@ public abstract class ContentElement2D : Element2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Brush Background
     {
@@ -110,15 +127,23 @@ public abstract class ContentElement2D : Element2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty ForegroundProperty
         = DependencyProperty.Register("Foreground", typeof(Brush), typeof(ContentElement2D),
     new PropertyMetadata(new SolidColorBrush(UIColors.Black)));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Brush Foreground
     {
@@ -132,8 +157,12 @@ public abstract class ContentElement2D : Element2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public HorizontalAlignment HorizontalContentAlignment
     {
@@ -147,8 +176,12 @@ public abstract class ContentElement2D : Element2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty HorizontalContentAlignmentProperty =
         DependencyProperty.Register("HorizontalContentAlignment", typeof(HorizontalAlignment), typeof(ContentElement2D),
@@ -160,8 +193,12 @@ public abstract class ContentElement2D : Element2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public VerticalAlignment VerticalContentAlignment
     {
@@ -175,8 +212,12 @@ public abstract class ContentElement2D : Element2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty VerticalContentAlignmentProperty =
         DependencyProperty.Register("VerticalContentAlignment", typeof(VerticalAlignment), typeof(ContentElement2D),

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/Element2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/Element2D.cs
@@ -1,19 +1,25 @@
 ﻿using HelixToolkit.SharpDX;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
 using HelixToolkit.WinUI.SharpDX.Extensions;
 using Media = Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
 using HelixToolkit.Wpf.SharpDX.Extensions;
 using System.Windows;
 using Media = System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
@@ -22,8 +28,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     /// <summary>
     /// 
     /// </summary>
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty VisibilityProperty =
         DependencyProperty.Register("Visibility", typeof(Visibility), typeof(Element2D), new PropertyMetadata(Visibility.Visible,
@@ -38,8 +48,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     /// <summary>
     /// 
     /// </summary>
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Visibility Visibility
     {
@@ -53,8 +67,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty IsHitTestVisibleProperty =
         DependencyProperty.Register("IsHitTestVisible", typeof(bool), typeof(Element2D), new PropertyMetadata(true,
@@ -66,8 +84,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public bool IsHitTestVisible
     {
@@ -84,8 +106,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     /// <summary>
     /// The is mouse over2 d property
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     new
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty IsMouseOverProperty =
         DependencyProperty.Register("IsMouseOver", typeof(bool), typeof(Element2D),
@@ -105,8 +131,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     /// <value>
     ///   <c>true</c> if this instance is mouse over2 d; otherwise, <c>false</c>.
     /// </value>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     new
+#else
+#error Unknown framework
 #endif
     public bool IsMouseOver
     {
@@ -120,8 +150,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty WidthProperty = DependencyProperty.Register("Width", typeof(double), typeof(Element2D),
         new PropertyMetadata(double.PositiveInfinity,
@@ -133,8 +167,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public double Width
     {
@@ -148,8 +186,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty HeightProperty = DependencyProperty.Register("Height", typeof(double), typeof(Element2D),
         new PropertyMetadata(double.PositiveInfinity,
@@ -161,8 +203,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public double Height
     {
@@ -264,8 +310,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public HorizontalAlignment HorizontalAlignment
     {
@@ -279,8 +329,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty HorizontalAlignmentProperty =
         DependencyProperty.Register("HorizontalAlignment", typeof(HorizontalAlignment), typeof(Element2D),
@@ -293,8 +347,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                     }
                 }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public VerticalAlignment VerticalAlignment
     {
@@ -308,8 +366,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty VerticalAlignmentProperty =
         DependencyProperty.Register("VerticalAlignment", typeof(VerticalAlignment), typeof(Element2D),
@@ -322,8 +384,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                     }
                 }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Thickness Margin
     {
@@ -337,8 +403,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty MarginProperty =
         DependencyProperty.Register("Margin", typeof(Thickness), typeof(Element2D), new PropertyMetadata(new Thickness(),
@@ -350,7 +420,8 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     public static readonly DependencyProperty TransformProperty =
         DependencyProperty.Register("Transform", typeof(Media.Transform), typeof(Element2D), new PropertyMetadata(new Media.MatrixTransform { Matrix = Media.Matrix.Identity }, (d, e) =>
         {
@@ -359,7 +430,7 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                 core.SceneNode.ModelMatrix = e.NewValue == null ? Matrix3x2.Identity : ((Media.MatrixTransform)e.NewValue).Matrix.ToMatrix3x2();
             }
         }));
-#else
+#elif WPF
     public static readonly DependencyProperty TransformProperty =
         DependencyProperty.Register("Transform", typeof(Media.Transform), typeof(Element2D), new PropertyMetadata(Media.Transform.Identity, (d, e) =>
         {
@@ -368,6 +439,8 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                 core.SceneNode.ModelMatrix = e.NewValue == null ? Matrix3x2.Identity : ((Media.Transform)e.NewValue).Value.ToMatrix3x2();
             }
         }));
+#else
+#error Unknown framework
 #endif
 
     /// <summary>
@@ -386,8 +459,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Point RenderTransformOrigin
     {
@@ -401,8 +478,12 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty RenderTransformOriginProperty =
         DependencyProperty.Register("RenderTransformOrigin", typeof(Point), typeof(Element2D), new PropertyMetadata(new Point(0.5, 0.5),
@@ -437,12 +518,13 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
                     }
                 }));
 
-    #endregion
+#endregion
 
     #region Events
     public delegate void Mouse2DRoutedEventHandler(object? sender, Mouse2DEventArgs e);
 
-#if WINUI
+#if false
+#elif WINUI
     public static readonly RoutedEvent MouseDown2DEvent = PointerPressedEvent;
 
     public static readonly RoutedEvent MouseUp2DEvent = PointerReleasedEvent;
@@ -452,7 +534,7 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     public static readonly RoutedEvent MouseEnter2DEvent = PointerEnteredEvent;
 
     public static readonly RoutedEvent MouseLeave2DEvent = PointerExitedEvent;
-#else
+#elif WPF
     public static readonly RoutedEvent MouseDown2DEvent =
         EventManager.RegisterRoutedEvent("MouseDown2D", RoutingStrategy.Bubble, typeof(Mouse2DRoutedEventHandler), typeof(Element2D));
 
@@ -467,20 +549,30 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
 
     public static readonly RoutedEvent MouseLeave2DEvent =
         EventManager.RegisterRoutedEvent("MouseLeave2D", RoutingStrategy.Bubble, typeof(Mouse2DRoutedEventHandler), typeof(Element2D));
+#else
+#error Unknown framework
 #endif
 
     public event Mouse2DRoutedEventHandler MouseDown2D
     {
         add
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             AddHandler(MouseDown2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
         remove
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             RemoveHandler(MouseDown2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
     }
@@ -489,14 +581,22 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     {
         add
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             AddHandler(MouseUp2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
         remove
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             RemoveHandler(MouseUp2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
     }
@@ -505,14 +605,22 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     {
         add
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             AddHandler(MouseMove2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
         remove
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             RemoveHandler(MouseMove2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
     }
@@ -521,14 +629,22 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     {
         add
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             AddHandler(MouseEnter2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
         remove
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             RemoveHandler(MouseEnter2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
     }
@@ -537,18 +653,26 @@ public abstract class Element2D : Element2DCore, ITransformable2D, IHitable2D
     {
         add
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             AddHandler(MouseLeave2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
         remove
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             RemoveHandler(MouseLeave2DEvent, value);
+#else
+#error Unknown framework
 #endif
         }
     }
-    #endregion
+#endregion
 
     public Element2D()
     {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/Mouse2DEventArgs.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/Mouse2DEventArgs.cs
@@ -1,24 +1,34 @@
 ﻿using HelixToolkit.SharpDX;
-#if WINUI
+#if false
+#elif WINUI
 using Microsoft.UI.Input;
-#else
+#elif WPF
 using System.Windows;
 using System.Windows.Input;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public class Mouse2DEventArgs : RoutedEventArgs
 {
-#if WINUI
+#if false
+#elif WINUI
     public RoutedEvent RoutedEvent
     {
         get; private set;
     }
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
     public HitTest2DResult? HitTest2DResult
@@ -42,12 +52,20 @@ public class Mouse2DEventArgs : RoutedEventArgs
     }
 
     public Mouse2DEventArgs(RoutedEvent routedEvent, object? source, HitTest2DResult? hitTestResult, Point position, Viewport3DX? viewport = null, InputEventArgs? inputArgs = null)
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
         : base(routedEvent, source)
+#else
+#error Unknown framework
 #endif
     {
-#if WINUI
+#if false
+#elif WINUI
         this.RoutedEvent = routedEvent;
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
         this.HitTest2DResult = hitTestResult;
@@ -57,12 +75,20 @@ public class Mouse2DEventArgs : RoutedEventArgs
     }
 
     public Mouse2DEventArgs(RoutedEvent routedEvent, object? source, Viewport3DX? viewport = null)
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
         : base(routedEvent, source)
+#else
+#error Unknown framework
 #endif
     {
-#if WINUI
+#if false
+#elif WINUI
         this.RoutedEvent = routedEvent;
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
         this.Viewport = viewport;

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/MoverButton2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/MoverButton2D.cs
@@ -1,14 +1,20 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using System.Windows;
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -19,9 +25,13 @@ public sealed class MoverButton2D : Button2D
 {
     static MoverButton2D()
     {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
         DefaultStyleKeyProperty.OverrideMetadata(
             typeof(MoverButton2D), new FrameworkPropertyMetadata(typeof(MoverButton2D)));
+#else
+#error Unknown framework
 #endif
     }
 
@@ -34,7 +44,8 @@ public sealed class MoverButton2D : Button2D
 
     private void SetDefaultStyle()
     {
-#if WINUI
+#if false
+#elif WINUI
         var backgroupUIColor = UIColors.Transparent;
         this.Background = new SolidColorBrush(backgroupUIColor);
 
@@ -44,18 +55,26 @@ public sealed class MoverButton2D : Button2D
         this.BorderThickness = new UIThickness(2, 2, 2, 2);
         this.BorderBrush = new SolidColorBrush(UIColor.FromArgb(255, 255, 125, 0));
         this.Margin = new Thickness(8, 8, 8, 8);
+#elif WPF
+#else
+#error Unknown framework
 #endif
     }
 
-#if WINUI
+#if false
+#elif WINUI
     private Brush? _previousBackgroundBrush;
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
     protected override void OnMouseOverChanged(bool newValue, bool oldValue)
     {
         base.OnMouseOverChanged(newValue, oldValue);
 
-#if WINUI
+#if false
+#elif WINUI
         if (newValue)
         {
             this._previousBackgroundBrush = this.Background;
@@ -70,6 +89,9 @@ public sealed class MoverButton2D : Button2D
                 this.Background = this._previousBackgroundBrush;
             }
         }
+#elif WPF
+#else
+#error Unknown framework
 #endif
     }
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ScreenSpaceMoveDirArgs.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ScreenSpaceMoveDirArgs.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public sealed class ScreenSpaceMoveDirArgs : EventArgs

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ScreenSpaceMoveDirection.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ScreenSpaceMoveDirection.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ScreenSpacePositionMover.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ScreenSpacePositionMover.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene2D;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -62,10 +65,13 @@ public class ScreenSpacePositionMover : ScreenSpacePositionMoverBase
 
         foreach (var b in buttons)
         {
-#if WINUI
+#if false
+#elif WINUI
             b.Visibility = UIVisibility.Collapsed;
-#else
+#elif WPF
             b.Visibility = UIVisibility.Hidden;
+#else
+#error Unknown framework
 #endif
             Children.Add(b);
         }
@@ -119,10 +125,13 @@ public class ScreenSpacePositionMover : ScreenSpacePositionMoverBase
                 {
                     foreach (Button2D b in Buttons)
                     {
-#if WINUI
+#if false
+#elif WINUI
                         b.Visibility = UIVisibility.Collapsed;
-#else
+#elif WPF
                         b.Visibility = UIVisibility.Hidden;
+#else
+#error Unknown framework
 #endif
                     }
                 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ScreenSpacePositionMoverBase.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ScreenSpacePositionMoverBase.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene2D;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ShapeModel2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Abstract/ShapeModel2D.cs
@@ -1,21 +1,27 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene2D;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
 using HelixToolkit.WinUI.SharpDX.Extensions;
 using Microsoft.UI.Xaml.Media;
 using DashStyle = SharpDX.Direct2D1.DashStyle;
 using DashStyles = SharpDX.Direct2D1.DashStyle;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
 using HelixToolkit.Wpf.SharpDX.Extensions;
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public abstract class ShapeModel2D : Element2D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Border2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Border2D.cs
@@ -1,31 +1,41 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene2D;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
 using HelixToolkit.WinUI.SharpDX.Extensions;
 using Microsoft.UI.Xaml.Media;
 using Thickness = Microsoft.UI.Xaml.Thickness;
 using DashStyle = SharpDX.Direct2D1.DashStyle;
 using DashStyles = SharpDX.Direct2D1.DashStyle;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
 using HelixToolkit.Wpf.SharpDX.Extensions;
 using System.Windows.Media;
 using Thickness = System.Windows.Thickness;
 using DashStyle = System.Windows.Media.DashStyle;
 using DashStyles = System.Windows.Media.DashStyles;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public class Border2D : ContentElement2D
 {
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public double CornerRadius
     {
@@ -39,8 +49,12 @@ public class Border2D : ContentElement2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty CornerRadiusProperty =
         DependencyProperty.Register("CornerRadius", typeof(double), typeof(Border2D), new PropertyMetadata(0.0,
@@ -52,8 +66,12 @@ public class Border2D : ContentElement2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Thickness Padding
     {
@@ -67,8 +85,12 @@ public class Border2D : ContentElement2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty PaddingProperty =
         DependencyProperty.Register("Padding", typeof(Thickness), typeof(Border2D), new PropertyMetadata(new Thickness(0, 0, 0, 0),
@@ -81,8 +103,12 @@ public class Border2D : ContentElement2D
             }));
 
     #region Stroke properties
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty BorderBrushProperty
         = DependencyProperty.Register("BorderBrush", typeof(Brush), typeof(Border2D), new PropertyMetadata(new SolidColorBrush(UIColors.Black),
@@ -94,8 +120,12 @@ public class Border2D : ContentElement2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Brush BorderBrush
     {
@@ -263,8 +293,12 @@ public class Border2D : ContentElement2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty BorderThicknessProperty
         = DependencyProperty.Register("BorderThickness", typeof(Thickness), typeof(Border2D),
@@ -276,8 +310,12 @@ public class Border2D : ContentElement2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Thickness BorderThickness
     {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Button2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Button2D.cs
@@ -1,30 +1,44 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using System.Windows;
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public class Button2D : Clickable2D
 {
     static Button2D()
     {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
         DefaultStyleKeyProperty.OverrideMetadata(
             typeof(Button2D), new FrameworkPropertyMetadata(typeof(Button2D)));
+#else
+#error Unknown framework
 #endif
     }
 
     public Button2D()
     {
-#if WINUI
+#if false
+#elif WINUI
         DefaultStyleKey = typeof(Button2D);
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
         SetDefaultStyle();
@@ -32,7 +46,8 @@ public class Button2D : Clickable2D
 
     private void SetDefaultStyle()
     {
-#if WINUI
+#if false
+#elif WINUI
         var backgroupColor = System.Drawing.SystemColors.ControlDark;
         var backgroupUIColor = UIColor.FromArgb(backgroupColor.A, backgroupColor.R, backgroupColor.G, backgroupColor.B);
         this.Background = new SolidColorBrush(backgroupUIColor);
@@ -43,18 +58,26 @@ public class Button2D : Clickable2D
 
         this.CornerRadius = 2;
         this.BorderThickness = new UIThickness(0, 0, 0, 0);
+#elif WPF
+#else
+#error Unknown framework
 #endif
     }
 
-#if WINUI
+#if false
+#elif WINUI
     private Brush? _previousBackgroundBrush;
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
     protected override void OnMouseOverChanged(bool newValue, bool oldValue)
     {
         base.OnMouseOverChanged(newValue, oldValue);
 
-#if WINUI
+#if false
+#elif WINUI
         if (newValue)
         {
             this._previousBackgroundBrush = this.Background;
@@ -70,6 +93,9 @@ public class Button2D : Clickable2D
                 this.Background = this._previousBackgroundBrush;
             }
         }
+#elif WPF
+#else
+#error Unknown framework
 #endif
     }
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Canvas2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Canvas2D.cs
@@ -1,14 +1,20 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/ContentPresenter2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/ContentPresenter2D.cs
@@ -1,23 +1,32 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
 using System.ComponentModel;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
 using Microsoft.UI.Xaml.Markup;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
 using System.Windows.Markup;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 [ContentProperty(Name = "Content")]
-#else
+#elif WPF
 [ContentProperty("Content")]
+#else
+#error Unknown framework
 #endif
 public class ContentPresenter2D : Element2D
 {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Element2DCore.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Element2DCore.cs
@@ -2,10 +2,13 @@
 using HelixToolkit.SharpDX.Model.Scene2D;
 using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Core2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Core2D;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -84,7 +87,8 @@ public abstract partial class Element2DCore : FrameworkControl, IDisposable
 
     private void SceneNode_OnDetached(object? sender, EventArgs e)
     {
-#if WINUI
+#if false
+#elif WINUI
         if (Dispatcher != null)
         {
             if (Dispatcher.HasThreadAccess)
@@ -93,7 +97,7 @@ public abstract partial class Element2DCore : FrameworkControl, IDisposable
             }
         }
 
-#else
+#elif WPF
         if (this.Dispatcher != null && this.Dispatcher.Thread.IsAlive)
         {
             if (this.Dispatcher.CheckAccess())
@@ -105,6 +109,8 @@ public abstract partial class Element2DCore : FrameworkControl, IDisposable
                 Dispatcher.Invoke(() => { OnDetached(); });
             }
         }
+#else
+#error Unknown framework
 #endif
     }
 
@@ -156,16 +162,24 @@ public abstract partial class Element2DCore : FrameworkControl, IDisposable
         SceneNode.InvalidateRender();
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public void InvalidateMeasure()
     {
         SceneNode.InvalidateMeasure();
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public void InvalidateArrange()
     {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/EllipseModel2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/EllipseModel2D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public class EllipseModel2D : ShapeModel2D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/FrameStatisticsModel2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/FrameStatisticsModel2D.cs
@@ -1,24 +1,34 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene2D;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Extensions;
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Extensions;
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public class FrameStatisticsModel2D : Element2D
 {
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty ForegroundProperty
         = DependencyProperty.Register("Foreground", typeof(Brush), typeof(FrameStatisticsModel2D),
@@ -30,8 +40,12 @@ public class FrameStatisticsModel2D : Element2D
         }
     }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Brush? Foreground
     {
@@ -45,8 +59,12 @@ public class FrameStatisticsModel2D : Element2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty BackgroundProperty
         = DependencyProperty.Register("Background", typeof(Brush), typeof(FrameStatisticsModel2D),
@@ -58,8 +76,12 @@ public class FrameStatisticsModel2D : Element2D
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Brush? Background
     {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/IBackground.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/IBackground.cs
@@ -1,13 +1,19 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public interface IBackground

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/ITextBlock.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/ITextBlock.cs
@@ -1,13 +1,19 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public interface ITextBlock : IBackground

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/ITransformable2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/ITransformable2D.cs
@@ -1,13 +1,19 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public interface ITransformable2D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/ImageModel2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/ImageModel2D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
 using System.IO;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -56,10 +62,13 @@ public class ImageModel2D : Element2D
     /// <value>
     /// The opacity.
     /// </value>
-#if WINUI
+#if false
+#elif WINUI
     public new double Opacity
-#else
+#elif WPF
     public double Opacity
+#else
+#error Unknown framework
 #endif
     {
         get
@@ -75,10 +84,13 @@ public class ImageModel2D : Element2D
     /// <summary>
     /// The opacity property
     /// </summary>
-#if WINUI
+#if false
+#elif WINUI
     public static readonly new DependencyProperty OpacityProperty =
-#else
+#elif WPF
     public static readonly DependencyProperty OpacityProperty =
+#else
+#error Unknown framework
 #endif
     DependencyProperty.Register("Opacity", typeof(double), typeof(ImageModel2D), new PropertyMetadata(1.0, (d, e) =>
         {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Overlay.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Overlay.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 internal sealed class Overlay : Panel2D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Panel2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/Panel2D.cs
@@ -2,30 +2,43 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-#if WINUI
+#if false
+#elif WINUI
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using System.Windows.Markup;
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 [ContentProperty(Name = "Children")]
-#else
+#elif WPF
 [ContentProperty("Children")]
+#else
+#error Unknown framework
 #endif
 public class Panel2D : Element2D
 {
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Brush Background
     {
@@ -39,8 +52,12 @@ public class Panel2D : Element2D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty BackgroundProperty =
         DependencyProperty.Register("Background", typeof(Brush), typeof(Panel2D), new PropertyMetadata(new SolidColorBrush(Colors.Transparent)));

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/RectangleModel2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/RectangleModel2D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public class RectangleModel2D : ShapeModel2D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/RelativePositionCanvas2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/RelativePositionCanvas2D.cs
@@ -1,14 +1,20 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/StackPanel2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/StackPanel2D.cs
@@ -1,14 +1,20 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene2D;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Extensions;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Extensions;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
 public class StackPanel2D : Panel2D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/TextModel2D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements2D/TextModel2D.cs
@@ -1,29 +1,38 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene2D;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Core2D;
 using HelixToolkit.WinUI.SharpDX.Extensions;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Core2D;
 using HelixToolkit.Wpf.SharpDX.Extensions;
 using System.Windows;
 using System.Windows.Markup;
 using System.Windows.Media;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 [ContentProperty(Name = "Text")]
-#else
+#elif WPF
 [ContentProperty("Text")]
+#else
+#error Unknown framework
 #endif
 public class TextModel2D : Element2D, ITextBlock
 {
@@ -51,9 +60,12 @@ public class TextModel2D : Element2D, ITextBlock
         }
     }
 
-
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty ForegroundProperty
         = DependencyProperty.Register("Foreground", typeof(Brush), typeof(TextModel2D),
@@ -65,8 +77,12 @@ public class TextModel2D : Element2D, ITextBlock
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Brush Foreground
     {
@@ -80,8 +96,12 @@ public class TextModel2D : Element2D, ITextBlock
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty BackgroundProperty
         = DependencyProperty.Register("Background", typeof(Brush), typeof(TextModel2D),
@@ -93,8 +113,12 @@ public class TextModel2D : Element2D, ITextBlock
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public Brush Background
     {
@@ -108,8 +132,12 @@ public class TextModel2D : Element2D, ITextBlock
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty FontSizeProperty
         = DependencyProperty.Register("FontSize", typeof(int), typeof(TextModel2D),
@@ -121,8 +149,12 @@ public class TextModel2D : Element2D, ITextBlock
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public int FontSize
     {
@@ -136,8 +168,12 @@ public class TextModel2D : Element2D, ITextBlock
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty FontWeightProperty
         = DependencyProperty.Register("FontWeight", typeof(FontWeight), typeof(TextModel2D),
@@ -149,8 +185,12 @@ public class TextModel2D : Element2D, ITextBlock
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public FontWeight FontWeight
     {
@@ -164,8 +204,12 @@ public class TextModel2D : Element2D, ITextBlock
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty FontStyleProperty
         = DependencyProperty.Register("FontStyle", typeof(UIFontStyle), typeof(TextModel2D),
@@ -177,8 +221,12 @@ public class TextModel2D : Element2D, ITextBlock
                 }
             }));
 
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public FontStyle FontStyle
     {
@@ -229,10 +277,13 @@ public class TextModel2D : Element2D, ITextBlock
     /// <value>
     /// The text alignment.
     /// </value>
-#if WINUI
+#if false
+#elif WINUI
     public new FlowDirection FlowDirection
-#else
+#elif WPF
     public FlowDirection FlowDirection
+#else
+#error Unknown framework
 #endif
     {
         get
@@ -248,10 +299,13 @@ public class TextModel2D : Element2D, ITextBlock
     /// <summary>
     /// The text alignment property
     /// </summary>
-#if WINUI
+#if false
+#elif WINUI
     public static readonly new DependencyProperty FlowDirectionProperty =
-#else
+#elif WPF
     public static readonly DependencyProperty FlowDirectionProperty =
+#else
+#error Unknown framework
 #endif
         DependencyProperty.Register("FlowDirection", typeof(FlowDirection), typeof(TextModel2D), new PropertyMetadata(FlowDirection.LeftToRight, (d, e) =>
         {
@@ -268,8 +322,12 @@ public class TextModel2D : Element2D, ITextBlock
     /// <value>
     /// The font family.
     /// </value>
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public string? FontFamily
     {
@@ -285,8 +343,12 @@ public class TextModel2D : Element2D, ITextBlock
     /// <summary>
     /// The font family property
     /// </summary>
-#if WINUI
+#if false
+#elif WINUI
     new
+#elif WPF
+#else
+#error Unknown framework
 #endif
     public static readonly DependencyProperty FontFamilyProperty =
         DependencyProperty.Register("FontFamily", typeof(string), typeof(TextModel2D), new PropertyMetadata(DefaultFont, (d, e) =>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/BoundChangedEventArgs.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/BoundChangedEventArgs.cs
@@ -1,9 +1,12 @@
 ﻿using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/Element3DCore.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/Element3DCore.cs
@@ -2,10 +2,13 @@
 using HelixToolkit.SharpDX.Model.Scene;
 using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/GeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/GeometryModel3D.cs
@@ -4,16 +4,22 @@ using HelixToolkit.SharpDX.Model.Scene;
 using SharpDX.Direct3D11;
 using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/MaterialGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/MaterialGeometryModel3D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/Mouse3DEventArgs.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/Mouse3DEventArgs.cs
@@ -1,18 +1,28 @@
 ﻿using HelixToolkit.SharpDX;
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public abstract class Mouse3DEventArgs
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     : RoutedEventArgs
+#else
+#error Unknown framework
 #endif
 {
     public HitTestResult? HitTestResult { get; private set; }
@@ -31,21 +41,32 @@ public abstract class Mouse3DEventArgs
         get; private set;
     }
 
-#if WINUI
+#if false
+#elif WINUI
     private bool handled;
+#elif WPF
+#else
+#error Unknown framework
 #endif
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     new
+#else
+#error Unknown framework
 #endif
     public bool Handled
     { // not overridable
         get
         {
-#if WINUI
+#if false
+#elif WINUI
             return handled;
-#else
+#elif WPF
             return base.Handled;
+#else
+#error Unknown framework
 #endif
         }
         set
@@ -53,19 +74,25 @@ public abstract class Mouse3DEventArgs
             if (OriginalInputEventArgs != null)
                 OriginalInputEventArgs.Handled = value; // ensuring that the original input event is also marked as Handled
 
-#if WINUI
+#if false
+#elif WINUI
             handled = value;
-#else
+#elif WPF
             base.Handled = value;
+#else
+#error Unknown framework
 #endif
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     public Mouse3DEventArgs(HitTestResult? hitTestResult, Point position, Viewport3DX? viewport = null, UIInputEventArgs? originalInputEventArgs = null)
-#else
+#elif WPF
     public Mouse3DEventArgs(RoutedEvent routedEvent, object? source, HitTestResult? hitTestResult, Point position, Viewport3DX? viewport = null, UIInputEventArgs? originalInputEventArgs = null)
         : base(routedEvent, source)
+#else
+#error Unknown framework
 #endif
     {
         this.HitTestResult = hitTestResult;

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/MouseDown3DEventArgs.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/MouseDown3DEventArgs.cs
@@ -1,19 +1,25 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class MouseDown3DEventArgs : Mouse3DEventArgs
 {
-#if WINUI
+#if false
+#elif WINUI
     public MouseDown3DEventArgs(HitTestResult? hitTestResult, Point position, Viewport3DX? viewport = null, UIInputEventArgs? originalInputEventArgs = null)
         : base(hitTestResult, position, viewport, originalInputEventArgs)
-#else
+#elif WPF
     public MouseDown3DEventArgs(object? source, HitTestResult? hitTestResult, Point position, Viewport3DX? viewport = null, UIInputEventArgs? originalInputEventArgs = null)
         : base(Element3D.MouseDown3DEvent, source, hitTestResult, position, viewport, originalInputEventArgs)
+#else
+#error Unknown framework
 #endif
     {
     }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/MouseMove3DEventArgs.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/MouseMove3DEventArgs.cs
@@ -1,19 +1,25 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class MouseMove3DEventArgs : Mouse3DEventArgs
 {
-#if WINUI
+#if false
+#elif WINUI
     public MouseMove3DEventArgs(HitTestResult? hitTestResult, Point position, Viewport3DX? viewport = null, UIInputEventArgs? originalInputEventArgs = null)
         : base(hitTestResult, position, viewport, originalInputEventArgs)
-#else
+#elif WPF
     public MouseMove3DEventArgs(object? source, HitTestResult? hitTestResult, Point position, Viewport3DX? viewport = null, UIInputEventArgs? originalInputEventArgs = null)
         : base(Element3D.MouseMove3DEvent, source, hitTestResult, position, viewport, originalInputEventArgs)
+#else
+#error Unknown framework
 #endif
     {
     }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/MouseUp3DEventArgs.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Abstract/MouseUp3DEventArgs.cs
@@ -1,19 +1,25 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class MouseUp3DEventArgs : Mouse3DEventArgs
 {
-#if WINUI
+#if false
+#elif WINUI
     public MouseUp3DEventArgs(HitTestResult? hitTestResult, Point position, Viewport3DX? viewport = null, UIInputEventArgs? originalInputEventArgs = null)
         : base(hitTestResult, position, viewport, originalInputEventArgs)
-#else
+#elif WPF
     public MouseUp3DEventArgs(object? source, HitTestResult? hitTestResult, Point position, Viewport3DX? viewport = null, UIInputEventArgs? originalInputEventArgs = null)
         : base(Element3D.MouseUp3DEvent, source, hitTestResult, position, viewport, originalInputEventArgs)
+#else
+#error Unknown framework
 #endif
     {
     }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/AxisPlaneGridModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/AxisPlaneGridModel3D.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/BatchedMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/BatchedMeshGeometryModel3D.cs
@@ -4,16 +4,22 @@ using HelixToolkit.SharpDX.Core;
 using HelixToolkit.SharpDX.Model;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/BillboardTextModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/BillboardTextModel3D.cs
@@ -3,16 +3,22 @@ using HelixToolkit.SharpDX.Model.Scene;
 using HelixToolkit.SharpDX.Shaders;
 using SharpDX.Direct3D11;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/BoneGroupModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/BoneGroupModel3D.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/BoneSkinMeshGeometryModel3D.cs
@@ -2,16 +2,22 @@
 using HelixToolkit.SharpDX.Model.Scene;
 using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/CompositeModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/CompositeModel3D.cs
@@ -1,26 +1,35 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 using System.Collections.Specialized;
-#if WINUI
+#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Markup;
-#else
+#elif WPF
 using System.Windows;
 using System.Windows.Markup;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
 ///     Represents a composite Model3D.
 /// </summary>
-#if WINUI
+#if false
+#elif WINUI
 [ContentProperty(Name = "Children")]
-#else
+#elif WPF
 [ContentProperty("Children")]
+#else
+#error Unknown framework
 #endif
 public class CompositeModel3D : Element3D, IHitable, ISelectable, IMouse3D
 {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ContinuousRender3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ContinuousRender3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/CoordinateSystemModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/CoordinateSystemModel3D.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/CrossSectionMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/CrossSectionMeshGeometryModel3D.cs
@@ -2,16 +2,22 @@
 using HelixToolkit.SharpDX.Model.Scene;
 using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -56,11 +62,7 @@ public class CrossSectionMeshGeometryModel3D : MeshGeometryModel3D
     /// Defines the CrossSectionColorProperty
     /// </summary>
     public static readonly DependencyProperty CrossSectionColorProperty = DependencyProperty.Register("CrossSectionColor", typeof(UIColor), typeof(CrossSectionMeshGeometryModel3D),
-#if WINUI
-            new PropertyMetadata(Microsoft.UI.Colors.Firebrick,
-#else
                 new PropertyMetadata(UIColors.Firebrick,
-#endif
        (d, e) =>
        {
            if (d is Element3DCore { SceneNode: CrossSectionMeshNode node })

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/DepthPrepassElement3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/DepthPrepassElement3D.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/DynamicCodeSurfaceModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/DynamicCodeSurfaceModel3D.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 using System.CodeDom.Compiler;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class DynamicCodeSurfaceModel3D : MeshGeometryModel3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/DynamicReflectionMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/DynamicReflectionMap3D.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX.Core;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class DynamicReflectionMap3D : GroupModel3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Element3DPresenter.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Element3DPresenter.cs
@@ -1,21 +1,30 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
-#if WINUI
+#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Markup;
-#else
+#elif WPF
 using System.Windows;
 using System.Windows.Markup;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 [ContentProperty(Name = "Content")]
-#else
+#elif WPF
 [ContentProperty("Content")]
+#else
+#error Unknown framework
 #endif
 public class Element3DPresenter : Element3D
 {
@@ -76,9 +85,13 @@ public class Element3DPresenter : Element3D
     {
         if (Content != null)
         {
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
             RemoveLogicalChild(Content);
             AddLogicalChild(Content);
+#else
+#error Unknown framework
 #endif
         }
     }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/EnvironmentMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/EnvironmentMap3D.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/GroupModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/GroupModel3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/InstancingBillboardModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/InstancingBillboardModel3D.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/InstancingMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/InstancingMeshGeometryModel3D.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class InstancingMeshGeometryModel3D : MeshGeometryModel3D
@@ -39,13 +45,14 @@ public class InstancingMeshGeometryModel3D : MeshGeometryModel3D
                 return;
             }
 
-#if WINUI
+#if false
+#elif WINUI
             d.AttachChild(null);
             if(e.NewValue is Element3D elem)
             {
                 d.AttachChild(elem);
             }
-#else
+#elif WPF
             if (e.OldValue != null)
             {
                 d.RemoveLogicalChild(e.OldValue);
@@ -55,6 +62,8 @@ public class InstancingMeshGeometryModel3D : MeshGeometryModel3D
             {
                 d.AddLogicalChild(e.NewValue);
             }
+#else
+#error Unknown framework
 #endif
             if (d.SceneNode is InstancingMeshNode node)
             {
@@ -124,7 +133,8 @@ public class InstancingMeshGeometryModel3D : MeshGeometryModel3D
         return new InstancingMeshNode();
     }
 
-#if WINUI
+#if false
+#elif WINUI
     protected override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
@@ -133,5 +143,8 @@ public class InstancingMeshGeometryModel3D : MeshGeometryModel3D
             AttachChild(elem);
         }
     }
+#elif WPF
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Light3DCollection.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/Light3DCollection.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class Light3DCollection : GroupElement3D, ILight3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/LineGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/LineGeometryModel3D.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX.Model;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/LineMaterialGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/LineMaterialGeometryModel3D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class LineMaterialGeometryModel3D : GeometryModel3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/MeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/MeshGeometryModel3D.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 using SharpDX.Direct3D11;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ObservableElement2DCollection.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ObservableElement2DCollection.cs
@@ -2,16 +2,22 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Elements2D;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Elements2D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class ObservableElement2DCollection : ObservableCollection<Element2D>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ObservableElement3DCollection.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ObservableElement3DCollection.cs
@@ -2,10 +2,13 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/OctreeLineGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/OctreeLineGeometryModel3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class OctreeLineGeometryModel3D : CompositeModel3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/OutLineMeshGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/OutLineMeshGeometryModel3D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class OutLineMeshGeometryModel3D : MeshGeometryModel3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ParticleStormModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ParticleStormModel3D.cs
@@ -5,18 +5,24 @@ using static HelixToolkit.SharpDX.Core.ParticleRenderCore;
 using SharpDX;
 using SharpDX.Direct3D11;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
 using System.Windows;
 using Rect3D = System.Windows.Media.Media3D.Rect3D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class ParticleStormModel3D : Element3D
@@ -91,7 +97,8 @@ public class ParticleStormModel3D : Element3D
         }
     }
 
-#if WINUI
+#if false
+#elif WINUI
     public static readonly DependencyProperty ParticleBoundsProperty = DependencyProperty.Register("ParticleBounds", typeof(BoundingBox), typeof(ParticleStormModel3D),
         new PropertyMetadata(new BoundingBox(new Vector3(-50, -50, -50), new Vector3(50, 50, 50)),
         (d, e) =>
@@ -115,7 +122,7 @@ public class ParticleStormModel3D : Element3D
             return (BoundingBox)GetValue(ParticleBoundsProperty);
         }
     }
-#else
+#elif WPF
     public static readonly DependencyProperty ParticleBoundsProperty = DependencyProperty.Register("ParticleBounds", typeof(Rect3D), typeof(ParticleStormModel3D),
     new PropertyMetadata(new Rect3D(0, 0, 0, 100, 100, 100),
         (d, e) =>
@@ -139,6 +146,8 @@ public class ParticleStormModel3D : Element3D
             return (Rect3D)GetValue(ParticleBoundsProperty);
         }
     }
+#else
+#error Unknown framework
 #endif
 
     public static readonly DependencyProperty EmitterRadiusProperty = DependencyProperty.Register("EmitterRadius", typeof(double), typeof(ParticleStormModel3D),
@@ -782,18 +791,21 @@ public class ParticleStormModel3D : Element3D
             c.DestAlphaBlend = DestAlphaBlend;
             c.SampleMask = SampleMask;
             c.BlendColor = BlendColor.ToColor4();
-#if WINUI
+#if false
+#elif WINUI
             c.EmitterLocation = EmitterLocation;
             c.ConsumerLocation = ConsumerLocation;
             c.InitAcceleration = Acceleration;
             c.DomainBoundMax = ParticleBounds.Maximum;
             c.DomainBoundMin = ParticleBounds.Minimum;
-#else
+#elif WPF
             c.EmitterLocation = EmitterLocation.ToVector3();
             c.ConsumerLocation = ConsumerLocation.ToVector3();
             c.InitAcceleration = Acceleration.ToVector3();
             c.DomainBoundMax = new Vector3((float)(ParticleBounds.SizeX / 2 + ParticleBounds.Location.X), (float)(ParticleBounds.SizeY / 2 + ParticleBounds.Location.Y), (float)(ParticleBounds.SizeZ / 2 + ParticleBounds.Location.Z));
             c.DomainBoundMin = new Vector3((float)(ParticleBounds.Location.X - ParticleBounds.SizeX / 2), (float)(ParticleBounds.Location.Y - ParticleBounds.SizeY / 2), (float)(ParticleBounds.Location.Z - ParticleBounds.SizeZ / 2));
+#else
+#error Unknown framework
 #endif
         }
     }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PointGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PointGeometryModel3D.cs
@@ -2,15 +2,21 @@
 using HelixToolkit.SharpDX.Model;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PointMaterialGeometryModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PointMaterialGeometryModel3D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class PointMaterialGeometryModel3D : GeometryModel3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectBloom.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectBloom.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectMeshBorderHighlight.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectMeshBorderHighlight.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectMeshOutlineBlur.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectMeshOutlineBlur.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectMeshXRay.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectMeshXRay.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if fals
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectMeshXRayGrid.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/PostEffects/PostEffectMeshXRayGrid.cs
@@ -1,16 +1,22 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/SceneNodeGroupModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/SceneNodeGroupModel3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ScreenDuplicationModel.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ScreenDuplicationModel.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ScreenQuadModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ScreenQuadModel3D.cs
@@ -3,22 +3,32 @@ using HelixToolkit.SharpDX.Model.Scene;
 using HelixToolkit.SharpDX.Shaders;
 using SharpDX.Direct3D11;
 
-#if WINUI
+#if false
+#elif WINUI
 using System.Runtime.Versioning;
+#elif WPF
 #else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
 /// 
 /// </summary>
-#if WINUI
+#if false
+#elif WINUI
 [SupportedOSPlatform("windows")]
+#elif WPF
+#else
+#error Unknown framework
 #endif
 public class ScreenQuadModel3D : Element3D
 {

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ScreenSpacedElement3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ScreenSpacedElement3D.cs
@@ -1,20 +1,26 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Elements2D;
 using HelixToolkit.WinUI.SharpDX.Model;
 using Microsoft.UI.Xaml.Data;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Elements2D;
 using HelixToolkit.Wpf.SharpDX.Model;
 using System.Windows;
 using System.Windows.Data;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ScreenSpacedGroup3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ScreenSpacedGroup3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/SortingGroupModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/SortingGroupModel3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class SortingGroupModel3D : GroupModel3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/TopMostGroup3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/TopMostGroup3D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/TransformManipulator3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/TransformManipulator3D.cs
@@ -5,17 +5,23 @@ using SharpDX;
 using SharpDX.Direct3D11;
 using System.Diagnostics;
 
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Utilities;
 using System.ComponentModel;
 using Media3D = System.Windows.Media.Media3D;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class TransformManipulator3D : GroupElement3D
@@ -354,9 +360,12 @@ public class TransformManipulator3D : GroupElement3D
             }
         }));
 
-
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Vector3Converter))]
+#else
+#error Unknown framework
 #endif
     public Vector3 CenterOffset
     {
@@ -401,7 +410,7 @@ public class TransformManipulator3D : GroupElement3D
             }
         }));
 
-    #endregion
+#endregion
     #region Variables
     private readonly MeshGeometryModel3D translationX, translationY, translationZ;
     private readonly MeshGeometryModel3D rotationX, rotationY, rotationZ;
@@ -442,12 +451,15 @@ public class TransformManipulator3D : GroupElement3D
         translationY = new MeshGeometryModel3D() { Geometry = TranslationXGeometry, Material = DiffuseMaterials.Green, CullMode = CullMode.Back, PostEffects = "ManipulatorXRayGrid" };
         translationZ = new MeshGeometryModel3D() { Geometry = TranslationXGeometry, Material = DiffuseMaterials.Blue, CullMode = CullMode.Back, PostEffects = "ManipulatorXRayGrid" };
 
-#if WINUI
+#if false
+#elif WINUI
         translationY.HxTransform3D = rotationYMatrix;
         translationZ.HxTransform3D = rotationZMatrix;
-#else
+#elif WPF
         translationY.Transform = new Media3D.MatrixTransform3D(rotationYMatrix.ToMatrix3D());
         translationZ.Transform = new Media3D.MatrixTransform3D(rotationZMatrix.ToMatrix3D());
+#else
+#error Unknown framework
 #endif
 
         translationX.Mouse3DDown += Translation_Mouse3DDown;
@@ -471,12 +483,15 @@ public class TransformManipulator3D : GroupElement3D
         rotationY = new MeshGeometryModel3D() { Geometry = RotationXGeometry, Material = DiffuseMaterials.Green, CullMode = CullMode.Back, PostEffects = "ManipulatorXRayGrid" };
         rotationZ = new MeshGeometryModel3D() { Geometry = RotationXGeometry, Material = DiffuseMaterials.Blue, CullMode = CullMode.Back, PostEffects = "ManipulatorXRayGrid" };
 
-#if WINUI
+#if false
+#elif WINUI
         rotationY.HxTransform3D = rotationYMatrix;
         rotationZ.HxTransform3D = rotationZMatrix;
-#else
+#elif WPF
         rotationY.Transform = new Media3D.MatrixTransform3D(rotationYMatrix.ToMatrix3D());
         rotationZ.Transform = new Media3D.MatrixTransform3D(rotationZMatrix.ToMatrix3D());
+#else
+#error Unknown framework
 #endif
 
         rotationX.Mouse3DDown += Rotation_Mouse3DDown;
@@ -500,12 +515,15 @@ public class TransformManipulator3D : GroupElement3D
         scaleY = new MeshGeometryModel3D() { Geometry = ScalingGeometry, Material = DiffuseMaterials.Green, CullMode = CullMode.Back, PostEffects = "ManipulatorXRayGrid" };
         scaleZ = new MeshGeometryModel3D() { Geometry = ScalingGeometry, Material = DiffuseMaterials.Blue, CullMode = CullMode.Back, PostEffects = "ManipulatorXRayGrid" };
 
-#if WINUI
+#if false
+#elif WINUI
         scaleY.HxTransform3D = rotationYMatrix;
         scaleZ.HxTransform3D = rotationZMatrix;
-#else
+#elif WPF
         scaleY.Transform = new Media3D.MatrixTransform3D(rotationYMatrix.ToMatrix3D());
         scaleZ.Transform = new Media3D.MatrixTransform3D(rotationZMatrix.ToMatrix3D());
+#else
+#error Unknown framework
 #endif
 
         scaleX.Mouse3DDown += Scaling_Mouse3DDown;
@@ -918,10 +936,13 @@ public class TransformManipulator3D : GroupElement3D
             return;
         }
         targetMatrix = Matrix.CreateTranslation(-centerOffset) * scaleMatrix * rotationMatrix * Matrix.CreateTranslation(centerOffset) * Matrix.CreateTranslation(translationVector);
-#if WINUI
+#if false
+#elif WINUI
         target.HxTransform3D = targetMatrix;
-#else
+#elif WPF
         target.Transform = new Media3D.MatrixTransform3D(targetMatrix.ToMatrix3D());
+#else
+#error Unknown framework
 #endif
     }
 
@@ -929,10 +950,13 @@ public class TransformManipulator3D : GroupElement3D
     {
         var m = Matrix.CreateTranslation(centerOffset + translationVector);
         m.M11 = m.M22 = m.M33 = (float)sizeScale;
-#if WINUI
+#if false
+#elif WINUI
         ctrlGroup.HxTransform3D = m;
-#else
+#elif WPF
         ctrlGroup.Transform = new Media3D.MatrixTransform3D(m.ToMatrix3D());
+#else
+#error Unknown framework
 #endif
     }
 

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ViewBoxModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/ViewBoxModel3D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/VolumeTextureModel3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Elements3D/VolumeTextureModel3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class VolumeTextureModel3D : Element3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/IMouse3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/IMouse3D.cs
@@ -1,23 +1,32 @@
-﻿#if WINUI
-#else
+﻿#if false
+#elif WINUI
+#elif WPF
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public interface IMouse3D
 {
-#if WINUI
+#if false
+#elif WINUI
     event EventHandler<MouseDown3DEventArgs>? Mouse3DDown;
     event EventHandler<MouseUp3DEventArgs>? Mouse3DUp;
     event EventHandler<MouseMove3DEventArgs>? Mouse3DMove;
-#else
+#elif WPF
     event RoutedEventHandler MouseDown3D;
     event RoutedEventHandler MouseUp3D;
     event RoutedEventHandler MouseMove3D;
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/ISelectable.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/ISelectable.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public interface ISelectable

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/ITransformable.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/ITransformable.cs
@@ -1,13 +1,19 @@
 ﻿using HelixToolkit.SharpDX;
-#if WINUI
+#if false
+#elif WINUI
 using Microsoft.UI.Xaml.Media.Media3D;
+#elif WPF
 #else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public interface ITransformable : ITransform

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/ITraversable.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/ITraversable.cs
@@ -1,7 +1,10 @@
-﻿#if WINUI
+﻿#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public interface ITraversable

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/IVisible.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/IVisible.cs
@@ -1,12 +1,18 @@
-﻿#if WINUI
-#else
+﻿#if false
+#elif WINUI
+#elif WPF
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public interface IVisible

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/AmbientLight3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/AmbientLight3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public sealed class AmbientLight3D : Light3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/DirectionalLight3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/DirectionalLight3D.cs
@@ -1,14 +1,20 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public sealed class DirectionalLight3D : Light3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/Light3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/Light3D.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model.Scene;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public abstract class Light3D : Element3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/PointLight3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/PointLight3D.cs
@@ -1,14 +1,20 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class PointLight3D : Light3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/ShadowMap3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/ShadowMap3D.cs
@@ -2,17 +2,23 @@
 using HelixToolkit.SharpDX.Model.Scene;
 using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/SpotLight3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/SpotLight3D.cs
@@ -1,14 +1,20 @@
 ﻿using HelixToolkit.SharpDX.Model.Scene;
-#if WINUI
+#if false
+#elif WINUI
 using HelixToolkit.WinUI.SharpDX.Model;
-#else
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Model;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public sealed class SpotLight3D : PointLight3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/ThreePointLight3D.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Lights3D/ThreePointLight3D.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class ThreePointLight3D : GroupElement3D, ILight3D

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/ColorStripeMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/ColorStripeMaterial.cs
@@ -5,15 +5,21 @@ using SharpDX.Direct3D11;
 using System.ComponentModel;
 using System.Runtime.Serialization;
 
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Utilities;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -38,8 +44,12 @@ public class ColorStripeMaterial : Material
     /// <summary>
     /// Gets or sets the diffuse color for the material.
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 DiffuseColor
     {
@@ -230,7 +240,9 @@ public class ColorStripeMaterial : Material
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new ColorStripeMaterial()
@@ -244,5 +256,7 @@ public class ColorStripeMaterial : Material
             Name = Name
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/DiffuseMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/DiffuseMaterial.cs
@@ -5,15 +5,21 @@ using SharpDX;
 using SharpDX.Direct3D11;
 using System.ComponentModel;
 
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Utilities;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class DiffuseMaterial : Material
@@ -35,8 +41,12 @@ public class DiffuseMaterial : Material
     /// Gets or sets the diffuse color for the material.
     /// For details see: http://msdn.microsoft.com/en-us/library/windows/desktop/bb147175(v=vs.85).aspx
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 DiffuseColor
     {
@@ -270,10 +280,14 @@ public class DiffuseMaterial : Material
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return CloneMaterial();
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/DiffuseMaterialCollection.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/DiffuseMaterialCollection.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.ObjectModel;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class DiffuseMaterialCollection : ObservableCollection<DiffuseMaterial>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/DiffuseMaterials.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/DiffuseMaterials.cs
@@ -1,9 +1,12 @@
 ﻿using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public static class DiffuseMaterials

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/LineArrowHeadMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/LineArrowHeadMaterial.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class LineArrowHeadMaterial : LineMaterial

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/LineArrowHeadTailMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/LineArrowHeadTailMaterial.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class LineArrowHeadTailMaterial : LineArrowHeadMaterial

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/LineMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/LineMaterial.cs
@@ -3,10 +3,13 @@ using HelixToolkit.SharpDX.Model;
 using HelixToolkit.SharpDX.Shaders;
 using SharpDX.Direct3D11;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class LineMaterial : Material
@@ -330,7 +333,9 @@ public class LineMaterial : Material
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new LineMaterial()
@@ -348,5 +353,7 @@ public class LineMaterial : Material
             FixedSize = FixedSize
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/Material.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/Material.cs
@@ -1,10 +1,13 @@
 ﻿using System.Runtime.Serialization;
 using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 [DataContract]

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/NormalMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/NormalMaterial.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -32,7 +35,9 @@ public sealed class NormalMaterial : Material
         return NormalMaterialCore.Core;
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new NormalMaterial()
@@ -40,5 +45,7 @@ public sealed class NormalMaterial : Material
             Name = Name
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/NormalVectorMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/NormalVectorMaterial.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -31,7 +34,9 @@ public sealed class NormalVectorMaterial : Material
         return NormalVectorMaterialCore.Core;
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new NormalVectorMaterial()
@@ -39,5 +44,7 @@ public sealed class NormalVectorMaterial : Material
             Name = Name
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PBRMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PBRMaterial.cs
@@ -6,15 +6,21 @@ using SharpDX.Direct3D11;
 using System.ComponentModel;
 using System.Runtime.Serialization;
 
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Utilities;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 [DataContract]
@@ -498,8 +504,12 @@ public partial class PBRMaterial : Material
     /// Gets or sets the diffuse color for the material.
     /// For details see: http://msdn.microsoft.com/en-us/library/windows/desktop/bb147175(v=vs.85).aspx
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 AlbedoColor
     {
@@ -761,7 +771,9 @@ public partial class PBRMaterial : Material
         }
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Vector4Converter))]
 #endif
     public Vector4 DisplacementMapScaleMask
@@ -1168,11 +1180,15 @@ public partial class PBRMaterial : Material
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return CloneMaterial();
     }
+#else
+#error Unknown framework
 #endif
 
     public virtual PBRMaterial CloneMaterial()

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PBRSampleColors.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PBRSampleColors.cs
@@ -1,9 +1,12 @@
 ﻿using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PhongMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PhongMaterial.cs
@@ -6,15 +6,21 @@ using System.ComponentModel;
 using System.Runtime.Serialization;
 using HelixToolkit.SharpDX.Shaders;
 
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using HelixToolkit.Wpf.SharpDX.Utilities;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -458,8 +464,12 @@ public partial class PhongMaterial : Material
     /// Gets or sets a color that represents how the material reflects System.Windows.Media.Media3D.AmbientLight.
     /// For details see: http://msdn.microsoft.com/en-us/library/windows/desktop/bb147175(v=vs.85).aspx
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 AmbientColor
     {
@@ -477,8 +487,12 @@ public partial class PhongMaterial : Material
     /// Gets or sets the diffuse color for the material.
     /// For details see: http://msdn.microsoft.com/en-us/library/windows/desktop/bb147175(v=vs.85).aspx
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 DiffuseColor
     {
@@ -496,8 +510,12 @@ public partial class PhongMaterial : Material
     /// Gets or sets the emissive color for the material.
     /// For details see: http://msdn.microsoft.com/en-us/library/windows/desktop/bb147175(v=vs.85).aspx
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 EmissiveColor
     {
@@ -514,8 +532,12 @@ public partial class PhongMaterial : Material
     /// <summary>
     /// A fake parameter for reflectivity of the environment map
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 ReflectiveColor
     {
@@ -533,8 +555,12 @@ public partial class PhongMaterial : Material
     /// Gets or sets the specular color for the material.
     /// For details see: http://msdn.microsoft.com/en-us/library/windows/desktop/bb147175(v=vs.85).aspx
     /// </summary>
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Color4Converter))]
+#else
+#error Unknown framework
 #endif
     public Color4 SpecularColor
     {
@@ -677,8 +703,12 @@ public partial class PhongMaterial : Material
         }
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     [TypeConverter(typeof(Vector4Converter))]
+#else
+#error Unknown framework
 #endif
     public Vector4 DisplacementMapScaleMask
     {
@@ -1042,11 +1072,15 @@ public partial class PhongMaterial : Material
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return CloneMaterial();
     }
+#else
+#error Unknown framework
 #endif
 
     protected override MaterialCore OnCreateCore()

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PhongMaterialCollection.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PhongMaterialCollection.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.ObjectModel;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class PhongMaterialCollection : ObservableCollection<PhongMaterial>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PhongMaterials.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PhongMaterials.cs
@@ -1,9 +1,12 @@
 ﻿using SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PointMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PointMaterial.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model;
 
-#if WINUI
-#else
+#if false
+#elif WINUI
+#elif WPF
 using System.Windows;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public class PointMaterial : Material
@@ -300,7 +306,9 @@ public class PointMaterial : Material
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new PointMaterial()
@@ -308,5 +316,7 @@ public class PointMaterial : Material
             Name = Name
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PositionColorMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/PositionColorMaterial.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -24,7 +27,9 @@ public sealed class PositionColorMaterial : Material
     {
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new PositionColorMaterial()
@@ -32,5 +37,7 @@ public sealed class PositionColorMaterial : Material
             Name = Name
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VertColorMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VertColorMaterial.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -24,7 +27,9 @@ public sealed class VertColorMaterial : Material
     {
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new VertColorMaterial()
@@ -32,5 +37,7 @@ public sealed class VertColorMaterial : Material
             Name = Name
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VolumeTextureDDS3DMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VolumeTextureDDS3DMaterial.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -66,7 +69,9 @@ public sealed class VolumeTextureDDS3DMaterial : VolumeTextureMaterialBase
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new VolumeTextureDDS3DMaterial()
@@ -83,5 +88,7 @@ public sealed class VolumeTextureDDS3DMaterial : VolumeTextureMaterialBase
             EnablePlaneAlignment = EnablePlaneAlignment,
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VolumeTextureDiffuseMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VolumeTextureDiffuseMaterial.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -69,7 +72,9 @@ public sealed class VolumeTextureDiffuseMaterial : VolumeTextureMaterialBase
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new VolumeTextureDiffuseMaterial()
@@ -86,5 +91,7 @@ public sealed class VolumeTextureDiffuseMaterial : VolumeTextureMaterialBase
             EnablePlaneAlignment = EnablePlaneAlignment,
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VolumeTextureMaterialBase.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VolumeTextureMaterialBase.cs
@@ -3,10 +3,13 @@ using HelixToolkit.SharpDX.Shaders;
 using SharpDX;
 using SharpDX.Direct3D11;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public abstract class VolumeTextureMaterialBase : Material, IVolumeTextureMaterial

--- a/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VolumeTextureRawDataMaterial.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Model/Materials/VolumeTextureRawDataMaterial.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX.Model;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -70,7 +73,9 @@ public sealed class VolumeTextureRawDataMaterial : VolumeTextureMaterialBase
         };
     }
 
-#if WPF
+#if false
+#elif WINUI
+#elif WPF
     protected override Freezable CreateInstanceCore()
     {
         return new VolumeTextureRawDataMaterial()
@@ -87,5 +92,7 @@ public sealed class VolumeTextureRawDataMaterial : VolumeTextureMaterialBase
             EnablePlaneAlignment = EnablePlaneAlignment,
         };
     }
+#else
+#error Unknown framework
 #endif
 }

--- a/Source/HelixToolkit.SharpDX.SharedModel/Utilities/GeometryModel3DOctreeManager.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Utilities/GeometryModel3DOctreeManager.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Utilities;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Utilities/IOctreeManagerWrapper.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Utilities/IOctreeManagerWrapper.cs
@@ -1,9 +1,12 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>

--- a/Source/HelixToolkit.SharpDX.SharedModel/Utilities/InstancingModel3DOctreeManager.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Utilities/InstancingModel3DOctreeManager.cs
@@ -1,10 +1,13 @@
 ﻿using HelixToolkit.SharpDX;
 using HelixToolkit.SharpDX.Utilities;
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 public sealed class InstancingModel3DOctreeManager : OctreeManagerBaseWrapper

--- a/Source/HelixToolkit.SharpDX.SharedModel/Utilities/OctreeManagerBaseWrapper.cs
+++ b/Source/HelixToolkit.SharpDX.SharedModel/Utilities/OctreeManagerBaseWrapper.cs
@@ -1,15 +1,21 @@
 ﻿using HelixToolkit.SharpDX;
 
-#if WINUI
+#if false
+#elif WINUI
 using Windows.UI.Core;
-#else
+#elif WPF
 using System.Windows.Threading;
+#else
+#error Unknown framework
 #endif
 
-#if WINUI
+#if false
+#elif WINUI
 namespace HelixToolkit.WinUI.SharpDX;
-#else
+#elif WPF
 namespace HelixToolkit.Wpf.SharpDX;
+#else
+#error Unknown framework
 #endif
 
 /// <summary>
@@ -209,10 +215,13 @@ public abstract class OctreeManagerBaseWrapper : FrameworkContentElement, IOctre
             return (int)GetValue(MinObjectSizeToSplitProperty);
         }
     }
-#if WINUI
+#if false
+#elif WINUI
     private IAsyncAction? octreeOpt;
-#else
+#elif WPF
     private DispatcherOperation? octreeOpt;
+#else
+#error Unknown framework
 #endif
     private bool enableOctreeOutput = false;
     private IOctreeManager? manager;
@@ -232,7 +241,8 @@ public abstract class OctreeManagerBaseWrapper : FrameworkContentElement, IOctre
                 manager = OnCreateManager();
                 manager.OnOctreeCreated += (s, e) =>
                 {
-#if WINUI
+#if false
+#elif WINUI
                     if (octreeOpt != null && octreeOpt.Status != AsyncStatus.Completed)
                     {
                         octreeOpt?.Cancel();
@@ -245,7 +255,7 @@ public abstract class OctreeManagerBaseWrapper : FrameworkContentElement, IOctre
                             this.Octree = e.Octree;
                         });
                     }
-#else
+#elif WPF
                     if (octreeOpt != null && octreeOpt.Status == DispatcherOperationStatus.Pending)
                     {
                         octreeOpt.Abort();
@@ -259,6 +269,8 @@ public abstract class OctreeManagerBaseWrapper : FrameworkContentElement, IOctre
                                 this.Octree = e.Octree;
                             }));
                     }
+#else
+#error Unknown framework
 #endif
                 };
             }


### PR DESCRIPTION
In the sharpdx shared project the namespaces are:
```
if WINUI
...
else
...
endif
```
Win this PR the namespaces are:
```
if false
elif WINUI
...
elif WPF
...
else
error Unknown framework
endif
``` 

Each framework is explicitly defined and the if directive is `elif FRAMEWORK_NAME`.
