### PR TITLE
Invalidate scene graph in RemoveChildNode and Clear

### DIFF
--- a/Source/HelixToolkit.SharpDX/Model/Scene/Abstract/GroupNodeBase.cs
+++ b/Source/HelixToolkit.SharpDX/Model/Scene/Abstract/GroupNodeBase.cs
@@ -189,6 +189,10 @@ public abstract class GroupNodeBase : SceneNode
         }
         ItemsInternal.Clear();
         itemHashSet.Clear();
+        if (IsAttached)
+        {
+            InvalidateSceneGraph();
+        }
         Cleared?.Invoke(this, new OnChildNodeChangedArgs(null, Operation.Clear));
     }
     /// <summary>
@@ -207,6 +211,10 @@ public abstract class GroupNodeBase : SceneNode
             }
             ItemsInternal.Remove(node);
             node.Parent = null;
+            if (IsAttached)
+            {
+                InvalidateSceneGraph();
+            }
             ChildNodeRemoved?.Invoke(this, new OnChildNodeChangedArgs(node, Operation.Remove));
             return true;
         }


### PR DESCRIPTION
Fixes #2406.

RemoveChildNode and Clear in GroupNodeBase don't call InvalidateSceneGraph(), unlike AddChildNode, InsertChildNode, MoveChildNode and TransferChildNode. The render host only rebuilds its per-frame draw list when the scene graph is invalidated, so a removed node can keep rendering until some unrelated change invalidates it.

It's most noticeable when removing with detachChild: false (to keep the node cached): the node stays attached and in the stale draw list, so it stays on screen. With detachChild: true it goes away, because a detached node is skipped while rendering.

This adds InvalidateSceneGraph() after a successful remove/clear, guarded by IsAttached to match AddChildNode. It runs regardless of the detach flag, since the node has left the visible graph either way.