### PR TITLE
fix(Avalonia.SharpDX): fix Viewport3DX detach/reattach lifecycle

### DIFF
--- a/Source/HelixToolkit.Avalonia.SharpDX/Controls/D3DRenderHost.cs
+++ b/Source/HelixToolkit.Avalonia.SharpDX/Controls/D3DRenderHost.cs
@@ -41,6 +41,9 @@ internal sealed class D3DRenderHost : DefaultRenderHost
         base.OnStartD3D();
         Initialize().Wait();
         _parent.PropertyChanged += ParentPropertyChanged;
+        // Start the render loop after initialization is complete.
+        // This ensures the first frame is queued even if Bounds have not changed.
+        QueueNextFrame();
     }
 
     protected override void OnEndingD3D()
@@ -51,6 +54,7 @@ internal sealed class D3DRenderHost : DefaultRenderHost
             FreeGraphicsResources();
         }
         _initialized = false;
+        _updateQueued = false; // Reset so QueueNextFrame can re-register on reattach.
         base.OnEndingD3D();
     }
 
@@ -58,7 +62,14 @@ internal sealed class D3DRenderHost : DefaultRenderHost
     {
         try
         {
-            var selfVisual = ElementComposition.GetElementVisual(_parent)!;
+            var selfVisual = ElementComposition.GetElementVisual(_parent);
+            if (selfVisual is null)
+            {
+                _info = "Parent visual is not attached to compositor";
+                _initialized = false;
+                return;
+            }
+
             _compositor = selfVisual.Compositor;
 
             Surface = _compositor.CreateDrawingSurface();
@@ -75,6 +86,7 @@ internal sealed class D3DRenderHost : DefaultRenderHost
         catch (Exception e)
         {
             _info = e.ToString();
+            _initialized = false;
         }
     }
 
@@ -138,7 +150,7 @@ internal sealed class D3DRenderHost : DefaultRenderHost
 
         if (EffectsManager is null || EffectsManager.Device is null)
         {
-            return (true, string.Empty);
+            return (false, "EffectsManager or Device is null");
         }
 
         _device = EffectsManager.Device;

--- a/Source/HelixToolkit.Avalonia.SharpDX/Controls/Viewport3DX.cs
+++ b/Source/HelixToolkit.Avalonia.SharpDX/Controls/Viewport3DX.cs
@@ -1461,7 +1461,10 @@ public partial class Viewport3DX : TemplatedControl, IViewport3DX
         //    parentWindow.Closed -= ParentWindow_Closed;
         //}
 
-        Dispose();
+        // Do not dispose here. Detach from visual tree is handled by D3DDrawingSurfaceBase.OnDetachedFromVisualTree.
+        // Disposing here would destroy the render infrastructure and prevent reattachment (e.g., after TabControl tab switch).
+        // Only detach renderables; D3D resources will be released via EndD3D() when the surface is detached from visual tree.
+        Detach();
     }
 
     /// <summary>


### PR DESCRIPTION
Fix rendering pipeline broken after TabControl tab switch by correcting several lifecycle issues in D3DRenderHost and Viewport3DX:

- Viewport3DX.ControlUnloaded: Replace Dispose() with Detach() to avoid destroying render infrastructure when removed from visual tree (e.g. TabControl tab switch). D3D resources are already released via EndD3D() from D3DDrawingSurfaceBase.OnDetachedFromVisualTree.

- D3DRenderHost.Initialize: Add null-safety for ElementComposition. GetElementVisual() and set _initialized=false on failure instead of throwing NullReferenceException.

- D3DRenderHost.InitializeGraphicsResources: Return (false, ...) when EffectsManager or Device is null instead of incorrectly returning (true, string.Empty), which caused _initialized=true with no swapchain.

- D3DRenderHost.OnStartD3D: Call QueueNextFrame() after initialization to ensure the render loop starts even when Bounds have not changed.

- D3DRenderHost.OnEndingD3D: Reset _updateQueued=false so that QueueNextFrame() can re-register on reattach.

Fixes #2473