### PR TITLE
Handle device loss during Resize with the same recovery as the render loop

### DIFF
--- a/Source/HelixToolkit.SharpDX/Render/RenderHost/DX11RenderHostBase.cs
+++ b/Source/HelixToolkit.SharpDX/Render/RenderHost/DX11RenderHostBase.cs
@@ -1154,31 +1154,57 @@ public abstract class DX11RenderHostBase : DisposeObject, IRenderHost
         ActualWidth = Math.Max(2, width * DpiScale);
         ActualHeight = Math.Max(2, height * DpiScale);
         logger.LogInformation("Resizing. Width = {0}; Height = {1};", width, height);
-        lock (lockObj)
+        try
         {
-            if (IsInitialized)
+            lock (lockObj)
             {
-                StopRendering();
-                var texture = renderBuffer?.Resize((int)Math.Floor(ActualWidth), (int)Math.Floor(ActualHeight));
-                if (texture is not null)
+                if (IsInitialized)
                 {
-                    OnNewRenderTargetTexture?.Invoke(this, new Texture2DArgs(texture));
-                }
-                if (Viewport != null)
-                {
-                    var overlay = Viewport.D2DRenderables.FirstOrDefault();
-                    if (overlay != null)
+                    StopRendering();
+                    var texture = renderBuffer?.Resize((int)Math.Floor(ActualWidth), (int)Math.Floor(ActualHeight));
+                    if (texture is not null)
                     {
-                        if (dpiChanged)
-                        {
-                            overlay.Detach();
-                            overlay.Attach(this);
-                        }
-                        overlay.InvalidateAll();
+                        OnNewRenderTargetTexture?.Invoke(this, new Texture2DArgs(texture));
                     }
+                    if (Viewport != null)
+                    {
+                        var overlay = Viewport.D2DRenderables.FirstOrDefault();
+                        if (overlay != null)
+                        {
+                            if (dpiChanged)
+                            {
+                                overlay.Detach();
+                                overlay.Attach(this);
+                            }
+                            overlay.InvalidateAll();
+                        }
+                    }
+                    StartRendering();
                 }
-                StartRendering();
             }
+        }
+        catch (SharpDXException ex)
+        {
+            var desc = ResultDescriptor.Find(ex.ResultCode);
+            if (desc == global::SharpDX.DXGI.ResultCode.DeviceRemoved || desc == global::SharpDX.DXGI.ResultCode.DeviceReset
+                || desc == global::SharpDX.DXGI.ResultCode.DeviceHung || desc == global::SharpDX.Direct2D1.ResultCode.RecreateTarget
+                || desc == global::SharpDX.DXGI.ResultCode.AccessLost)
+            {
+                logger.LogWarning("Device Lost during resize, code = {0}", desc.Code);
+                RenderBuffer_OnDeviceLost(RenderBuffer, EventArgs.Empty);
+            }
+            else
+            {
+                logger.LogError("DirectX Error during resize. Exception: {0}", ex);
+                EndD3D();
+                ExceptionOccurred?.Invoke(this, new RelayExceptionEventArgs(ex));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("Error during resize. Exception: {0}", ex);
+            EndD3D();
+            ExceptionOccurred?.Invoke(this, new RelayExceptionEventArgs(ex));
         }
     }
 


### PR DESCRIPTION
Fixes #2484.

`DX11RenderHostBase.Resize()` recreates the render targets with no exception handling, so `DXGI_ERROR_DEVICE_REMOVED` thrown during target recreation (e.g. after a TDR while the app was idle) escapes to the caller. For the WPF hosts this is mitigated by their own try/catch around `RenderHost.Resize()`; the Avalonia `D3DRenderHost` calls `Resize()` bare from its Bounds-change handler, which on Windows runs inside the `WM_WINDOWPOSCHANGED` kernel callback — an escaping managed exception there cannot be caught by the application and terminates the process (observed in production; details and crash-dump stacks in #2484).

This change wraps the resize body with the exact device-lost handling `UpdateAndRender` already uses: `DeviceRemoved` / `DeviceReset` / `DeviceHung` / `AccessLost` / `RecreateTarget` → `RenderBuffer_OnDeviceLost` (EndD3D + EffectsManager reinitialize); anything else → `EndD3D` + `ExceptionOccurred`. Placed in the shared base so all hosts (WPF, Avalonia, WinUI) are covered; the WPF hosts' outer guards remain as a second layer.

The catch sits outside `lock (lockObj)` so recovery never runs while holding the render lock. Builds clean; device removal itself isn't practical to unit-test without a real GPU/TDR, but the failing path is reproducible with `dxcap -forcetdr` + window resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
