### PR TITLE
Fix CameraType in CoordinateSystemNode

### DIFF
--- a/Source/HelixToolkit.SharpDX/Model/Scene/CoordinateSystemNode.cs
+++ b/Source/HelixToolkit.SharpDX/Model/Scene/CoordinateSystemNode.cs
@@ -176,7 +176,7 @@ public class CoordinateSystemNode : ScreenSpacedNode
     public CoordinateSystemNode()
     {
         IsHitTestVisible = false;
-        CameraType = ScreenSpacedCameraType.Perspective;
+        CameraType = ScreenSpacedCameraType.Auto;
         arrowMeshModel.Material = new ColorMaterialCore();
         arrowMeshModel.CullMode = CullMode.Back;
         axisBillboard.EnableViewFrustumCheck = false;


### PR DESCRIPTION
In CoordinateSystemNode the CameraType is Perspective instead of Auto.
I've fixed that.

Fix #2385 