### PR TITLE
Fix a typo and add a clear method

### DIFF
--- a/Source/HelixToolkit.SharpDX/Utilities/LineBuilder.cs
+++ b/Source/HelixToolkit.SharpDX/Utilities/LineBuilder.cs
@@ -339,13 +339,13 @@ public class LineBuilder
     }
 
     /// <summary>
-    /// Generates the circile.
+    /// Generates the circle.
     /// </summary>
     /// <param name="plane">The plane.</param>
     /// <param name="radius">The radius.</param>
     /// <param name="segments">The segments.</param>
     /// <returns></returns>
-    public static LineGeometry3D GenerateCircile(Plane plane, float radius, int segments)
+    public static LineGeometry3D GenerateCircle(Plane plane, float radius, int segments)
     {
         var bd = new LineBuilder();
         bd.AddCircle(plane.Normal * plane.D, plane.Normal, radius, segments);
@@ -534,5 +534,14 @@ public class LineBuilder
         var tv = sp - tp;
 
         return tv.Length(); // return the closest distance
+    }
+
+    /// <summary>
+    /// Removes all the data from the current LineBuilder instance.
+    /// </summary>
+    public void Clear()
+    {
+        positions.Clear();
+        lineListIndices.Clear();
     }
 }


### PR DESCRIPTION
The Clear method is useful when you want to reuse a LineBuilder object in a loop to reduce allocations.