### PR TITLE
Fix text scale in CoordinateSystemNode

### DIFF
--- a/Source/HelixToolkit.SharpDX/Model/Scene/CoordinateSystemNode.cs
+++ b/Source/HelixToolkit.SharpDX/Model/Scene/CoordinateSystemNode.cs
@@ -297,4 +297,19 @@ public class CoordinateSystemNode : ScreenSpacedNode
     {
         return false;
     }
+
+    protected override void OnCoordinateSystemChanged(bool e)
+    {
+        base.OnCoordinateSystemChanged(e);
+
+        if (axisBillboard.Geometry is BillboardText3D labelText)
+        {
+            float scale = Mode == ScreenSpacedMode.RelativeScreenSpaced ? 0.5f : 4.0f;
+
+            for (int i = 0; i < 3; i++)
+            {
+                labelText.TextInfo[i].Scale = scale;
+            }
+        }
+    }
 }

--- a/Source/HelixToolkit.SharpDX/Model/Scene/ScreenSpacedNode.cs
+++ b/Source/HelixToolkit.SharpDX/Model/Scene/ScreenSpacedNode.cs
@@ -189,6 +189,7 @@ public class ScreenSpacedNode : GroupNode
             if (RenderCore is IScreenSpacedRenderParams core)
             {
                 core.Mode = value;
+                OnCoordinateSystemChanged(true);
             }
         }
         get


### PR DESCRIPTION
Set scale to `0.5f` for relative mode (current behavior) and to `4.0f` for absolute mode (fix).

Fix #2387 
