### PR TITLE
Avalonia: dispose composition surface, child visual and imported GPU image on D3DRenderHost teardown

### DIFF
--- a/Source/HelixToolkit.Avalonia.SharpDX/Controls/D3D11SwapchainImage.cs
+++ b/Source/HelixToolkit.Avalonia.SharpDX/Controls/D3D11SwapchainImage.cs
@@ -91,6 +91,15 @@ internal sealed class D3D11SwapchainImage
             LastPresent.Dispose();
         }
 
+        if (_imported is not null)
+        {
+            // Server-side dispose of the imported GPU image; Avalonia marshals this to
+            // the render thread. Leaving it to the GC would dispose GPU resources on
+            // the finalizer thread (AvaloniaUI/Avalonia#21865).
+            _ = _imported.DisposeAsync();
+            _imported = null;
+        }
+
         RenderTargetView.Dispose();
         _mutex.Dispose();
         _texture.Dispose();

--- a/Source/HelixToolkit.Avalonia.SharpDX/Controls/D3DRenderHost.cs
+++ b/Source/HelixToolkit.Avalonia.SharpDX/Controls/D3DRenderHost.cs
@@ -55,7 +55,32 @@ internal sealed class D3DRenderHost : DefaultRenderHost
         }
         _initialized = false;
         _updateQueued = false; // Reset so QueueNextFrame can re-register on reattach.
+        ReleaseCompositionResources();
         base.OnEndingD3D();
+    }
+
+    private void ReleaseCompositionResources()
+    {
+        if (!global::Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
+        {
+            global::Avalonia.Threading.Dispatcher.UIThread.Post(ReleaseCompositionResources);
+            return;
+        }
+
+        // Deterministically tear down the composition objects instead of leaking them
+        // to the GC. A leaked CompositionDrawingSurface leaves its server-side surface
+        // snapshot to Avalonia's Ref<T> critical finalizer, which then performs GPU
+        // cleanup (context MakeCurrent + native SKImage dispose) on the .NET finalizer
+        // thread, racing the compositor render loop (AvaloniaUI/Avalonia#21865).
+        ElementComposition.SetElementChildVisual(_parent, null);
+        if (_visual is not null)
+        {
+            _visual.Surface = null;
+            _visual = null;
+        }
+        Surface?.Dispose();
+        Surface = null;
+        _compositor = null;
     }
 
     private async Task Initialize()
@@ -109,11 +134,11 @@ internal sealed class D3DRenderHost : DefaultRenderHost
     {
         _updateQueued = false;
         var root = _parent.GetVisualRoot();
-        if (root == null)
+        if (root == null || _visual is null)
             return;
 
         Rect bounds = _parent.Bounds;
-        _visual!.Size = new(bounds.Width, bounds.Height);
+        _visual.Size = new(bounds.Width, bounds.Height);
         //_pixelSize = PixelSize.FromSize(bounds.Size, root.RenderScaling);
         _pixelSize = PixelSize.FromSize(bounds.Size, 1.0);
         Resize(_pixelSize.Width, _pixelSize.Height);


### PR DESCRIPTION
Fixes #2482.

`D3DRenderHost` never disposed the `CompositionDrawingSurface`, child `CompositionSurfaceVisual`, or the `ICompositionImportedGpuImage` — every viewport attach/detach cycle leaked all three to the GC. Beyond the leak, this routes GPU cleanup through Avalonia's `Ref<T>` critical finalizer on the .NET finalizer thread, which races Avalonia's compositor render loop and crashes natively in `sk_canvas_flush` (full analysis + dumps: AvaloniaUI/Avalonia#21865).

Changes:
- `OnEndingD3D` → new `ReleaseCompositionResources()`: detach the child visual (`SetElementChildVisual(parent, null)`), clear `_visual.Surface`, dispose the `Surface`. UI-thread marshalled because `EndD3D` is also reachable from exception handlers off-thread.
- `D3D11SwapchainImage.Dispose` → `DisposeAsync()` the imported GPU image (Avalonia marshals the actual release to its render thread). Runs after the existing `LastPresent.Wait()`, so no in-flight present references it.
- `UpdateFrame` null-guards `_visual` — a queued composition update can run after teardown (previously `_visual!` would NRE).

No public API changes. Tests: not feasible for this path headlessly (requires a real D3D11 device + Avalonia GPU interop); validated in a production desktop app that creates/destroys Helix viewports at high frequency (3D hover previews) — the fix (backported to 3.1.2) has been shipping since 2026-07-28 with no regressions and eliminated the composition-object accumulation.
