### PR TITLE
Fixed issues with included files

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -1,7 +1,6 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <SolutionDir Condition="'$(SolutionDir)'==''">$(MSBuildThisFileDirectory)</SolutionDir>
     <Version>3.0.0</Version>
     <IsPackable>false</IsPackable>
     <Description>Helix Toolkit is a collection of 3D components for .NET.</Description>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -29,23 +29,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(SolutionDir)..\LICENSE">
+    <None Include="$(MSBuildThisFileDirectory)..\LICENSE">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="$(SolutionDir)..\AUTHORS">
+    <None Include="$(MSBuildThisFileDirectory)..\AUTHORS">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="$(SolutionDir)..\CONTRIBUTORS">
+    <None Include="$(MSBuildThisFileDirectory)..\CONTRIBUTORS">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="$(SolutionDir)..\README.md">
+    <None Include="$(MSBuildThisFileDirectory)..\README.md">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="$(SolutionDir)..\Images\helixtoolkit.png">
+    <None Include="$(MSBuildThisFileDirectory)..\Images\helixtoolkit.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>


### PR DESCRIPTION
This fixes the issues with common files included in multiple projects, like LICENSE, README.md, etc. (see #2452)

These files caused build errors when HelixToolkit projects were included in solutions outside the repository. The reason was that file paths were specified relative to solution directory, which gives wrong results in such cases. Fix in `Directory.Build.props` replaces paths relative to VS solution with paths that are relative to this file, such that these paths always point to fixed positions within the repository.

Finally, the element that defines the `SolutionDir` variable if it is not defined, in `Directory.Build.props`, was removed. Solution-wide search indicates that the variable is not used in any project files.

Locally, solution builds and all tests pass after modifications.