### PR TITLE
Fix ThreadBufferManager.GetBuffer returning undersized buffers above 2^24 elements

### DIFF
--- a/Source/HelixToolkit.SharpDX.Tests/ThreadBufferManagerTests.cs
+++ b/Source/HelixToolkit.SharpDX.Tests/ThreadBufferManagerTests.cs
@@ -1,0 +1,28 @@
+using HelixToolkit.SharpDX.Core;
+using NUnit.Framework;
+
+namespace HelixToolkit.SharpDX.Tests;
+
+[TestFixture]
+public class ThreadBufferManagerTests
+{
+    [Test]
+    public void GetBufferReturnsAtLeastRequestedSizeAboveTwoPow24()
+    {
+        // Above 2^24 the int -> float conversion inside the size computation rounds to
+        // the nearest representable float; when it rounded down, GetBuffer allocated
+        // fewer elements than requested and BuildVertexArray indexed past the end of
+        // the returned buffer (IndexOutOfRangeException during OnAttachBuffers for
+        // meshes with more than 16,777,216 vertices).
+        // 67,108,867 and 100,000,003 sit in float ranges with spacing 8 and round down
+        // on conversion; both exceed MaximumElementCount for byte (64 MB), taking the
+        // unscaled allocation path where no growth factor masks the loss.
+        int[] requests = { 16_777_217, 67_108_867, 67_108_869, 100_000_003 };
+        foreach (var request in requests)
+        {
+            var buffer = ThreadBufferManager<byte>.GetBuffer(request);
+            Assert.That(buffer.Length, Is.GreaterThanOrEqualTo(request),
+                $"GetBuffer({request}) returned a buffer {request - buffer.Length} elements short.");
+        }
+    }
+}

--- a/Source/HelixToolkit.SharpDX/Core/Buffers/ThreadBufferManager.cs
+++ b/Source/HelixToolkit.SharpDX/Core/Buffers/ThreadBufferManager.cs
@@ -39,7 +39,12 @@ public static class ThreadBufferManager<T> where T : unmanaged
             {
                 scale = 1.5f;
             }
-            array = new T[(int)(requestCount * scale)];
+            // Compute the scaled size in double: converting requestCount to float loses
+            // precision above 2^24, and rounding down allocates a buffer smaller than
+            // requestCount (IndexOutOfRangeException in BuildVertexArray for meshes
+            // with more than 16,777,216 vertices). Math.Max guarantees the returned
+            // buffer always holds at least requestCount elements.
+            array = new T[Math.Max(requestCount, (int)(requestCount * (double)scale))];
             if (logger.IsEnabled(LogLevel.Debug))
             {
                 logger.LogDebug("Created new thread buffer. Type: {0}; Size: {1} kB.", typeof(T), array.Length * StructSize / 1024);


### PR DESCRIPTION
Fixes #2486

`GetBuffer` computed the allocation size as `(int)(requestCount * scale)`, promoting `requestCount` to `float`. Floats represent integers exactly only up to 2^24 = 16,777,216; above that the conversion rounds to the nearest representable value, and when it rounds down the returned buffer is smaller than `requestCount` — e.g. `GetBuffer(67_108_867)` returned a 67,108,864-element buffer.

Callers assume the returned buffer holds at least `requestCount` elements: `DefaultMeshGeometryBufferModel.BuildVertexArray` writes `array[i]` for every `i < Positions.Count`, so any mesh with more than 16,777,216 vertices whose count rounds down threw `IndexOutOfRangeException` during `OnAttachBuffers`/`UpdateBuffers` — deterministically for a given mesh, so the affected model could never render. Observed in production with large binary STL sculpts (>5.59M triangles loaded without vertex welding). Only the unscaled `requestCount > MaximumElementCount` path is affected in practice; the 1.5×/2× growth paths outgrow the rounding loss.

The fix computes the scaled size in `double` (exact for all `int` values) and clamps with `Math.Max` so the returned buffer always holds at least `requestCount` elements:

```csharp
array = new T[Math.Max(requestCount, (int)(requestCount * (double)scale))];
```

The `Math.Max` clamp also makes the pathological-config case (a `MaximumSizeToRetainMb` large enough that `requestCount * 1.5` overflows the int cast) strictly safer than before — the result can never drop below `requestCount`.

Includes a regression test (`ThreadBufferManagerTests`) covering request sizes just above 2^24 and in the float-spacing-8 range; it fails against the previous code (`67,108,864 < 67,108,867`) and passes with the fix.
