### PR TITLE
Update 'WindowsAppSDK' to version 1.7

### DIFF
--- a/Source/HelixToolkit.WinUI/HelixToolkit.WinUI.csproj
+++ b/Source/HelixToolkit.WinUI/HelixToolkit.WinUI.csproj
@@ -44,7 +44,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
         <PackageReference Include="SharpDX" Version="4.2.0" />
         <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
         <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />


### PR DESCRIPTION
Fix for issue in `WindowsAppSDK 1.6.X`:

- #2398
- https://github.com/microsoft/WindowsAppSDK/issues/4807#issuecomment-2616672133

Tested locally with a local _NuGet server_, works fine.

If possible, releasing `HelixToolkit.WinUI v2.27.1` (minor bump from `v2.27.0`) with this small fix would be very helpful.

Thanks and looking forward to merge! :blush: