### PR TITLE
Enabled Debugging with RenderDoc again

### DIFF
--- a/Source/HelixToolkit.SharpDX/Extensions/BitmapExtensions.cs
+++ b/Source/HelixToolkit.SharpDX/Extensions/BitmapExtensions.cs
@@ -67,6 +67,10 @@ public static class BitmapExtensions
         {
             return null;
         }
+        if (deviceResources.Device2D is null)
+        {
+            return null;
+        }
 
         var bitmap = new global::SharpDX.WIC.Bitmap(deviceResources.WICImgFactory, width, height, global::SharpDX.WIC.PixelFormat.Format32bppBGR,
             BitmapCreateCacheOption.CacheOnDemand);

--- a/Source/HelixToolkit.SharpDX/ShaderManager/EffectsManager.cs
+++ b/Source/HelixToolkit.SharpDX/ShaderManager/EffectsManager.cs
@@ -253,6 +253,14 @@ public class EffectsManager : DisposeObject, IEffectsManager
         get;
     } = false;
     /// <summary>
+    /// 
+    /// </summary>
+    public bool Initialize2DRendering
+    {
+        get;
+    } = true;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="EffectsManager"/> class.
     /// </summary>
     public EffectsManager()
@@ -275,6 +283,7 @@ public class EffectsManager : DisposeObject, IEffectsManager
     public EffectsManager(EffectsManagerConfiguration configuration)
     {
         EnableSoftwareRendering = configuration.EnableSoftwareRendering;
+        Initialize2DRendering = configuration.Initialize2DRendering;
         Initialize(configuration.AdapterIndex);
     }
 
@@ -380,11 +389,14 @@ public class EffectsManager : DisposeObject, IEffectsManager
         factory2D = new global::SharpDX.Direct2D1.Factory1(global::SharpDX.Direct2D1.FactoryType.MultiThreaded);
         wicImgFactory = new global::SharpDX.WIC.ImagingFactory();
         directWriteFactory = new global::SharpDX.DirectWrite.Factory(global::SharpDX.DirectWrite.FactoryType.Shared);
-        using (var dxgiDevice2 = device.QueryInterface<global::SharpDX.DXGI.Device>())
+        if (Initialize2DRendering)
         {
-            device2D = new global::SharpDX.Direct2D1.Device(factory2D, dxgiDevice2);
-            deviceContext2D = new global::SharpDX.Direct2D1.DeviceContext(device2D,
-                global::SharpDX.Direct2D1.DeviceContextOptions.EnableMultithreadedOptimizations);
+            using (var dxgiDevice2 = device.QueryInterface<global::SharpDX.DXGI.Device>())
+            {
+                device2D = new global::SharpDX.Direct2D1.Device(factory2D, dxgiDevice2);
+                deviceContext2D = new global::SharpDX.Direct2D1.DeviceContext(device2D,
+                    global::SharpDX.Direct2D1.DeviceContextOptions.EnableMultithreadedOptimizations);
+            }
         }
         Initialized = true;
     }

--- a/Source/HelixToolkit.SharpDX/ShaderManager/EffectsManagerConfiguration.cs
+++ b/Source/HelixToolkit.SharpDX/ShaderManager/EffectsManagerConfiguration.cs
@@ -17,4 +17,15 @@ public sealed class EffectsManagerConfiguration
     {
         set; get;
     } = false;
+
+    /// <summary>
+    /// Initialize 2D Rendering.
+    /// </summary>
+    /// <remarks>
+    /// Must be disabled when debugging with RenderDoc, for example
+    /// </remarks>
+    public bool Initialize2DRendering
+    {
+        set; get;
+    } = true;
 }


### PR DESCRIPTION
I have added an option to the “EffectsManagerConfiguration” that allows 2D rendering to be disabled, so that shaders can once again be debugged using RenderDoc. However, disabling this feature also prevents a BitmapStream from being created.