### PR TITLE
Fix WinUI Viewport3DX mouse events

### DIFF
--- a/Source/Examples/WinUI.SharpDX/ModelViewerDemo/MainWindow.xaml.cs
+++ b/Source/Examples/WinUI.SharpDX/ModelViewerDemo/MainWindow.xaml.cs
@@ -40,14 +40,28 @@ public sealed partial class MainWindow : Window
         MainVM.Target = this;
 
         viewport.OnMouse3DDown += Viewport_OnMouse3DDown;
+        viewport.OnMouse3DUp += Viewport_OnMouse3DUp;
+        viewport.OnMouse3DMove += Viewport_OnMouse3DMove;
     }
+
+    private bool didMouseMove = false;
 
     private void Viewport_OnMouse3DDown(object? sender, MouseDown3DEventArgs e)
     {
-        if (e.HitTestResult == null)
-        {
-            return;
-        }
+        didMouseMove = false;
+    }
+
+	private void Viewport_OnMouse3DMove(object? sender, MouseMove3DEventArgs e)
+	{
+		didMouseMove = true;
+	}
+
+	private void Viewport_OnMouse3DUp(object? sender, MouseUp3DEventArgs e)
+    {
+		if (didMouseMove || e.HitTestResult == null)
+		{
+			return;
+		}
         if (e.HitTestResult.ModelHit is SceneNode node && node.Tag is AttachedNodeViewModel vm)
         {
             vm.Selected = !vm.Selected;

--- a/Source/HelixToolkit.WinUI.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.WinUI.SharpDX/Controls/Viewport3DX.cs
@@ -1245,10 +1245,8 @@ public partial class Viewport3DX : Control, IViewport3DX
         {
             currentHit = null;
         }
-        if (currentHit is not null)
-        {
-            this.OnMouse3DDown?.Invoke(this, new MouseDown3DEventArgs(currentHit, pt, this, originalInputEventArgs));
-        }
+
+        this.OnMouse3DDown?.Invoke(this, new MouseDown3DEventArgs(currentHit, pt, this, originalInputEventArgs));
     }
 
     private bool ViewBoxHitTest(Point p)
@@ -1329,10 +1327,7 @@ public partial class Viewport3DX : Control, IViewport3DX
             }
         }
 
-        if (currentHit is not null)
-        {
-            this.OnMouse3DMove?.Invoke(this, new MouseMove3DEventArgs(currentHit, pt, this, originalInputEventArgs));
-        }
+        this.OnMouse3DMove?.Invoke(this, new MouseMove3DEventArgs(currentHit, pt, this, originalInputEventArgs));
     }
 
     /// <summary>
@@ -1368,13 +1363,10 @@ public partial class Viewport3DX : Control, IViewport3DX
             {
                 node.RaiseMouseUpEvent(this, pt.ToVector2(), currentHit, originalInputEventArgs);
             }
-            this.currentHit = null;
         }
 
-        if (this.currentHit is not null)
-        {
-            this.OnMouse3DUp?.Invoke(this, new MouseUp3DEventArgs(currentHit, pt, this, originalInputEventArgs));
-        }
+        this.OnMouse3DUp?.Invoke(this, new MouseUp3DEventArgs(currentHit, pt, this, originalInputEventArgs));
+        this.currentHit = null;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
The fact that Mouse3DEventArgs.HitTestResult is nullable implies that 3D mouse events should be raised regardless of whether something in the scene was clicked, and handlers can check HitTestResult to see if the hit test found anything. However, Viewport3DX's OnMouse3DDown and OnMouse3DMove events were only raised if the hit test found something, so it was not possible to handle events for clicking on nothing or moving the mouse without having clicked on something. The OnMouse3DUp event was never raised at all, because it checked for a hit test, but it always reset the hit test result to null first.

This fixes the events so they are raised even if there's not hit, matching the behavior of the Avalonia and Wpf versions.

Also updated the ModelViewerDemo project to test these changes by making it differentiate between drags for camera pan and clicks for toggling the highlight on nodes.