### PR TITLE
EnableColorBlending comment is wrong

### DIFF
--- a/Source/HelixToolkit.SharpDX/Model/Material/PointMaterialCore.cs
+++ b/Source/HelixToolkit.SharpDX/Model/Material/PointMaterialCore.cs
@@ -158,7 +158,7 @@ public class PointMaterialCore : MaterialCore, IPointRenderParams
     /// <summary>
     /// Gets or sets a value indicating whether [enable blending].
     /// <para>Once enabled, final color 
-    /// = <see cref="BlendingFactor"/> * <see cref="PointColor"/> + (1 - <see cref="BlendingFactor"/>) * Vertex Color.</para>
+    /// = <see cref="BlendingFactor"/> * Vertex Color + (1 - <see cref="BlendingFactor"/>) * <see cref="PointColor"/>.</para>
     /// </summary>
     /// <value>
     ///   <c>true</c> if [enable blending]; otherwise, <c>false</c>.


### PR DESCRIPTION
The comment says:

> final color = BlendingFactor * PointColor + (1 - BlendingFactor) * Vertex Color

But the code in `Source/HelixToolkit.Native.ShaderBuilder/VS/vsPoint.hlsl` is:

```
pBlendingFactor * input.c + (1 - pBlendingFactor) * pColor
```

So the comment should be:

> final color = BlendingFactor * Vertex Color + (1 - BlendingFactor) * PointColor